### PR TITLE
M2.1 StructNode: serde structs as nodes, with coverage

### DIFF
--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -10,6 +10,7 @@ use crate::registry::Registry;
 pub mod list;
 pub mod math;
 pub mod source;
+pub mod structs;
 pub mod text;
 
 /// Register every builtin node kind.
@@ -45,7 +46,7 @@ mod tests {
             }
             for p in &spec.inputs {
                 let scalar = matches!(p.kind, ValueKind::Number | ValueKind::Int | ValueKind::Bool | ValueKind::Text);
-                if scalar && p.access == Access::Item {
+                if scalar && p.access == Access::Item && !p.optional {
                     assert!(p.default.is_some(), "{key}.{} has no default", p.name);
                 }
             }

--- a/crates/ringdesign-graph/src/nodes/structs.rs
+++ b/crates/ringdesign-graph/src/nodes/structs.rs
@@ -1,0 +1,342 @@
+//! Existing serde structs as nodes.
+//!
+//! A [`StructNode`] is a patch over a base: the node starts from the
+//! handle on its base pin (or `T::default()`), writes every *set* field pin
+//! into the struct's JSON at that field's pointer, reads the struct back,
+//! runs an optional finish hook, and wraps the result. An unset pin leaves
+//! the base's field alone — which is what makes a modifier node safe to
+//! put after another node of the same kind. Pins are written through
+//! serde, so an enum pin is a text pin carrying the variant's serde name
+//! and a handle pin carries a whole nested struct.
+//!
+//! [`StructNode::coverage`] compares the struct's serialized keys with the
+//! pins and the declared `hidden` list, so a field added to the core
+//! cannot go unnoticed by its node.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::graph::set_pointer;
+use crate::registry::{EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec};
+use crate::value::{Value, ValueKind};
+
+/// Runs after the patch, with the inputs, for what JSON cannot express —
+/// `apply_style`, `fit_length_to`, a clamp.
+pub type FinishFn<T> = fn(&mut T, &Inputs, &mut EvalCtx<'_>) -> Result<(), NodeError>;
+
+struct FieldPin {
+    pin: String,
+    path: String,
+}
+
+/// A node built over a serde struct `T`.
+pub struct StructNode<T> {
+    spec: NodeSpec,
+    fields: Vec<FieldPin>,
+    hidden: Vec<String>,
+    base: Option<(String, ValueKind)>,
+    out: String,
+    wrap: fn(T) -> Value,
+    unwrap: fn(&Value) -> Option<T>,
+    finish: Option<FinishFn<T>>,
+}
+
+impl<T> StructNode<T>
+where
+    T: Serialize + DeserializeOwned + Default + Clone + Send + Sync + 'static,
+{
+    /// `out` is the output pin's name; `wrap` and `unwrap` move `T` in and
+    /// out of a [`Value`].
+    pub fn new(spec: NodeSpec, out: impl Into<String>, wrap: fn(T) -> Value, unwrap: fn(&Value) -> Option<T>) -> Self {
+        Self { spec, fields: Vec::new(), hidden: Vec::new(), base: None, out: out.into(), wrap, unwrap, finish: None }
+    }
+
+    /// An optional input of the struct's own kind to start from.
+    pub fn base(mut self, pin: impl Into<String>, kind: ValueKind, doc: impl Into<String>) -> Self {
+        let pin = pin.into();
+        self.spec = self.spec.input(PinSpec::item(pin.clone(), kind).doc(doc).optional());
+        self.base = Some((pin, kind));
+        self
+    }
+
+    /// A pin written at `/<name>`.
+    pub fn field(self, pin: PinSpec) -> Self {
+        let path = format!("/{}", pin.name);
+        self.field_at(pin, path)
+    }
+
+    /// A pin written at a JSON pointer inside the struct (`/head/length_mm`).
+    pub fn field_at(mut self, pin: PinSpec, path: impl Into<String>) -> Self {
+        self.fields.push(FieldPin { pin: pin.name.clone(), path: path.into() });
+        self.spec = self.spec.input(pin.optional());
+        self
+    }
+
+    /// Fields deliberately not exposed as pins.
+    pub fn hidden(mut self, names: &[&str]) -> Self {
+        self.hidden.extend(names.iter().map(|s| s.to_string()));
+        self
+    }
+
+    pub fn finish(mut self, f: FinishFn<T>) -> Self {
+        self.finish = Some(f);
+        self
+    }
+
+    /// Every serialized field of `T::default()` is a pin or hidden, and
+    /// every pin or hidden name is a field.
+    pub fn coverage(&self) -> Result<(), String> {
+        let json = serde_json::to_value(T::default()).map_err(|e| format!("{}: {e}", self.spec.key))?;
+        let Some(obj) = json.as_object() else { return Err(format!("{}: the struct does not serialize as an object", self.spec.key)) };
+        let keys: BTreeSet<&str> = obj.keys().map(String::as_str).collect();
+        let mut named: BTreeSet<&str> = self.hidden.iter().map(String::as_str).collect();
+        for f in &self.fields {
+            let first = f.path.trim_start_matches('/').split('/').next().unwrap_or("");
+            named.insert(first);
+        }
+        let missing: Vec<&str> = keys.difference(&named).copied().collect();
+        let extra: Vec<&str> = named.difference(&keys).copied().collect();
+        if missing.is_empty() && extra.is_empty() {
+            Ok(())
+        } else {
+            let mut msg = format!("{}:", self.spec.key);
+            if !missing.is_empty() {
+                msg.push_str(&format!(" fields with no pin and not hidden: {missing:?};"));
+            }
+            if !extra.is_empty() {
+                msg.push_str(&format!(" pins or hidden names that are not fields: {extra:?};"));
+            }
+            Err(msg)
+        }
+    }
+
+    /// The node spec. In debug builds the coverage check must pass.
+    pub fn build(mut self) -> NodeSpec {
+        debug_assert!(self.coverage().is_ok(), "{}", self.coverage().unwrap_err());
+        // A modifier must not overwrite its base with pin defaults.
+        if self.base.is_some() {
+            let fields: BTreeSet<&str> = self.fields.iter().map(|f| f.pin.as_str()).collect();
+            for p in &mut self.spec.inputs {
+                if fields.contains(p.name.as_str()) {
+                    p.default = None;
+                }
+            }
+        }
+        let out_kind = self.out_kind();
+        self.spec = self.spec.output(PinSpec::item(self.out.clone(), out_kind).doc("The result."));
+        let fields: Arc<Vec<FieldPin>> = Arc::new(self.fields);
+        let base = self.base.clone();
+        let out = self.out.clone();
+        let key = self.spec.key.clone();
+        let (wrap, unwrap, finish) = (self.wrap, self.unwrap, self.finish);
+        self.spec.eval(move |ctx, _node, inputs| {
+            let mut value: T = match &base {
+                Some((pin, kind)) => {
+                    let v = inputs.get(pin);
+                    if v.is_null() {
+                        T::default()
+                    } else {
+                        unwrap(v).ok_or_else(|| NodeError::input(pin, format!("expected {}, got {}", kind.label(), v.kind().label())))?
+                    }
+                }
+                None => T::default(),
+            };
+            let mut json = serde_json::to_value(&value).map_err(|e| NodeError::new(format!("{key}: {e}")))?;
+            let mut touched = false;
+            for f in fields.iter() {
+                let v = inputs.get(&f.pin);
+                if v.is_null() {
+                    continue;
+                }
+                let jv = v.to_json_any().ok_or_else(|| NodeError::input(&f.pin, format!("{} cannot be written into a field", v.kind().label())))?;
+                set_pointer(&mut json, &f.path, jv).map_err(|m| NodeError::input(&f.pin, m))?;
+                touched = true;
+            }
+            if touched {
+                value = serde_json::from_value(json).map_err(|e| NodeError::new(format!("{key}: {e}")))?;
+            }
+            if let Some(f) = finish {
+                f(&mut value, inputs, ctx)?;
+            }
+            Ok(Outputs::one(out.clone(), wrap(value)))
+        })
+    }
+
+    fn out_kind(&self) -> ValueKind {
+        (self.wrap)(T::default()).kind()
+    }
+}
+
+/// The serde names of an enum's variants, for a select pin.
+pub fn enum_names<E: Serialize>(all: &[E]) -> Vec<String> {
+    all.iter().filter_map(|e| serde_json::to_value(e).ok()).filter_map(|v| v.as_str().map(str::to_string)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{Evaluator, Targets};
+    use crate::graph::Graph;
+    use crate::registry::{Category, Registry, Widget};
+    use crate::value::Literal;
+    use ringdesign_core::profile::ShankKind;
+    use ringdesign_core::{AlphaLibrary, BandProfile, ShankStyle};
+
+    fn profile_node() -> StructNode<BandProfile> {
+        StructNode::new(
+            NodeSpec::new("test.profile", "Profile", Category::Band).doc("A band section."),
+            "profile",
+            Value::Profile,
+            |v| match v {
+                Value::Profile(p) => Some(*p),
+                _ => None,
+            },
+        )
+        .base("profile", ValueKind::Profile, "Start from this section.")
+        .field(PinSpec::item("width_mm", ValueKind::Number).doc("Width.").widget(Widget::Mm { min: 1.0, max: 20.0 }))
+        .field(PinSpec::item("thickness_mm", ValueKind::Number).doc("Thickness."))
+        .field(PinSpec::item("crown_mm", ValueKind::Number).doc("Crown."))
+        .field(PinSpec::item("shape_a", ValueKind::Number).doc("a."))
+        .field(PinSpec::item("shape_b", ValueKind::Number).doc("b."))
+        .field(PinSpec::item("crest_bias", ValueKind::Number).doc("Bias."))
+        .field(PinSpec::item("edge_round_mm", ValueKind::Number).doc("Edge."))
+        .field(PinSpec::item("comfort_fit_mm", ValueKind::Number).doc("Comfort."))
+        .field(PinSpec::item("side_draft_deg", ValueKind::Number).doc("Draft."))
+        .field(PinSpec::select("style", vec!["HalfRound".into(), "Flat".into()]).doc("Family."))
+        .hidden(&["flange", "drop_curve", "morph"])
+    }
+
+    fn shank_node() -> StructNode<ShankStyle> {
+        let keys: Vec<String> = serde_json::to_value(ShankStyle::default())
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .keys()
+            .filter(|k| *k != "kind" && *k != "amount")
+            .cloned()
+            .collect();
+        let hidden: Vec<&str> = keys.iter().map(String::as_str).collect();
+        StructNode::new(
+            NodeSpec::new("test.shank", "Shank", Category::Shank).doc("A shank."),
+            "shank",
+            |s| Value::Shank(Arc::new(s)),
+            |v| match v {
+                Value::Shank(s) => Some((**s).clone()),
+                _ => None,
+            },
+        )
+        .field(PinSpec::select("kind", enum_names(ShankKind::ALL)).doc("Kind."))
+        .field_at(PinSpec::item("amount", ValueKind::Number).doc("Amount."), "/amount")
+        .hidden(&hidden)
+    }
+
+    fn reg() -> Registry {
+        let mut reg = Registry::empty();
+        reg.register(profile_node().build()).unwrap();
+        reg.register(shank_node().build()).unwrap();
+        reg
+    }
+
+    fn run(g: &Graph, reg: &Registry) -> crate::eval::EvalReport {
+        Evaluator::new().evaluate(g, reg, &AlphaLibrary::default(), 0, Targets::AllPure)
+    }
+
+    #[test]
+    fn unset_pins_leave_the_base_alone_and_set_pins_patch_it() {
+        let reg = reg();
+        let mut g = Graph::default();
+        let a = g.add("test.profile").unwrap();
+        let r = run(&g, &reg);
+        let Some(Value::Profile(p)) = r.value(a, "profile") else { panic!("{:?}", r.value(a, "profile")) };
+        let d = BandProfile::default();
+        assert_eq!((p.width_mm, p.thickness_mm), (d.width_mm, d.thickness_mm), "nothing set: the default");
+
+        g.set_input(a, "width_mm", Literal::Number(8.0)).unwrap();
+        let r = run(&g, &reg);
+        let Some(Value::Profile(p)) = r.value(a, "profile") else { panic!() };
+        assert_eq!(p.width_mm, 8.0);
+        assert_eq!(p.thickness_mm, d.thickness_mm, "an unset pin leaves its field");
+
+        // A second node patches the first's result, keeping the width.
+        let b = g.add("test.profile").unwrap();
+        g.connect(a, "profile", b, "profile").unwrap();
+        g.set_input(b, "thickness_mm", Literal::Number(2.5)).unwrap();
+        g.set_input(b, "style", Literal::Text("Flat".into())).unwrap();
+        let r = run(&g, &reg);
+        let Some(Value::Profile(p)) = r.value(b, "profile") else { panic!() };
+        assert_eq!((p.width_mm, p.thickness_mm), (8.0, 2.5));
+        assert_eq!(p.style, ringdesign_core::ProfileStyle::Flat, "an enum pin is its serde name");
+
+        // Lists patch per item.
+        g.set_input(a, "width_mm", Literal::List(vec![Literal::Number(5.0), Literal::Number(7.0)])).unwrap();
+        let r = run(&g, &reg);
+        match r.value(b, "profile") {
+            Some(Value::List(items)) => {
+                let widths: Vec<f64> = items.iter().map(|v| if let Value::Profile(p) = v { p.width_mm } else { f64::NAN }).collect();
+                assert_eq!(widths, vec![5.0, 7.0]);
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn bad_values_fail_by_name() {
+        let reg = reg();
+        let mut g = Graph::default();
+        let a = g.add("test.profile").unwrap();
+        g.set_input(a, "style", Literal::Text("Octagon".into())).unwrap();
+        let r = run(&g, &reg);
+        let msg = &r.status[&a].errors[0].1;
+        assert!(msg.contains("unknown variant") && msg.contains("Octagon"), "{msg}");
+        // The base pin refuses a value of another kind.
+        let s = g.add("test.shank").unwrap();
+        let b = g.add("test.profile").unwrap();
+        g.wires.push(crate::graph::Wire { from: s, out: "shank".into(), to: b, input: "profile".into() });
+        let errs = g.validate(Some(&reg));
+        assert!(errs.iter().any(|e| e.message.contains("takes profile, but")), "{errs:?}");
+    }
+
+    #[test]
+    fn enum_pins_read_serde_names_and_ints_write_whole_numbers() {
+        let reg = reg();
+        let names = enum_names(ShankKind::ALL);
+        assert!(names.contains(&"Signet".to_string()) && names.contains(&"Uniform".to_string()), "{names:?}");
+        let mut g = Graph::default();
+        let s = g.add("test.shank").unwrap();
+        g.set_input(s, "kind", Literal::Text("Signet".into())).unwrap();
+        g.set_input(s, "amount", Literal::Int(1)).unwrap();
+        let r = run(&g, &reg);
+        let Some(Value::Shank(sh)) = r.value(s, "shank") else { panic!("{:?}", r.status[&s]) };
+        assert_eq!(sh.kind, ShankKind::Signet);
+        assert_eq!(sh.amount, 1.0);
+        let spec = reg.get("test.shank").unwrap();
+        assert!(matches!(&spec.inputs[0].widget, Widget::Select(v) if v.len() == ShankKind::ALL.len()));
+        assert!(spec.inputs.iter().all(|p| p.optional), "struct pins are optional");
+        assert_eq!(spec.outputs[0].kind, ValueKind::Shank);
+    }
+
+    #[test]
+    fn coverage_names_what_a_node_forgot_or_invented() {
+        assert!(profile_node().coverage().is_ok());
+        let missing = StructNode::<BandProfile>::new(
+            NodeSpec::new("test.thin", "Thin", Category::Band),
+            "profile",
+            Value::Profile,
+            |_| None,
+        )
+        .field(PinSpec::item("width_mm", ValueKind::Number))
+        .hidden(&["flange", "drop_curve", "morph", "bogus"])
+        .coverage()
+        .unwrap_err();
+        assert!(missing.contains("\"thickness_mm\"") && missing.contains("no pin"), "{missing}");
+        assert!(missing.contains("\"bogus\"") && missing.contains("not fields"), "{missing}");
+        // A pin on a nested path counts its first segment.
+        let nested = StructNode::<ShankStyle>::new(NodeSpec::new("test.n", "N", Category::Shank), "shank", |s| Value::Shank(Arc::new(s)), |_| None)
+            .field_at(PinSpec::item("head_length", ValueKind::Number), "/head/length_mm");
+        let err = nested.coverage().unwrap_err();
+        assert!(!err.contains("\"head\""), "head is covered by the nested pin: {err}");
+    }
+}

--- a/crates/ringdesign-graph/src/registry.rs
+++ b/crates/ringdesign-graph/src/registry.rs
@@ -8,6 +8,7 @@
 //! everything else has them fixed.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use ringdesign_core::AlphaLibrary;
 
@@ -86,11 +87,14 @@ pub struct PinSpec {
     /// What the pin reads when nothing is wired and no literal is set.
     pub default: Option<Literal>,
     pub widget: Widget,
+    /// `Null` is an answer: the node treats an unset pin as "leave as is"
+    /// rather than failing on it.
+    pub optional: bool,
 }
 
 impl PinSpec {
     pub fn item(name: impl Into<String>, kind: ValueKind) -> Self {
-        Self { name: name.into(), kind, access: Access::Item, doc: String::new(), default: None, widget: Widget::Auto }
+        Self { name: name.into(), kind, access: Access::Item, doc: String::new(), default: None, widget: Widget::Auto, optional: false }
     }
 
     pub fn list(name: impl Into<String>, kind: ValueKind) -> Self {
@@ -110,6 +114,16 @@ impl PinSpec {
     pub fn widget(mut self, widget: Widget) -> Self {
         self.widget = widget;
         self
+    }
+
+    pub fn optional(mut self) -> Self {
+        self.optional = true;
+        self
+    }
+
+    /// A text pin restricted to these names: an enum field.
+    pub fn select(name: impl Into<String>, names: Vec<String>) -> Self {
+        Self::item(name, ValueKind::Text).widget(Widget::Select(names))
     }
 
     pub fn info(&self) -> PinInfo {
@@ -270,8 +284,9 @@ impl From<anyhow::Error> for NodeError {
     }
 }
 
-/// Evaluate one item of a node.
-pub type EvalFn = fn(&mut EvalCtx<'_>, &Node, &Inputs) -> Result<Outputs, NodeError>;
+/// Evaluate one item of a node. A closure, so an adapter built over a
+/// table (a struct's fields, a script's pins) can carry it.
+pub type EvalFn = Arc<dyn Fn(&mut EvalCtx<'_>, &Node, &Inputs) -> Result<Outputs, NodeError> + Send + Sync>;
 /// Pins for one instance, read from its params.
 pub type ResolveFn = fn(&NodeSpec, &Node) -> (Vec<PinSpec>, Vec<PinSpec>);
 /// Rewrite a node saved under an older graph format version.
@@ -321,7 +336,7 @@ impl NodeSpec {
             outputs: Vec::new(),
             doc: String::new(),
             side_effect: false,
-            eval: eval_nothing,
+            eval: Arc::new(eval_nothing),
             resolve: None,
             migrate: None,
         }
@@ -356,8 +371,8 @@ impl NodeSpec {
         self
     }
 
-    pub fn eval(mut self, f: EvalFn) -> Self {
-        self.eval = f;
+    pub fn eval(mut self, f: impl Fn(&mut EvalCtx<'_>, &Node, &Inputs) -> Result<Outputs, NodeError> + Send + Sync + 'static) -> Self {
+        self.eval = Arc::new(f);
         self
     }
 

--- a/crates/ringdesign-graph/src/value.rs
+++ b/crates/ringdesign-graph/src/value.rs
@@ -400,6 +400,31 @@ impl Value {
         })
     }
 
+    /// The JSON form of any serializable value, handles included; `None`
+    /// for meshes, reports and solids.
+    pub fn to_json_any(&self) -> Option<serde_json::Value> {
+        if let Some(j) = self.to_json() {
+            return Some(j);
+        }
+        match self {
+            Value::Design(d) => serde_json::to_value(&**d).ok(),
+            Value::Profile(p) => serde_json::to_value(p).ok(),
+            Value::Shank(s) => serde_json::to_value(&**s).ok(),
+            Value::Head(h) => serde_json::to_value(h).ok(),
+            Value::Outline(o) => serde_json::to_value(&**o).ok(),
+            Value::Gem(g) => serde_json::to_value(g).ok(),
+            Value::Window(w) => serde_json::to_value(w).ok(),
+            Value::Remap(r) => serde_json::to_value(r).ok(),
+            Value::Layer(l) => serde_json::to_value(&**l).ok(),
+            Value::Entry(e) => serde_json::to_value(&**e).ok(),
+            Value::Stack(s) => serde_json::to_value(&**s).ok(),
+            Value::Recipe(r) => serde_json::to_value(&**r).ok(),
+            Value::AlphaSource(a) => serde_json::to_value(&**a).ok(),
+            Value::Build(b) => serde_json::to_value(b).ok(),
+            _ => None,
+        }
+    }
+
     /// One line for badges, logs and error messages.
     pub fn summary(&self) -> String {
         match self {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,7 +85,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 
 ## M2 — The model as nodes, sinks, modes, files, template graphs (XL)
 
-- [ ] **M2.1 `struct_node!`** (M, #12). Existing serde structs become nodes with one line per pin;
+- [x] **M2.1 `struct_node!`** (M, #12). Existing serde structs become nodes with one line per pin;
   enum pins by serde name; a coverage test so a new core field cannot be forgotten.
 - [ ] **M2.2 Band/shank/head/outline nodes** (M, #13).
 - [ ] **M2.3 Layer nodes** (M, #14). One per `Layer` variant, the fitters, the `entry` wrapper


### PR DESCRIPTION
## Summary
- `nodes/structs.rs`: `StructNode<T>` — a node as a patch over a base handle (unset pins leave fields alone), field pins at JSON pointers, enum pins as serde names, handle pins as nested structs, a finish hook, and `coverage()` so a new core field cannot go unnoticed.
- `EvalFn` is now `Arc<dyn Fn>`; `PinSpec::optional`; `Value::to_json_any`.

## Verification
- `cargo test -p ringdesign-graph`: 34 tests (4 new).
- wasm check passes.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)