### PR TITLE
M1.6 Source and utility nodes

### DIFF
--- a/crates/ringdesign-graph/src/nodes.rs
+++ b/crates/ringdesign-graph/src/nodes.rs
@@ -1,6 +1,0 @@
-//! The node library.
-
-use crate::registry::Registry;
-
-/// Register every builtin node kind.
-pub fn register_all(_reg: &mut Registry) {}

--- a/crates/ringdesign-graph/src/nodes/list.rs
+++ b/crates/ringdesign-graph/src/nodes/list.rs
@@ -1,0 +1,158 @@
+//! Basic list utilities. Every `items` pin is list-access: the node sees
+//! the whole list once, rather than running per item.
+
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry};
+use crate::value::{Value, ValueKind};
+
+fn length(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("n", i.list("items").len() as i64))
+}
+
+fn item(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let items = i.list("items");
+    let index = i.int("index")?;
+    let wrap = i.bool("wrap")?;
+    if items.is_empty() {
+        return Err(NodeError::input("items", "the list is empty"));
+    }
+    let n = items.len() as i64;
+    let k = if wrap { ((index % n) + n) % n } else if (0..n).contains(&index) { index } else {
+        return Err(NodeError::input("index", format!("{index} is outside 0..{n}")));
+    };
+    Ok(Outputs::one("item", items[k as usize].clone()))
+}
+
+fn flatten_into(v: Value, out: &mut Vec<Value>) {
+    match v {
+        Value::List(items) => items.into_iter().for_each(|x| flatten_into(x, out)),
+        other => out.push(other),
+    }
+}
+
+fn flatten(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut out = Vec::new();
+    for v in i.list("items") {
+        flatten_into(v, &mut out);
+    }
+    Ok(Outputs::one("out", out))
+}
+
+fn graft(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let out: Vec<Value> = i.list("items").into_iter().map(|v| Value::List(vec![v])).collect();
+    Ok(Outputs::one("out", out))
+}
+
+fn reverse(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut items = i.list("items");
+    items.reverse();
+    Ok(Outputs::one("out", items))
+}
+
+fn slice(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let items = i.list("items");
+    let n = items.len() as i64;
+    let norm = |k: i64| -> usize { (if k < 0 { n + k } else { k }).clamp(0, n) as usize };
+    let start = norm(i.int("start")?);
+    let end = norm(i.int("end")?);
+    let out: Vec<Value> = if end > start { items[start..end].to_vec() } else { Vec::new() };
+    Ok(Outputs::one("out", out))
+}
+
+fn sort(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut items = i.list("items");
+    let descending = i.bool("descending")?;
+    let all_numbers = items.iter().all(|v| v.as_number().is_some());
+    let all_text = items.iter().all(|v| matches!(v, Value::Text(_)));
+    if all_numbers {
+        items.sort_by(|a, b| a.as_number().unwrap().total_cmp(&b.as_number().unwrap()));
+    } else if all_text {
+        items.sort_by(|a, b| a.as_text().unwrap().cmp(b.as_text().unwrap()));
+    } else {
+        return Err(NodeError::input("items", "sort needs all numbers or all text"));
+    }
+    if descending {
+        items.reverse();
+    }
+    Ok(Outputs::one("out", items))
+}
+
+fn merge(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut out = Vec::new();
+    for pin in ["a", "b", "c", "d"] {
+        out.extend(i.list(pin));
+    }
+    Ok(Outputs::one("out", out))
+}
+
+fn sum(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let items = i.list("items");
+    let mut total = 0.0;
+    for (k, v) in items.iter().enumerate() {
+        total += v.as_number().ok_or_else(|| NodeError::input("items", format!("item {k} is not a number")))?;
+    }
+    Ok(Outputs::one("sum", total).with("mean", if items.is_empty() { 0.0 } else { total / items.len() as f64 }))
+}
+
+pub fn register(reg: &mut Registry) {
+    let items = || PinSpec::list("items", ValueKind::Any).doc("The list.");
+    let specs = [
+        NodeSpec::new("list.length", "Length", Category::Util)
+            .doc("How many items a list has.")
+            .input(items())
+            .output(PinSpec::item("n", ValueKind::Int).doc("The count."))
+            .eval(length),
+        NodeSpec::new("list.item", "Item", Category::Util)
+            .doc("One item of a list by index; wrapping, a negative index counts from the end.")
+            .input(items())
+            .input(PinSpec::item("index", ValueKind::Int).default(0i64).doc("Which item."))
+            .input(PinSpec::item("wrap", ValueKind::Bool).default(true).doc("Whether the index wraps round the list."))
+            .output(PinSpec::item("item", ValueKind::Any).doc("The item."))
+            .eval(item),
+        NodeSpec::new("list.flatten", "Flatten", Category::Util)
+            .doc("Every nested list opened into one flat list.")
+            .input(items())
+            .output(PinSpec::list("out", ValueKind::Any).doc("The flat list."))
+            .eval(flatten),
+        NodeSpec::new("list.graft", "Graft", Category::Util)
+            .doc("Each item wrapped in its own one-item list, so the next node sees one branch per item.")
+            .input(items())
+            .output(PinSpec::list("out", ValueKind::Any).doc("The grafted list."))
+            .eval(graft),
+        NodeSpec::new("list.reverse", "Reverse", Category::Util)
+            .doc("The list back to front.")
+            .input(items())
+            .output(PinSpec::list("out", ValueKind::Any).doc("The reversed list."))
+            .eval(reverse),
+        NodeSpec::new("list.slice", "Slice", Category::Util)
+            .doc("Items from start up to (not including) end; a negative index counts from the end.")
+            .input(items())
+            .input(PinSpec::item("start", ValueKind::Int).default(0i64).doc("First index kept."))
+            .input(PinSpec::item("end", ValueKind::Int).default(-1i64).doc("First index dropped; −1 is the last item."))
+            .output(PinSpec::list("out", ValueKind::Any).doc("The slice."))
+            .eval(slice),
+        NodeSpec::new("list.sort", "Sort", Category::Util)
+            .doc("Numbers by value or text alphabetically; a mixed list is refused.")
+            .input(items())
+            .input(PinSpec::item("descending", ValueKind::Bool).default(false).doc("Largest first."))
+            .output(PinSpec::list("out", ValueKind::Any).doc("The sorted list."))
+            .eval(sort),
+        NodeSpec::new("list.merge", "Merge", Category::Util)
+            .doc("Up to four lists (or single values) joined end to end.")
+            .input(PinSpec::list("a", ValueKind::Any).doc("First."))
+            .input(PinSpec::list("b", ValueKind::Any).doc("Second."))
+            .input(PinSpec::list("c", ValueKind::Any).doc("Third."))
+            .input(PinSpec::list("d", ValueKind::Any).doc("Fourth."))
+            .output(PinSpec::list("out", ValueKind::Any).doc("The joined list."))
+            .eval(merge),
+        NodeSpec::new("list.sum", "Sum", Category::Util)
+            .doc("The total and the mean of a list of numbers.")
+            .input(items())
+            .output(PinSpec::item("sum", ValueKind::Number).doc("The total."))
+            .output(PinSpec::item("mean", ValueKind::Number).doc("The mean; 0 for an empty list."))
+            .eval(sum),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/math.rs
+++ b/crates/ringdesign-graph/src/nodes/math.rs
@@ -1,0 +1,190 @@
+//! Arithmetic, trigonometry in degrees, comparison and logic.
+
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::ValueKind;
+
+fn finite(name: &str, x: f64) -> Result<f64, NodeError> {
+    if x.is_finite() { Ok(x) } else { Err(NodeError::input(name, "the result is not a finite number")) }
+}
+
+macro_rules! binary {
+    ($($f:ident, $key:literal, $label:literal, $doc:literal, |$a:ident, $b:ident| $body:expr;)*) => {
+        $(
+            fn $f(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+                let $a = i.number("a")?;
+                let $b = i.number("b")?;
+                let out: Result<f64, NodeError> = $body;
+                Ok(Outputs::one("out", finite("out", out?)?))
+            }
+        )*
+        fn binary_specs() -> Vec<NodeSpec> {
+            vec![$(
+                NodeSpec::new($key, $label, Category::Util)
+                    .doc($doc)
+                    .input(PinSpec::item("a", ValueKind::Number).default(0.0).doc("First operand."))
+                    .input(PinSpec::item("b", ValueKind::Number).default(0.0).doc("Second operand."))
+                    .output(PinSpec::item("out", ValueKind::Number).doc("The result."))
+                    .eval($f),
+            )*]
+        }
+    };
+}
+
+binary! {
+    add, "math.add", "Add", "a + b.", |a, b| Ok(a + b);
+    sub, "math.sub", "Subtract", "a − b.", |a, b| Ok(a - b);
+    mul, "math.mul", "Multiply", "a × b.", |a, b| Ok(a * b);
+    div, "math.div", "Divide", "a ÷ b; b must not be zero.", |a, b| if b == 0.0 { Err(NodeError::input("b", "division by zero")) } else { Ok(a / b) };
+    pow, "math.pow", "Power", "a raised to b.", |a, b| Ok(a.powf(b));
+    modulo, "math.mod", "Modulo", "a modulo b, with the sign of b (so −30 mod 360 is 330).", |a, b| if b == 0.0 { Err(NodeError::input("b", "modulo by zero")) } else { Ok(((a % b) + b) % b) };
+    min, "math.min", "Minimum", "The smaller of a and b.", |a, b| Ok(a.min(b));
+    max, "math.max", "Maximum", "The larger of a and b.", |a, b| Ok(a.max(b));
+    atan2, "math.atan2", "Atan2", "The bearing of (a, b) = (y, x) in degrees.", |a, b| Ok(a.atan2(b).to_degrees());
+}
+
+macro_rules! unary {
+    ($($f:ident, $key:literal, $label:literal, $doc:literal, |$x:ident| $body:expr;)*) => {
+        $(
+            fn $f(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+                let $x = i.number("x")?;
+                let out: Result<f64, NodeError> = $body;
+                Ok(Outputs::one("out", finite("out", out?)?))
+            }
+        )*
+        fn unary_specs() -> Vec<NodeSpec> {
+            vec![$(
+                NodeSpec::new($key, $label, Category::Util)
+                    .doc($doc)
+                    .input(PinSpec::item("x", ValueKind::Number).default(0.0).doc("The operand."))
+                    .output(PinSpec::item("out", ValueKind::Number).doc("The result."))
+                    .eval($f),
+            )*]
+        }
+    };
+}
+
+unary! {
+    neg, "math.neg", "Negate", "−x.", |x| Ok(-x);
+    abs, "math.abs", "Absolute", "|x|.", |x| Ok(x.abs());
+    floor, "math.floor", "Floor", "x rounded down.", |x| Ok(x.floor());
+    ceil, "math.ceil", "Ceiling", "x rounded up.", |x| Ok(x.ceil());
+    round, "math.round", "Round", "x rounded to the nearest whole number.", |x| Ok(x.round());
+    sqrt, "math.sqrt", "Square root", "√x; x must not be negative.", |x| if x < 0.0 { Err(NodeError::input("x", "negative")) } else { Ok(x.sqrt()) };
+    sin, "math.sin", "Sine", "sin x, x in degrees.", |x| Ok(x.to_radians().sin());
+    cos, "math.cos", "Cosine", "cos x, x in degrees.", |x| Ok(x.to_radians().cos());
+    tan, "math.tan", "Tangent", "tan x, x in degrees.", |x| Ok(x.to_radians().tan());
+    deg, "math.deg", "To degrees", "Radians to degrees.", |x| Ok(x.to_degrees());
+    rad, "math.rad", "To radians", "Degrees to radians.", |x| Ok(x.to_radians());
+}
+
+fn lerp(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let (a, b, t) = (i.number("a")?, i.number("b")?, i.number("t")?);
+    Ok(Outputs::one("out", finite("out", a + (b - a) * t)?))
+}
+
+fn clamp(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let (x, lo, hi) = (i.number("x")?, i.number("min")?, i.number("max")?);
+    if lo > hi {
+        return Err(NodeError::input("min", format!("{lo} is above max {hi}")));
+    }
+    Ok(Outputs::one("out", x.clamp(lo, hi)))
+}
+
+fn remap(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let (x, a, b, c, d) = (i.number("x")?, i.number("from_min")?, i.number("from_max")?, i.number("to_min")?, i.number("to_max")?);
+    if a == b {
+        return Err(NodeError::input("from_max", "the source range is empty"));
+    }
+    Ok(Outputs::one("out", finite("out", c + (d - c) * (x - a) / (b - a))?))
+}
+
+fn compare(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let (a, b) = (i.number("a")?, i.number("b")?);
+    let op = i.text("op")?;
+    let out = match op {
+        "<" => a < b,
+        "<=" => a <= b,
+        ">" => a > b,
+        ">=" => a >= b,
+        "=" | "==" => a == b,
+        "!=" => a != b,
+        other => return Err(NodeError::input("op", format!("{other:?} is not one of < <= > >= = !="))),
+    };
+    Ok(Outputs::one("out", out))
+}
+
+fn not(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("out", !i.bool("x")?))
+}
+
+fn and(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("out", i.bool("a")? && i.bool("b")?))
+}
+
+fn or(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("out", i.bool("a")? || i.bool("b")?))
+}
+
+pub fn register(reg: &mut Registry) {
+    for s in binary_specs().into_iter().chain(unary_specs()) {
+        reg.register(s).expect("unique");
+    }
+    let specs = [
+        NodeSpec::new("math.lerp", "Lerp", Category::Util)
+            .doc("a + (b − a)·t: the blend of a and b at t.")
+            .input(PinSpec::item("a", ValueKind::Number).default(0.0).doc("The value at t = 0."))
+            .input(PinSpec::item("b", ValueKind::Number).default(1.0).doc("The value at t = 1."))
+            .input(PinSpec::item("t", ValueKind::Number).default(0.5).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("The blend."))
+            .output(PinSpec::item("out", ValueKind::Number).doc("The blend."))
+            .eval(lerp),
+        NodeSpec::new("math.clamp", "Clamp", Category::Util)
+            .doc("x held between min and max.")
+            .input(PinSpec::item("x", ValueKind::Number).default(0.0).doc("The value."))
+            .input(PinSpec::item("min", ValueKind::Number).default(0.0).doc("The floor."))
+            .input(PinSpec::item("max", ValueKind::Number).default(1.0).doc("The ceiling."))
+            .output(PinSpec::item("out", ValueKind::Number).doc("The held value."))
+            .eval(clamp),
+        NodeSpec::new("math.remap", "Remap", Category::Util)
+            .doc("x carried from one range to another, linearly and without clamping.")
+            .input(PinSpec::item("x", ValueKind::Number).default(0.0).doc("The value."))
+            .input(PinSpec::item("from_min", ValueKind::Number).default(0.0).doc("The source range's start."))
+            .input(PinSpec::item("from_max", ValueKind::Number).default(1.0).doc("The source range's end."))
+            .input(PinSpec::item("to_min", ValueKind::Number).default(0.0).doc("The target range's start."))
+            .input(PinSpec::item("to_max", ValueKind::Number).default(1.0).doc("The target range's end."))
+            .output(PinSpec::item("out", ValueKind::Number).doc("The carried value."))
+            .eval(remap),
+        NodeSpec::new("math.compare", "Compare", Category::Util)
+            .doc("a compared with b by op: < <= > >= = !=.")
+            .input(PinSpec::item("a", ValueKind::Number).default(0.0).doc("Left side."))
+            .input(PinSpec::item("b", ValueKind::Number).default(0.0).doc("Right side."))
+            .input(
+                PinSpec::item("op", ValueKind::Text)
+                    .default("<")
+                    .widget(Widget::Select(["<", "<=", ">", ">=", "=", "!="].iter().map(|s| s.to_string()).collect()))
+                    .doc("The comparison."),
+            )
+            .output(PinSpec::item("out", ValueKind::Bool).doc("Whether it holds."))
+            .eval(compare),
+        NodeSpec::new("logic.not", "Not", Category::Util)
+            .doc("The opposite of x.")
+            .input(PinSpec::item("x", ValueKind::Bool).default(false).doc("The value."))
+            .output(PinSpec::item("out", ValueKind::Bool).doc("Not x."))
+            .eval(not),
+        NodeSpec::new("logic.and", "And", Category::Util)
+            .doc("Both a and b.")
+            .input(PinSpec::item("a", ValueKind::Bool).default(false).doc("First."))
+            .input(PinSpec::item("b", ValueKind::Bool).default(false).doc("Second."))
+            .output(PinSpec::item("out", ValueKind::Bool).doc("a and b."))
+            .eval(and),
+        NodeSpec::new("logic.or", "Or", Category::Util)
+            .doc("Either a or b.")
+            .input(PinSpec::item("a", ValueKind::Bool).default(false).doc("First."))
+            .input(PinSpec::item("b", ValueKind::Bool).default(false).doc("Second."))
+            .output(PinSpec::item("out", ValueKind::Bool).doc("a or b."))
+            .eval(or),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -1,0 +1,201 @@
+//! The node library.
+//!
+//! One file per family; each exposes `register(reg)`. Keys are
+//! `family.name`, labels are what the palette shows, and every spec
+//! carries a doc line, because the palette, the MCP listing and the Python
+//! module all read the same table.
+
+use crate::registry::Registry;
+
+pub mod list;
+pub mod math;
+pub mod source;
+pub mod text;
+
+/// Register every builtin node kind.
+pub fn register_all(reg: &mut Registry) {
+    source::register(reg);
+    math::register(reg);
+    list::register(reg);
+    text::register(reg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Access;
+    use crate::value::ValueKind;
+    use std::collections::BTreeSet;
+
+    /// The table is consistent: every spec documented, pins uniquely named,
+    /// every scalar item input given a default so an unwired node still runs.
+    #[test]
+    fn the_builtin_table_is_consistent() {
+        let reg = Registry::builtin();
+        assert!(reg.len() >= 40, "{} kinds", reg.len());
+        for key in reg.keys() {
+            let spec = reg.get(key).unwrap();
+            assert!(!spec.doc.is_empty(), "{key} has no doc");
+            assert!(!spec.label.is_empty(), "{key} has no label");
+            assert!(key.contains('.') || matches!(key, "number" | "int" | "bool" | "text" | "series" | "range"), "{key} is not family.name");
+            let mut seen = BTreeSet::new();
+            for p in spec.inputs.iter().chain(&spec.outputs) {
+                assert!(seen.insert(&p.name), "{key} names pin {:?} twice", p.name);
+                assert!(!p.doc.is_empty(), "{key}.{} has no doc", p.name);
+            }
+            for p in &spec.inputs {
+                let scalar = matches!(p.kind, ValueKind::Number | ValueKind::Int | ValueKind::Bool | ValueKind::Text);
+                if scalar && p.access == Access::Item {
+                    assert!(p.default.is_some(), "{key}.{} has no default", p.name);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod acceptance {
+    use crate::eval::{Evaluator, Targets};
+    use crate::graph::{Graph, NodeId};
+    use crate::registry::Registry;
+    use crate::value::{Literal, Value};
+    use crate::MAX_LIST_ITEMS;
+    use ringdesign_core::AlphaLibrary;
+
+    fn run(g: &Graph) -> crate::eval::EvalReport {
+        Evaluator::new().evaluate(g, &Registry::builtin(), &AlphaLibrary::default(), 0, Targets::AllPure)
+    }
+
+    fn nums(xs: &[f64]) -> Literal {
+        Literal::List(xs.iter().map(|x| Literal::Number(*x)).collect())
+    }
+
+    fn list_of(v: Option<&Value>) -> Vec<f64> {
+        match v {
+            Some(Value::List(items)) => items.iter().map(|x| x.as_number().unwrap_or(f64::NAN)).collect(),
+            Some(other) => vec![other.as_number().unwrap_or(f64::NAN)],
+            None => vec![],
+        }
+    }
+
+    #[test]
+    fn the_headline_case_runs_through_real_nodes() {
+        let mut g = Graph::default();
+        let a = g.add("math.add").unwrap();
+        g.set_input(a, "a", nums(&[1.0, 2.0, 3.0])).unwrap();
+        g.set_input(a, "b", nums(&[10.0])).unwrap();
+        let r = run(&g);
+        assert_eq!(list_of(r.value(a, "out")), vec![11.0, 12.0, 13.0]);
+    }
+
+    #[test]
+    fn series_and_range_count_and_clamp() {
+        let mut g = Graph::default();
+        let s = g.add("series").unwrap();
+        g.set_input(s, "start", Literal::Number(0.0)).unwrap();
+        g.set_input(s, "step", Literal::Number(30.0)).unwrap();
+        g.set_input(s, "count", Literal::Int(4)).unwrap();
+        let r_ = g.add("range").unwrap();
+        g.set_input(r_, "count", Literal::Int(5)).unwrap();
+        let one = g.add("range").unwrap();
+        g.set_input(one, "count", Literal::Int(1)).unwrap();
+        let big = g.add("series").unwrap();
+        g.set_input(big, "count", Literal::Int(MAX_LIST_ITEMS as i64 * 2)).unwrap();
+        let neg = g.add("series").unwrap();
+        g.set_input(neg, "count", Literal::Int(-1)).unwrap();
+        let r = run(&g);
+        assert_eq!(list_of(r.value(s, "out")), vec![0.0, 30.0, 60.0, 90.0]);
+        assert_eq!(list_of(r.value(r_, "out")), vec![0.0, 0.25, 0.5, 0.75, 1.0]);
+        assert_eq!(list_of(r.value(one, "out")), vec![0.0]);
+        assert_eq!(list_of(r.value(big, "out")).len(), MAX_LIST_ITEMS);
+        assert!(r.status[&big].warnings[0].contains("clamped"));
+        assert!(r.status[&neg].errors[0].1.contains("negative"));
+    }
+
+    #[test]
+    fn math_is_in_degrees_and_attributes_its_failures() {
+        let mut g = Graph::default();
+        let sin = g.add("math.sin").unwrap();
+        g.set_input(sin, "x", Literal::Number(90.0)).unwrap();
+        let m = g.add("math.mod").unwrap();
+        g.set_input(m, "a", Literal::Number(-30.0)).unwrap();
+        g.set_input(m, "b", Literal::Number(360.0)).unwrap();
+        let d = g.add("math.div").unwrap();
+        g.set_input(d, "a", nums(&[1.0, 2.0])).unwrap();
+        g.set_input(d, "b", nums(&[2.0, 0.0])).unwrap();
+        let rm = g.add("math.remap").unwrap();
+        g.set_input(rm, "x", Literal::Number(5.0)).unwrap();
+        g.set_input(rm, "from_max", Literal::Number(10.0)).unwrap();
+        g.set_input(rm, "to_min", Literal::Number(90.0)).unwrap();
+        g.set_input(rm, "to_max", Literal::Number(270.0)).unwrap();
+        let cmp = g.add("math.compare").unwrap();
+        g.set_input(cmp, "a", nums(&[1.0, 2.0, 3.0])).unwrap();
+        g.set_input(cmp, "b", Literal::Number(2.0)).unwrap();
+        g.set_input(cmp, "op", Literal::Text(">=".into())).unwrap();
+        let sq = g.add("math.sqrt").unwrap();
+        g.set_input(sq, "x", Literal::Number(-1.0)).unwrap();
+        let r = run(&g);
+        assert!((r.value(sin, "out").unwrap().as_number().unwrap() - 1.0).abs() < 1e-12);
+        assert_eq!(r.value(m, "out"), Some(&Value::Number(330.0)));
+        let q = list_of(r.value(d, "out"));
+        assert_eq!(q[0], 0.5);
+        assert!(q[1].is_nan(), "the zero-divisor item is Null");
+        assert_eq!(r.status[&d].errors, vec![(1, "b: division by zero".to_string())]);
+        assert_eq!(r.value(rm, "out"), Some(&Value::Number(180.0)));
+        assert_eq!(r.value(cmp, "out"), Some(&Value::List(vec![Value::Bool(false), Value::Bool(true), Value::Bool(true)])));
+        assert_eq!(r.status[&sq].errors[0].1, "x: negative");
+    }
+
+    #[test]
+    fn list_utilities_do_what_they_say() {
+        let mut g = Graph::default();
+        let s = g.add("series").unwrap();
+        g.set_input(s, "count", Literal::Int(5)).unwrap();
+        let wire = |g: &mut Graph, kind: &str| -> NodeId {
+            let n = g.add(kind).unwrap();
+            g.connect(s, "out", n, "items").unwrap();
+            n
+        };
+        let len = wire(&mut g, "list.length");
+        let item = wire(&mut g, "list.item");
+        g.set_input(item, "index", Literal::Int(-1)).unwrap();
+        let strict = wire(&mut g, "list.item");
+        g.set_input(strict, "index", Literal::Int(7)).unwrap();
+        g.set_input(strict, "wrap", Literal::Bool(false)).unwrap();
+        let rev = wire(&mut g, "list.reverse");
+        let sl = wire(&mut g, "list.slice");
+        g.set_input(sl, "start", Literal::Int(1)).unwrap();
+        g.set_input(sl, "end", Literal::Int(-1)).unwrap();
+        let graft = wire(&mut g, "list.graft");
+        let flat = g.add("list.flatten").unwrap();
+        g.connect(graft, "out", flat, "items").unwrap();
+        let sorted = g.add("list.sort").unwrap();
+        g.set_input(sorted, "items", nums(&[3.0, 1.0, 2.0])).unwrap();
+        g.set_input(sorted, "descending", Literal::Bool(true)).unwrap();
+        let mixed = g.add("list.sort").unwrap();
+        g.set_input(mixed, "items", Literal::List(vec![Literal::Number(1.0), Literal::Text("a".into())])).unwrap();
+        let merged = g.add("list.merge").unwrap();
+        g.connect(s, "out", merged, "a").unwrap();
+        g.set_input(merged, "b", Literal::Number(99.0)).unwrap();
+        let total = wire(&mut g, "list.sum");
+        let joined = wire(&mut g, "text.join");
+        g.set_input(joined, "sep", Literal::Text("-".into())).unwrap();
+        let r = run(&g);
+        assert_eq!(r.value(len, "n"), Some(&Value::Int(5)));
+        assert_eq!(r.value(item, "item"), Some(&Value::Number(4.0)), "−1 wraps to the last");
+        assert!(r.status[&strict].errors[0].1.contains("outside"));
+        assert_eq!(list_of(r.value(rev, "out")), vec![4.0, 3.0, 2.0, 1.0, 0.0]);
+        assert_eq!(list_of(r.value(sl, "out")), vec![1.0, 2.0, 3.0]);
+        match r.value(graft, "out") {
+            Some(Value::List(outer)) => assert_eq!(outer[2], Value::List(vec![Value::Number(2.0)])),
+            other => panic!("{other:?}"),
+        }
+        assert_eq!(list_of(r.value(flat, "out")), vec![0.0, 1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(list_of(r.value(sorted, "out")), vec![3.0, 2.0, 1.0]);
+        assert!(r.status[&mixed].errors[0].1.contains("all numbers or all text"));
+        assert_eq!(list_of(r.value(merged, "out")), vec![0.0, 1.0, 2.0, 3.0, 4.0, 99.0]);
+        assert_eq!(r.value(total, "sum"), Some(&Value::Number(10.0)));
+        assert_eq!(r.value(total, "mean"), Some(&Value::Number(2.0)));
+        assert_eq!(r.value(joined, "out"), Some(&Value::Text("0-1-2-3-4".into())));
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/source.rs
+++ b/crates/ringdesign-graph/src/nodes/source.rs
@@ -1,0 +1,98 @@
+//! Literal sources and number generators.
+
+use crate::MAX_LIST_ITEMS;
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::{Value, ValueKind};
+
+fn number(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("out", i.number("value")?))
+}
+
+fn int(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("out", i.int("value")?))
+}
+
+fn bool_(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("out", i.bool("value")?))
+}
+
+fn text(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("out", i.text("value")?.to_string()))
+}
+
+/// A count for a generated list, clamped to the cap with a warning.
+fn capped_count(ctx: &mut EvalCtx<'_>, i: &Inputs, pin: &str) -> Result<usize, NodeError> {
+    let n = i.int(pin)?;
+    if n < 0 {
+        return Err(NodeError::input(pin, format!("{n} is negative")));
+    }
+    let n = n as usize;
+    if n > MAX_LIST_ITEMS {
+        ctx.warn(format!("{pin} {n} clamped to {MAX_LIST_ITEMS}"));
+        return Ok(MAX_LIST_ITEMS);
+    }
+    Ok(n)
+}
+
+fn series(ctx: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let start = i.number("start")?;
+    let step = i.number("step")?;
+    let count = capped_count(ctx, i, "count")?;
+    let out: Vec<Value> = (0..count).map(|k| Value::Number(start + step * k as f64)).collect();
+    Ok(Outputs::one("out", out))
+}
+
+fn range(ctx: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let start = i.number("start")?;
+    let end = i.number("end")?;
+    let count = capped_count(ctx, i, "count")?;
+    let out: Vec<Value> = match count {
+        0 => Vec::new(),
+        1 => vec![Value::Number(start)],
+        n => (0..n).map(|k| Value::Number(start + (end - start) * k as f64 / (n - 1) as f64)).collect(),
+    };
+    Ok(Outputs::one("out", out))
+}
+
+pub fn register(reg: &mut Registry) {
+    let specs = [
+        NodeSpec::new("number", "Number", Category::Source)
+            .doc("A number, or a list of them.")
+            .input(PinSpec::item("value", ValueKind::Number).default(0.0).doc("The value."))
+            .output(PinSpec::item("out", ValueKind::Number).doc("The value, unchanged."))
+            .eval(number),
+        NodeSpec::new("int", "Integer", Category::Source)
+            .doc("A whole number: a count, a repeat, an index.")
+            .input(PinSpec::item("value", ValueKind::Int).default(1i64).doc("The value."))
+            .output(PinSpec::item("out", ValueKind::Int).doc("The value, unchanged."))
+            .eval(int),
+        NodeSpec::new("bool", "Boolean", Category::Source)
+            .doc("True or false.")
+            .input(PinSpec::item("value", ValueKind::Bool).default(true).widget(Widget::Checkbox).doc("The value."))
+            .output(PinSpec::item("out", ValueKind::Bool).doc("The value, unchanged."))
+            .eval(bool_),
+        NodeSpec::new("text", "Text", Category::Source)
+            .doc("A piece of text: a name, an inscription, an enum choice.")
+            .input(PinSpec::item("value", ValueKind::Text).default("").widget(Widget::TextLine).doc("The text."))
+            .output(PinSpec::item("out", ValueKind::Text).doc("The text, unchanged."))
+            .eval(text),
+        NodeSpec::new("series", "Series", Category::Source)
+            .doc("Count numbers from a start by a step: 0, 30, 60 … for stations round the ring.")
+            .input(PinSpec::item("start", ValueKind::Number).default(0.0).doc("The first number."))
+            .input(PinSpec::item("step", ValueKind::Number).default(1.0).doc("Added for each next number."))
+            .input(PinSpec::item("count", ValueKind::Int).default(10i64).doc("How many; capped at the list limit."))
+            .output(PinSpec::list("out", ValueKind::Number).doc("The numbers."))
+            .eval(series),
+        NodeSpec::new("range", "Range", Category::Source)
+            .doc("Count evenly spaced numbers from a start to an end, both included.")
+            .input(PinSpec::item("start", ValueKind::Number).default(0.0).doc("The first number."))
+            .input(PinSpec::item("end", ValueKind::Number).default(1.0).doc("The last number."))
+            .input(PinSpec::item("count", ValueKind::Int).default(10i64).doc("How many; capped at the list limit. One gives the start alone."))
+            .output(PinSpec::list("out", ValueKind::Number).doc("The numbers."))
+            .eval(range),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/text.rs
+++ b/crates/ringdesign-graph/src/nodes/text.rs
@@ -1,0 +1,45 @@
+//! Text utilities.
+
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry};
+use crate::value::ValueKind;
+
+fn concat(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let sep = i.text("sep")?;
+    Ok(Outputs::one("out", format!("{}{sep}{}", i.text("a")?, i.text("b")?)))
+}
+
+fn join(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let sep = i.text("sep")?.to_string();
+    let parts: Result<Vec<String>, NodeError> = i
+        .list("items")
+        .iter()
+        .enumerate()
+        .map(|(k, v)| match ValueKind::Text.coerce(v.clone()) {
+            Ok(t) => Ok(t.as_text().unwrap_or("").to_string()),
+            Err(e) => Err(NodeError::input("items", format!("item {k}: {e}"))),
+        })
+        .collect();
+    Ok(Outputs::one("out", parts?.join(&sep)))
+}
+
+pub fn register(reg: &mut Registry) {
+    let specs = [
+        NodeSpec::new("text.concat", "Concat", Category::Util)
+            .doc("a and b joined, with a separator between.")
+            .input(PinSpec::item("a", ValueKind::Text).default("").doc("First."))
+            .input(PinSpec::item("b", ValueKind::Text).default("").doc("Second."))
+            .input(PinSpec::item("sep", ValueKind::Text).default("").doc("Put between them."))
+            .output(PinSpec::item("out", ValueKind::Text).doc("The joined text."))
+            .eval(concat),
+        NodeSpec::new("text.join", "Join", Category::Util)
+            .doc("A list joined into one text with a separator; numbers are written out.")
+            .input(PinSpec::list("items", ValueKind::Any).doc("The parts."))
+            .input(PinSpec::item("sep", ValueKind::Text).default(", ").doc("Put between them."))
+            .output(PinSpec::item("out", ValueKind::Text).doc("The joined text."))
+            .eval(join),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,7 +78,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   attributed errors; nested lists pass whole; caps on list items, nodes and cluster depth;
   recipe-signature cache so one edit re-runs one chain; `Targets`; side-effect nodes only on
   demand; `evaluate_design` returns the design **with** its field report.
-- [ ] **M1.6 Source + util nodes** (S, #11). Numbers, series/range, math, basic list ops.
+- [x] **M1.6 Source + util nodes** (S, #11). Numbers, series/range, math, basic list ops.
 - Accept: `[1,2,3]+[10] → [11,12,13]`; empty in → empty out; a failed item does not abort its
   siblings; cache hits after one edit equal the chain length; cycles and fan-in refused; an
   oversize series clamps and warns.


### PR DESCRIPTION
## Summary
- `nodes/{source,math,list,text}.rs`: number/int/bool/text, series, range; 20 macro-generated math ops + lerp/clamp/remap/compare + logic; list length/item/flatten/graft/reverse/slice/sort/merge/sum; text concat/join.
- Table-consistency test (docs, unique named pins, defaults on scalar item inputs) and acceptance tests through `Registry::builtin()`.

## Verification
- `cargo test -p ringdesign-graph`: 30 tests.
- wasm check passes.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)