### PR TITLE
M2.2 Band, shank, head and outline nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -863,8 +863,11 @@ inherited, not re-proven per shape.
 **The fairing ball is per-import** (`CustomOutline::fair_r`, default the
 calibrated `BODY_FAIR_R` 0.75), because 0.75 is tuned on a heart's two
 gentle lobes and a four-lobe clover corrugates a flank it only smooths.
-The importer sizes it from the plan's convex-hull area defect; closing is
-extensive at any radius, so containment is not a function of the choice.
+`CustomOutline::from_points` sizes it from the plan's convex-hull area
+defect (`hull_defect` → `fair_r_for`: the default for a convex plan,
+rising to 2.5 at a 15% defect — the exporter's own rule, so the GUI, MCP
+and graph imports agree with it); closing is extensive at any radius, so
+containment is not a function of the choice.
 And the table's *quality* matters as much as the machinery: 256
 uniform-parameter curve samples left chord kinks that swept ripple bands
 down every wall (clover max second difference 0.0121; 0.0044 after

--- a/crates/ringdesign-core/src/field.rs
+++ b/crates/ringdesign-core/src/field.rs
@@ -2745,6 +2745,62 @@ impl std::fmt::Debug for CustomOutline {
     }
 }
 
+/// `1 − area / hull area`: how deeply lobed a closed plan is. A circle or a
+/// square is ~0, a four-leaf clover ~0.2.
+pub fn hull_defect(pts: &[[f64; 2]]) -> f64 {
+    fn cross(o: [f64; 2], a: [f64; 2], b: [f64; 2]) -> f64 {
+        (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+    }
+    fn area(poly: &[[f64; 2]]) -> f64 {
+        let n = poly.len();
+        if n < 3 {
+            return 0.0;
+        }
+        (0..n)
+            .map(|i| {
+                let (p, q) = (poly[i], poly[(i + 1) % n]);
+                p[0] * q[1] - q[0] * p[1]
+            })
+            .sum::<f64>()
+            .abs()
+            * 0.5
+    }
+    let mut p: Vec<[f64; 2]> = pts.to_vec();
+    p.sort_by(|a, b| a[0].total_cmp(&b[0]).then(a[1].total_cmp(&b[1])));
+    p.dedup();
+    if p.len() < 3 {
+        return 0.0;
+    }
+    let mut lo: Vec<[f64; 2]> = Vec::new();
+    for &q in &p {
+        while lo.len() >= 2 && cross(lo[lo.len() - 2], lo[lo.len() - 1], q) <= 0.0 {
+            lo.pop();
+        }
+        lo.push(q);
+    }
+    let mut up: Vec<[f64; 2]> = Vec::new();
+    for &q in p.iter().rev() {
+        while up.len() >= 2 && cross(up[up.len() - 2], up[up.len() - 1], q) <= 0.0 {
+            up.pop();
+        }
+        up.push(q);
+    }
+    lo.pop();
+    up.pop();
+    lo.extend(up);
+    let hull = area(&lo);
+    if hull < 1e-12 { 0.0 } else { (1.0 - area(pts) / hull).max(0.0) }
+}
+
+/// The fairing ball for a plan this lobed: the calibrated default for a
+/// convex plan, rising to 2.5 half-lengths at a 15% hull defect, so a
+/// clover's notches bridge flat in the body and the lobes read at the
+/// table's rim instead of rippling the whole flank.
+pub fn fair_r_for(defect: f64) -> f64 {
+    let t = ((defect - 0.02) / 0.13).clamp(0.0, 1.0);
+    default_fair_r() + t * 1.75
+}
+
 impl Clone for CustomOutline {
     fn clone(&self) -> Self {
         Self {
@@ -2798,7 +2854,7 @@ impl CustomOutline {
             name: name.into(),
             r: table.r.iter().map(|&v| v as f32).collect(),
             aspect: (w / h).clamp(0.05, 20.0),
-            fair_r: default_fair_r(),
+            fair_r: fair_r_for(hull_defect(&dense)),
             cache: std::sync::OnceLock::new(),
         })
     }
@@ -4354,6 +4410,32 @@ mod silhouette_tests {
         assert!((lo + hi).abs() < 1e-3, "{lo} {hi}");
     }
 
+    /// The import sizes the fairing ball from the plan's own hull defect,
+    /// as the exporter does, so a drawn clover goes onto the cut dome
+    /// without anyone setting a number.
+    #[test]
+    fn fair_r_follows_the_hull_defect() {
+        let ring = |f: &dyn Fn(f64) -> f64| -> Vec<[f64; 2]> {
+            (0..360).map(|k| { let t = (k as f64).to_radians(); let r = f(t); [r * t.cos(), r * t.sin()] }).collect()
+        };
+        let circle = ring(&|_| 1.0);
+        assert!(hull_defect(&circle) < 0.01);
+        assert!((fair_r_for(hull_defect(&circle)) - default_fair_r()).abs() < 1e-9, "a convex plan keeps the default");
+        let square: Vec<[f64; 2]> = vec![[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]];
+        assert!(hull_defect(&square) < 1e-9);
+        let clover = ring(&|t| 0.62 + 0.38 * (4.0 * t).cos());
+        let d = hull_defect(&clover);
+        assert!(d > 0.15, "four deep lobes: defect {d}");
+        assert_eq!(fair_r_for(d), default_fair_r() + 1.75);
+        let o = CustomOutline::from_points("Clover", &clover).unwrap();
+        assert!(o.fair_r > 1.2, "{}", o.fair_r);
+        let mut shank = crate::profile::ShankStyle::default();
+        let v = shank.adopt_outline(o);
+        assert_eq!(shank.suggest_dome(v), 1.0);
+        let oval = CustomOutline::from_points("Oval", &ring(&|t| 1.0 / (t.cos().powi(2) + (1.4 * t.sin()).powi(2)).sqrt())).unwrap();
+        assert!((oval.fair_r - default_fair_r()).abs() < 1e-9);
+    }
+
     #[test]
     fn a_drawn_outline_makes_a_head_that_pulls() {
         // The hostile plan, as a closed polyline.
@@ -4422,6 +4504,7 @@ mod silhouette_tests {
         // smooth lens and the lobes read in the arris — and it fields clean
         // there too.
         let mut lobed = co.clone();
+        assert!(lobed.fair_r > 1.2, "a clipped star's hull defect sizes its own ball: {}", lobed.fair_r);
         lobed.fair_r = 2.0;
         let mut d2 = d.clone();
         let o2 = d2.shank.adopt_outline(lobed);

--- a/crates/ringdesign-graph/src/nodes/band.rs
+++ b/crates/ringdesign-graph/src/nodes/band.rs
@@ -1,0 +1,225 @@
+//! The design, its size and its band section.
+
+use std::sync::Arc;
+
+use ringdesign_core::library;
+use ringdesign_core::sizing::RingSize;
+use ringdesign_core::{BandProfile, ProfileStyle, RingDesign, ShankStyle};
+
+use super::structs::{StructNode, enum_names};
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::{Value, ValueKind};
+
+fn design_new(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut d = RingDesign::default();
+    d.name = i.text("name")?.to_string();
+    let size = i.number("size")?;
+    if !(1.0..=20.0).contains(&size) {
+        return Err(NodeError::input("size", format!("{size} is not a US ring size between 1 and 20")));
+    }
+    d.size = RingSize(size);
+    match i.get("profile") {
+        Value::Profile(p) => d.profile = *p,
+        Value::Null => {}
+        other => return Err(NodeError::input("profile", format!("expected a profile, got {}", other.kind()))),
+    }
+    match i.get("shank") {
+        Value::Shank(s) => d.shank = (**s).clone(),
+        Value::Null => {}
+        other => return Err(NodeError::input("shank", format!("expected a shank, got {}", other.kind()))),
+    }
+    Ok(Outputs::one("design", d))
+}
+
+fn size(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let s = RingSize(i.number("size")?);
+    Ok(Outputs::one("inner_diameter_mm", s.inner_diameter_mm())
+        .with("inner_circumference_mm", s.inner_circumference_mm())
+        .with("bore_radius_mm", s.inner_diameter_mm() * 0.5)
+        .with("label", s.display()))
+}
+
+fn size_fit(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let d = i.number("inner_diameter_mm")?;
+    if d <= 0.0 {
+        return Err(NodeError::input("inner_diameter_mm", "must be positive"));
+    }
+    Ok(Outputs::one("size", RingSize::from_diameter_mm(d).0))
+}
+
+fn profile_prepare(p: &mut BandProfile, i: &Inputs, _: &mut EvalCtx<'_>) -> Result<(), NodeError> {
+    if let Some(name) = i.get("style").as_text() {
+        let style: ProfileStyle = serde_json::from_value(serde_json::Value::String(name.to_string()))
+            .map_err(|_| NodeError::input("style", format!("{name:?} is not a profile style")))?;
+        p.apply_style(style);
+    }
+    Ok(())
+}
+
+fn profile_finish(p: &mut BandProfile, i: &Inputs, _: &mut EvalCtx<'_>) -> Result<(), NodeError> {
+    if i.get("flatten_sides").as_bool() == Some(true) {
+        p.flatten_sides();
+    }
+    if p.width_mm <= 0.0 || p.thickness_mm <= 0.0 {
+        return Err(NodeError::new(format!("a band {:.2} × {:.2} mm has no metal", p.width_mm, p.thickness_mm)));
+    }
+    Ok(())
+}
+
+fn profile_node() -> NodeSpec {
+    StructNode::new(
+        NodeSpec::new("band.profile", "Band profile", Category::Band)
+            .doc("The band's cross-section: a style preset, then any field set explicitly. Unset pins keep the base's values."),
+        "profile",
+        Value::Profile,
+        |v| match v {
+            Value::Profile(p) => Some(*p),
+            _ => None,
+        },
+    )
+    .base("profile", ValueKind::Profile, "Start from this section; the default band otherwise.")
+    .extra(PinSpec::select("style", enum_names(ProfileStyle::ALL)).doc("Section family: sets the drop law, crown and edge before the pins below."))
+    .field(PinSpec::item("width_mm", ValueKind::Number).widget(Widget::Mm { min: 1.0, max: 25.0 }).doc("Width along the finger, mm."))
+    .field(PinSpec::item("thickness_mm", ValueKind::Number).widget(Widget::Mm { min: 0.6, max: 8.0 }).doc("Bore to crest, mm."))
+    .field(PinSpec::item("crown_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 6.0 }).doc("How much of the thickness is the dome, mm."))
+    .field(PinSpec::item("shape_a", ValueKind::Number).doc("Superellipse drop exponent a."))
+    .field(PinSpec::item("shape_b", ValueKind::Number).doc("Superellipse drop exponent b."))
+    .field(PinSpec::item("crest_bias", ValueKind::Number).widget(Widget::Slider { min: -1.0, max: 1.0 }).doc("Crest offset across the band, −1..1."))
+    .field(PinSpec::item("edge_round_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 2.0 }).doc("Edge fillet, mm."))
+    .field(PinSpec::item("comfort_fit_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 1.0 }).doc("Comfort-fit bore widening at the edges, mm."))
+    .field(PinSpec::item("side_draft_deg", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 30.0 }).doc("Side face draft, degrees."))
+    .extra(PinSpec::item("flatten_sides", ValueKind::Bool).widget(Widget::Checkbox).doc("Square the side faces for ornament: zero side draft, small edge fillet."))
+    .hidden(&["style", "flange", "drop_curve", "morph"])
+    .prepare(profile_prepare)
+    .finish(profile_finish)
+    .build()
+}
+
+fn profile_library(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let name = i.text("name")?;
+    let entries = library::list_profiles();
+    let Some((_, shape)) = entries.iter().find(|(n, _)| n == name) else {
+        let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+        return Err(NodeError::input("name", format!("no saved profile {name:?}; the library has {names:?}")));
+    };
+    let out = match i.get("profile") {
+        Value::Profile(base) => {
+            let mut p = *base;
+            p.apply_shape(shape);
+            p
+        }
+        Value::Null => *shape,
+        other => return Err(NodeError::input("profile", format!("expected a profile, got {}", other.kind()))),
+    };
+    Ok(Outputs::one("profile", out))
+}
+
+pub fn register(reg: &mut Registry) {
+    let specs = [
+        NodeSpec::new("design.new", "New design", Category::Band)
+            .doc("A ring design: a name, a US size, and optionally a band section and a shank. Layers come later in the chain.")
+            .input(PinSpec::item("name", ValueKind::Text).default("Untitled").widget(Widget::TextLine).doc("The design's name."))
+            .input(PinSpec::item("size", ValueKind::Number).default(7.0).widget(Widget::Slider { min: 3.0, max: 15.0 }).doc("US ring size."))
+            .input(PinSpec::item("profile", ValueKind::Profile).optional().doc("The band section; the default band if unset."))
+            .input(PinSpec::item("shank", ValueKind::Shank).optional().doc("The shank; uniform if unset."))
+            .output(PinSpec::item("design", ValueKind::Design).doc("The design."))
+            .eval(design_new),
+        NodeSpec::new("band.size", "Ring size", Category::Band)
+            .doc("A US ring size as millimetres: inner diameter, inner circumference, bore radius.")
+            .input(PinSpec::item("size", ValueKind::Number).default(7.0).widget(Widget::Slider { min: 3.0, max: 15.0 }).doc("US ring size."))
+            .output(PinSpec::item("inner_diameter_mm", ValueKind::Number).doc("Bore diameter, mm."))
+            .output(PinSpec::item("inner_circumference_mm", ValueKind::Number).doc("Bore circumference, mm."))
+            .output(PinSpec::item("bore_radius_mm", ValueKind::Number).doc("Bore radius, mm."))
+            .output(PinSpec::item("label", ValueKind::Text).doc("The size as shown in the app."))
+            .eval(size),
+        NodeSpec::new("band.size.fit", "Size from diameter", Category::Band)
+            .doc("The US size a bore diameter corresponds to.")
+            .input(PinSpec::item("inner_diameter_mm", ValueKind::Number).default(17.35).widget(Widget::Mm { min: 10.0, max: 30.0 }).doc("Bore diameter, mm."))
+            .output(PinSpec::item("size", ValueKind::Number).doc("US ring size."))
+            .eval(size_fit),
+        profile_node(),
+        NodeSpec::new("band.profile.library", "Saved profile", Category::Band)
+            .doc("A section from the user's profile library by name. With a base profile, applies the saved shape while keeping the base's width and thickness — a profile is a section, never a size.")
+            .input(PinSpec::item("name", ValueKind::Text).default("").widget(Widget::TextLine).doc("The saved profile's name."))
+            .input(PinSpec::item("profile", ValueKind::Profile).optional().doc("Keep this band's width and thickness."))
+            .output(PinSpec::item("profile", ValueKind::Profile).doc("The section."))
+            .eval(profile_library),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}
+
+/// A shank handle for tests and sibling modules.
+pub(crate) fn shank_value(s: ShankStyle) -> Value {
+    Value::Shank(Arc::new(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{Evaluator, Targets};
+    use crate::graph::Graph;
+    use crate::value::Literal;
+    use ringdesign_core::AlphaLibrary;
+
+    fn run(g: &Graph) -> crate::eval::EvalReport {
+        Evaluator::new().evaluate(g, &Registry::builtin(), &AlphaLibrary::default(), 0, Targets::AllPure)
+    }
+
+    #[test]
+    fn a_profile_node_applies_its_style_before_its_pins() {
+        let mut g = Graph::default();
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "style", Literal::Text("Flat".into())).unwrap();
+        g.set_input(p, "width_mm", Literal::Number(7.0)).unwrap();
+        g.set_input(p, "crown_mm", Literal::Number(0.9)).unwrap();
+        g.set_input(p, "flatten_sides", Literal::Bool(true)).unwrap();
+        let r = run(&g);
+        let Some(Value::Profile(bp)) = r.value(p, "profile") else { panic!("{:?}", r.status[&p]) };
+        let mut want = BandProfile::default();
+        want.apply_style(ProfileStyle::Flat);
+        assert_eq!(bp.style, ProfileStyle::Flat);
+        assert_eq!((bp.shape_a, bp.shape_b), (want.shape_a, want.shape_b), "the style's drop law");
+        assert_eq!(bp.width_mm, 7.0);
+        assert_eq!(bp.crown_mm, 0.9, "an explicit crown survives the style");
+        assert_eq!(bp.side_draft_deg, 0.0, "flattened");
+        // A style nobody has is refused by name; a dead band too.
+        g.set_input(p, "style", Literal::Text("Octagonal".into())).unwrap();
+        let r = run(&g);
+        assert!(r.status[&p].errors[0].1.contains("not a profile style"));
+        g.set_input(p, "style", Literal::Text("Flat".into())).unwrap();
+        g.set_input(p, "width_mm", Literal::Number(0.0)).unwrap();
+        let r = run(&g);
+        assert!(r.status[&p].errors[0].1.contains("no metal"));
+    }
+
+    #[test]
+    fn size_and_design_nodes_agree_with_the_core() {
+        let mut g = Graph::default();
+        let s = g.add("band.size").unwrap();
+        g.set_input(s, "size", Literal::Number(7.0)).unwrap();
+        let f = g.add("band.size.fit").unwrap();
+        g.connect(s, "inner_diameter_mm", f, "inner_diameter_mm").unwrap();
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "width_mm", Literal::Number(5.0)).unwrap();
+        let d = g.add("design.new").unwrap();
+        g.set_input(d, "name", Literal::Text("Court".into())).unwrap();
+        g.set_input(d, "size", Literal::Number(8.5)).unwrap();
+        g.connect(p, "profile", d, "profile").unwrap();
+        let r = run(&g);
+        let rs = RingSize(7.0);
+        assert_eq!(r.value(s, "inner_diameter_mm"), Some(&Value::Number(rs.inner_diameter_mm())));
+        assert_eq!(r.value(s, "bore_radius_mm"), Some(&Value::Number(rs.inner_diameter_mm() * 0.5)));
+        assert!((r.value(f, "size").unwrap().as_number().unwrap() - 7.0).abs() < 1e-9, "round trip");
+        let Some(Value::Design(design)) = r.value(d, "design") else { panic!("{:?}", r.status[&d]) };
+        assert_eq!(design.name, "Court");
+        assert_eq!(design.size, RingSize(8.5));
+        assert_eq!(design.profile.width_mm, 5.0);
+        assert_eq!(design.inner_radius_mm(), RingSize(8.5).inner_diameter_mm() * 0.5);
+        g.set_input(d, "size", Literal::Number(40.0)).unwrap();
+        let r = run(&g);
+        assert!(r.status[&d].errors[0].1.contains("US ring size"));
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -7,8 +7,10 @@
 
 use crate::registry::Registry;
 
+pub mod band;
 pub mod list;
 pub mod math;
+pub mod shank;
 pub mod source;
 pub mod structs;
 pub mod text;
@@ -19,6 +21,8 @@ pub fn register_all(reg: &mut Registry) {
     math::register(reg);
     list::register(reg);
     text::register(reg);
+    band::register(reg);
+    shank::register(reg);
 }
 
 #[cfg(test)]
@@ -38,11 +42,14 @@ mod tests {
             let spec = reg.get(key).unwrap();
             assert!(!spec.doc.is_empty(), "{key} has no doc");
             assert!(!spec.label.is_empty(), "{key} has no label");
-            assert!(key.contains('.') || matches!(key, "number" | "int" | "bool" | "text" | "series" | "range"), "{key} is not family.name");
-            let mut seen = BTreeSet::new();
-            for p in spec.inputs.iter().chain(&spec.outputs) {
-                assert!(seen.insert(&p.name), "{key} names pin {:?} twice", p.name);
-                assert!(!p.doc.is_empty(), "{key}.{} has no doc", p.name);
+            assert!(key.contains('.') || matches!(key, "number" | "int" | "bool" | "text" | "series" | "range" | "shank" | "head"), "{key} is not family.name");
+            // Inputs and outputs are separate namespaces: a wire names one of each.
+            for pins in [&spec.inputs, &spec.outputs] {
+                let mut seen = BTreeSet::new();
+                for p in pins {
+                    assert!(seen.insert(&p.name), "{key} names pin {:?} twice", p.name);
+                    assert!(!p.doc.is_empty(), "{key}.{} has no doc", p.name);
+                }
             }
             for p in &spec.inputs {
                 let scalar = matches!(p.kind, ValueKind::Number | ValueKind::Int | ValueKind::Bool | ValueKind::Text);

--- a/crates/ringdesign-graph/src/nodes/shank.rs
+++ b/crates/ringdesign-graph/src/nodes/shank.rs
@@ -1,0 +1,329 @@
+//! Shanks, signet heads and head outlines.
+
+use std::sync::Arc;
+
+use ringdesign_core::field::SignetOutline;
+use ringdesign_core::library;
+use ringdesign_core::profile::{ShankKind, SignetHead};
+use ringdesign_core::{CustomOutline, ShankStyle};
+
+use super::band::shank_value;
+use super::structs::{StructNode, enum_names};
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::{Value, ValueKind};
+
+fn unwrap_shank(v: &Value) -> Option<ShankStyle> {
+    match v {
+        Value::Shank(s) => Some((**s).clone()),
+        _ => None,
+    }
+}
+
+fn shank_of(i: &Inputs, pin: &str) -> Result<ShankStyle, NodeError> {
+    match i.get(pin) {
+        Value::Shank(s) => Ok((**s).clone()),
+        Value::Null => Ok(ShankStyle::default()),
+        other => Err(NodeError::input(pin, format!("expected a shank, got {}", other.kind()))),
+    }
+}
+
+fn parse_outline(name: &str) -> Result<SignetOutline, NodeError> {
+    serde_json::from_value(serde_json::Value::String(name.to_string()))
+        .map_err(|_| NodeError::input("outline", format!("{name:?} is not a builtin outline; custom plans come in through shank.outline")))
+}
+
+fn shank_node() -> NodeSpec {
+    StructNode::new(
+        NodeSpec::new("shank", "Shank", Category::Shank)
+            .doc("How the band changes round the ring: a kind, its strength, and the head it carries when it is a signet."),
+        "shank",
+        shank_value,
+        unwrap_shank,
+    )
+    .base("shank", ValueKind::Shank, "Start from this shank; uniform otherwise.")
+    .field(PinSpec::select("kind", enum_names(ShankKind::ALL)).doc("The modulation family. Switching to Signet here keeps the head as is; use shank.signet for signet defaults."))
+    .field(PinSpec::item("amount", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("The modulation's strength, 0..1."))
+    .field(PinSpec::item("waves", ValueKind::Int).doc("Waves round the ring for Wave and Twist; an integer, so the joint closes."))
+    .field(PinSpec::item("head", ValueKind::Head).doc("The signet head."))
+    .hidden(&["extra_heads", "keys", "custom_outlines"])
+    .build()
+}
+
+fn head_outline_check(_: &mut SignetHead, i: &Inputs, _: &mut EvalCtx<'_>) -> Result<(), NodeError> {
+    if let Some(name) = i.get("outline").as_text() {
+        parse_outline(name)?;
+    }
+    Ok(())
+}
+
+fn head_fit(h: &mut SignetHead, i: &Inputs, _: &mut EvalCtx<'_>) -> Result<(), NodeError> {
+    if let Some(w) = i.get("fit_to_width_mm").as_number() {
+        if w <= 0.0 {
+            return Err(NodeError::input("fit_to_width_mm", "must be positive"));
+        }
+        h.fit_length_to(w);
+    }
+    Ok(())
+}
+
+fn head_node() -> NodeSpec {
+    StructNode::new(
+        NodeSpec::new("head", "Signet head", Category::Shank).doc("A signet head: outline, size, stand-off and construction (prism, cut dome, or the lofted body)."),
+        "head",
+        Value::Head,
+        |v| match v {
+            Value::Head(h) => Some(*h),
+            _ => None,
+        },
+    )
+    .base("head", ValueKind::Head, "Start from this head; the lofted oval otherwise.")
+    .default_base(SignetHead::lofted)
+    .field(PinSpec::select("outline", enum_names(SignetOutline::ALL)).doc("The face's plan, one of the builtins."))
+    .field(PinSpec::item("theta_deg", ValueKind::Number).widget(Widget::Angle).doc("Where the head sits; 90° is the top."))
+    .field(PinSpec::item("length_mm", ValueKind::Number).widget(Widget::Mm { min: 2.0, max: 40.0 }).doc("The face's length along the ring, mm."))
+    .field(PinSpec::item("rise_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 8.0 }).doc("How far the table stands over the shank, mm."))
+    .field(PinSpec::item("shoulder_deg", ValueKind::Number).widget(Widget::Slider { min: 5.0, max: 120.0 }).doc("The arc over which the crest falls back to the shank."))
+    .field(PinSpec::item("swell_deg", ValueKind::Number).widget(Widget::Slider { min: 10.0, max: 170.0 }).doc("The arc the width takes to come back; scaled with the head if unset."))
+    .field(PinSpec::item("body_fair", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("How much the body is faired under the face, 0..1."))
+    .field(PinSpec::item("table_flat", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("1 is a true plane to engrave."))
+    .field(PinSpec::item("table_dome_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 3.0 }).doc("A cabochon cap on the table; on a lofted head, the apex height of the smooth table."))
+    .field(PinSpec::item("rim_round_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 2.0 }).doc("The table rim's fillet, mm."))
+    .field(PinSpec::item("dome", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("The cut-dome construction; takes precedence over the loft."))
+    .field(PinSpec::item("loft", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("The lofted body; 1 for a new signet."))
+    .field(PinSpec::item("loft_frontal_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 20.0 }).doc("Body growth along the ring under the table, mm."))
+    .field(PinSpec::item("loft_lateral_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 20.0 }).doc("Body growth across the band under the table, mm."))
+    .extra(PinSpec::item("fit_to_width_mm", ValueKind::Number).widget(Widget::Mm { min: 1.0, max: 25.0 }).doc("Size the face to a band this wide, by the outline's own aspect."))
+    .prepare(head_outline_check)
+    .finish(head_fit)
+    .build()
+}
+
+fn shank_signet(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut s = shank_of(i, "shank")?;
+    let width = i.number("band_width_mm")?;
+    if width <= 0.0 {
+        return Err(NodeError::input("band_width_mm", "must be positive"));
+    }
+    s.apply_signet(width);
+    if let Some(name) = i.get("outline").as_text() {
+        let o = parse_outline(name)?;
+        s.head.outline = o;
+        s.head.fit_length_to(width);
+        s.head.dome = s.suggest_dome(o);
+    }
+    Ok(Outputs::one("shank", shank_value(s)))
+}
+
+fn shank_add_head(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut s = shank_of(i, "shank")?;
+    match i.get("head") {
+        Value::Head(h) => s.extra_heads.push(*h),
+        other => return Err(NodeError::input("head", format!("expected a head, got {}", other.kind()))),
+    }
+    Ok(Outputs::one("shank", shank_value(s)))
+}
+
+fn shank_outline(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut s = shank_of(i, "shank")?;
+    let outline = match i.get("outline") {
+        Value::Outline(o) => o.clone(),
+        other => return Err(NodeError::input("outline", format!("expected an outline, got {}", other.kind()))),
+    };
+    let o = s.adopt_outline((*outline).clone());
+    s.head.outline = o;
+    if let Some(w) = i.get("band_width_mm").as_number() {
+        s.head.fit_length_to(w);
+    }
+    s.head.dome = s.suggest_dome(o);
+    Ok(Outputs::one("shank", shank_value(s)).with("outline_index", i64::from(match o {
+        SignetOutline::Custom(k) => k,
+        _ => 0,
+    })))
+}
+
+fn outline_custom(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let name = i.text("name")?.to_string();
+    let pts: Vec<[f64; 2]> = match i.get("points") {
+        Value::Path(p) => (**p).clone(),
+        Value::Null => Vec::new(),
+        other => return Err(NodeError::input("points", format!("expected a path, got {}", other.kind()))),
+    };
+    let mut o = CustomOutline::from_points(name, &pts).ok_or_else(|| NodeError::input("points", format!("{} points do not make a plan; at least 8 round a closed shape", pts.len())))?;
+    let across = i.bool("symmetric_across")?;
+    let along = i.bool("symmetric_along")?;
+    if across || along {
+        o.symmetrize(across, along);
+    }
+    if let Some(r) = i.get("fair_r").as_number() {
+        o.fair_r = r.clamp(0.0, 3.0);
+    }
+    Ok(Outputs::one("outline", Value::Outline(Arc::new(o))))
+}
+
+fn outline_library(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let name = i.text("name")?;
+    let entries = library::list_outlines();
+    let Some(o) = entries.into_iter().find(|o| o.name == name) else {
+        let names: Vec<String> = library::list_outlines().into_iter().map(|o| o.name).collect();
+        return Err(NodeError::input("name", format!("no saved outline {name:?}; the library has {names:?}")));
+    };
+    Ok(Outputs::one("outline", Value::Outline(Arc::new(o))))
+}
+
+pub fn register(reg: &mut Registry) {
+    let specs = [
+        shank_node(),
+        head_node(),
+        NodeSpec::new("shank.signet", "Signet shank", Category::Shank)
+            .doc("A shank made a signet the way the app does it: the signet taper, the face fitted to the band, the lofted body — then an optional builtin outline.")
+            .input(PinSpec::item("shank", ValueKind::Shank).optional().doc("Start from this shank."))
+            .input(PinSpec::item("band_width_mm", ValueKind::Number).default(12.0).widget(Widget::Mm { min: 1.0, max: 25.0 }).doc("The band's width, which sizes the face."))
+            .input(PinSpec::select("outline", enum_names(SignetOutline::ALL)).optional().doc("A builtin outline to fit, with the app's dome suggestion."))
+            .output(PinSpec::item("shank", ValueKind::Shank).doc("The signet shank."))
+            .eval(shank_signet),
+        NodeSpec::new("shank.add_head", "Add head", Category::Shank)
+            .doc("A second (or third) head on the shank, at its own angle.")
+            .input(PinSpec::item("shank", ValueKind::Shank).optional().doc("The shank to add to."))
+            .input(PinSpec::item("head", ValueKind::Head).doc("The extra head."))
+            .output(PinSpec::item("shank", ValueKind::Shank).doc("The shank with the head."))
+            .eval(shank_add_head),
+        NodeSpec::new("shank.outline", "Custom outline on shank", Category::Shank)
+            .doc("Carry an imported plan into the shank and put it on the head, with the app's dome suggestion for lobed plans.")
+            .input(PinSpec::item("shank", ValueKind::Shank).optional().doc("The shank."))
+            .input(PinSpec::item("outline", ValueKind::Outline).doc("The plan."))
+            .input(PinSpec::item("band_width_mm", ValueKind::Number).optional().widget(Widget::Mm { min: 1.0, max: 25.0 }).doc("Fit the face to a band this wide."))
+            .output(PinSpec::item("shank", ValueKind::Shank).doc("The shank carrying the plan."))
+            .output(PinSpec::item("outline_index", ValueKind::Int).doc("The plan's slot in the shank's registry."))
+            .eval(shank_outline),
+        NodeSpec::new("outline.custom", "Outline from points", Category::Shank)
+            .doc("A head plan from a closed point list (any units; the box is normalized), faired with the rolling ball like the builtins.")
+            .input(PinSpec::item("name", ValueKind::Text).default("Custom").widget(Widget::TextLine).doc("The plan's name."))
+            .input(PinSpec::item("points", ValueKind::Path).doc("The boundary, [x, y] pairs round the shape."))
+            .input(PinSpec::item("symmetric_across", ValueKind::Bool).default(false).widget(Widget::Checkbox).doc("Fold symmetric across the band."))
+            .input(PinSpec::item("symmetric_along", ValueKind::Bool).default(false).widget(Widget::Checkbox).doc("Fold symmetric along the ring."))
+            .input(PinSpec::item("fair_r", ValueKind::Number).optional().widget(Widget::Slider { min: 0.0, max: 3.0 }).doc("The fairing ball's radius in half-lengths; the importer's own choice if unset."))
+            .output(PinSpec::item("outline", ValueKind::Outline).doc("The plan."))
+            .eval(outline_custom),
+        NodeSpec::new("outline.library", "Saved outline", Category::Shank)
+            .doc("A head plan from the user's outline library by name.")
+            .input(PinSpec::item("name", ValueKind::Text).default("").widget(Widget::TextLine).doc("The saved outline's name."))
+            .output(PinSpec::item("outline", ValueKind::Outline).doc("The plan."))
+            .eval(outline_library),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{Evaluator, Targets, evaluate_design};
+    use crate::graph::Graph;
+    use crate::value::Literal;
+    use ringdesign_core::AlphaLibrary;
+
+    fn run(g: &Graph) -> crate::eval::EvalReport {
+        Evaluator::new().evaluate(g, &Registry::builtin(), &AlphaLibrary::default(), 0, Targets::AllPure)
+    }
+
+    #[test]
+    fn a_signet_built_through_nodes_is_lofted_and_fields_clean() {
+        let mut g = Graph::default();
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "style", Literal::Text("Flat".into())).unwrap();
+        g.set_input(p, "width_mm", Literal::Number(12.0)).unwrap();
+        g.set_input(p, "thickness_mm", Literal::Number(1.8)).unwrap();
+        g.set_input(p, "flatten_sides", Literal::Bool(true)).unwrap();
+        let s = g.add("shank.signet").unwrap();
+        g.set_input(s, "band_width_mm", Literal::Number(12.0)).unwrap();
+        g.set_input(s, "outline", Literal::Text("Cushion".into())).unwrap();
+        let h = g.add("head").unwrap();
+        g.set_input(h, "rise_mm", Literal::Number(0.5)).unwrap();
+        let sh = g.add("shank").unwrap();
+        g.connect(s, "shank", sh, "shank").unwrap();
+        g.connect(h, "head", sh, "head").unwrap();
+        let d = g.add("design.new").unwrap();
+        g.connect(p, "profile", d, "profile").unwrap();
+        g.connect(sh, "shank", d, "shank").unwrap();
+        let reg = Registry::builtin();
+        let out = evaluate_design(&mut Evaluator::new(), &g, &reg, &AlphaLibrary::default(), 0).unwrap();
+        assert!(out.notes.is_empty(), "{:?}", out.notes);
+        let design = &out.design;
+        assert_eq!(design.shank.kind, ShankKind::Signet);
+        // The head node started from the lofted default and set the rise;
+        // wired into the shank it replaced the signet's own head outright.
+        assert_eq!(design.shank.head.loft, 1.0);
+        assert_eq!(design.shank.head.rise_mm, 0.5);
+        assert_eq!(design.shank.head.outline, SignetOutline::Oval, "the head pin replaces the head");
+        assert_ne!(out.field.verdict, ringdesign_core::castability::Verdict::NotCastable, "{:?}", out.field.notes);
+
+        // Without the head pin, the signet node's fitted cushion stands.
+        g.disconnect(sh, "head");
+        let out = evaluate_design(&mut Evaluator::new(), &g, &reg, &AlphaLibrary::default(), 0).unwrap();
+        assert_eq!(out.design.shank.head.outline, SignetOutline::Cushion);
+        let want = 12.0 * SignetOutline::Cushion.head_aspect();
+        assert!((out.design.shank.head.length_mm - want).abs() < 1e-9);
+        assert_eq!(out.design.shank.head.loft, 1.0);
+    }
+
+    #[test]
+    fn heads_patch_and_fit_and_outlines_are_named() {
+        let mut g = Graph::default();
+        let h = g.add("head").unwrap();
+        g.set_input(h, "outline", Literal::Text("Heart".into())).unwrap();
+        g.set_input(h, "fit_to_width_mm", Literal::Number(10.0)).unwrap();
+        let h2 = g.add("head").unwrap();
+        g.connect(h, "head", h2, "head").unwrap();
+        g.set_input(h2, "dome", Literal::Number(1.0)).unwrap();
+        let r = run(&g);
+        let Some(Value::Head(a)) = r.value(h, "head") else { panic!("{:?}", r.status[&h]) };
+        assert_eq!(a.outline, SignetOutline::Heart);
+        assert!((a.length_mm - 10.0 * SignetOutline::Heart.head_aspect()).abs() < 1e-9);
+        let Some(Value::Head(b)) = r.value(h2, "head") else { panic!() };
+        assert_eq!((b.outline, b.dome, b.length_mm), (SignetOutline::Heart, 1.0, a.length_mm), "a patch over the first head");
+        g.set_input(h, "outline", Literal::Text("Custom".into())).unwrap();
+        let r = run(&g);
+        assert!(r.status[&h].errors[0].1.contains("not a builtin outline"), "{:?}", r.status[&h].errors);
+    }
+
+    #[test]
+    fn a_drawn_plan_lands_on_the_head_and_the_dome_suggestion_follows() {
+        // A clipped four-lobed star: deeply lobed, so the app would put it
+        // on the cut dome.
+        let mut pts = Vec::new();
+        for k in 0..360 {
+            let t = (k as f64).to_radians();
+            let r = 0.62 + 0.38 * (4.0 * t).cos();
+            pts.push([r * t.cos(), r * t.sin()]);
+        }
+        let mut g = Graph::default();
+        let o = g.add("outline.custom").unwrap();
+        g.set_input(o, "name", Literal::Text("Star".into())).unwrap();
+        g.set_input(o, "points", Literal::Json(serde_json::json!(pts))).unwrap();
+        g.set_input(o, "symmetric_across", Literal::Bool(true)).unwrap();
+        let s = g.add("shank.signet").unwrap();
+        g.set_input(s, "band_width_mm", Literal::Number(9.0)).unwrap();
+        let so = g.add("shank.outline").unwrap();
+        g.connect(s, "shank", so, "shank").unwrap();
+        g.connect(o, "outline", so, "outline").unwrap();
+        g.set_input(so, "band_width_mm", Literal::Number(9.0)).unwrap();
+        let d = g.add("design.new").unwrap();
+        g.connect(so, "shank", d, "shank").unwrap();
+        let r = run(&g);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        let Some(Value::Design(design)) = r.value(d, "design") else { panic!() };
+        assert!(matches!(design.shank.head.outline, SignetOutline::Custom(_)));
+        assert_eq!(design.shank.custom_outlines.len(), 1);
+        assert_eq!(design.shank.custom_outlines[0].name, "Star");
+        let plan = design.shank.head.outline;
+        assert_eq!(design.shank.head.dome, design.shank.suggest_dome(plan), "the node applies the app's dome suggestion");
+        assert_eq!(design.shank.head.dome, 1.0, "and four deep lobes are the lobed signature");
+        assert_eq!(r.value(so, "outline_index"), Some(&Value::Int(0)));
+        // Too few points is refused by name.
+        g.set_input(o, "points", Literal::Json(serde_json::json!([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]))).unwrap();
+        let r = run(&g);
+        assert!(r.status[&o].errors[0].1.contains("at least 8"));
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/structs.rs
+++ b/crates/ringdesign-graph/src/nodes/structs.rs
@@ -41,6 +41,8 @@ pub struct StructNode<T> {
     out: String,
     wrap: fn(T) -> Value,
     unwrap: fn(&Value) -> Option<T>,
+    default_base: fn() -> T,
+    prepare: Option<FinishFn<T>>,
     finish: Option<FinishFn<T>>,
 }
 
@@ -51,7 +53,7 @@ where
     /// `out` is the output pin's name; `wrap` and `unwrap` move `T` in and
     /// out of a [`Value`].
     pub fn new(spec: NodeSpec, out: impl Into<String>, wrap: fn(T) -> Value, unwrap: fn(&Value) -> Option<T>) -> Self {
-        Self { spec, fields: Vec::new(), hidden: Vec::new(), base: None, out: out.into(), wrap, unwrap, finish: None }
+        Self { spec, fields: Vec::new(), hidden: Vec::new(), base: None, out: out.into(), wrap, unwrap, default_base: T::default, prepare: None, finish: None }
     }
 
     /// An optional input of the struct's own kind to start from.
@@ -81,8 +83,29 @@ where
         self
     }
 
+    /// What the node starts from when no base is wired: `T::default()`
+    /// unless told otherwise (a new signet head is the lofted one).
+    pub fn default_base(mut self, f: fn() -> T) -> Self {
+        self.default_base = f;
+        self
+    }
+
+    /// Runs on the base before the field pins are written, so a pin the
+    /// hook reads (a style preset) cannot clobber pins set explicitly.
+    pub fn prepare(mut self, f: FinishFn<T>) -> Self {
+        self.prepare = Some(f);
+        self
+    }
+
     pub fn finish(mut self, f: FinishFn<T>) -> Self {
         self.finish = Some(f);
+        self
+    }
+
+    /// An input that is not a field: read by the hooks, ignored by the
+    /// patch and the coverage check.
+    pub fn extra(mut self, pin: PinSpec) -> Self {
+        self.spec = self.spec.input(pin.optional());
         self
     }
 
@@ -131,19 +154,22 @@ where
         let base = self.base.clone();
         let out = self.out.clone();
         let key = self.spec.key.clone();
-        let (wrap, unwrap, finish) = (self.wrap, self.unwrap, self.finish);
+        let (wrap, unwrap, prepare, finish, default_base) = (self.wrap, self.unwrap, self.prepare, self.finish, self.default_base);
         self.spec.eval(move |ctx, _node, inputs| {
             let mut value: T = match &base {
                 Some((pin, kind)) => {
                     let v = inputs.get(pin);
                     if v.is_null() {
-                        T::default()
+                        default_base()
                     } else {
                         unwrap(v).ok_or_else(|| NodeError::input(pin, format!("expected {}, got {}", kind.label(), v.kind().label())))?
                     }
                 }
-                None => T::default(),
+                None => default_base(),
             };
+            if let Some(f) = prepare {
+                f(&mut value, inputs, ctx)?;
+            }
             let mut json = serde_json::to_value(&value).map_err(|e| NodeError::new(format!("{key}: {e}")))?;
             let mut touched = false;
             for f in fields.iter() {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,7 +87,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 
 - [x] **M2.1 `struct_node!`** (M, #12). Existing serde structs become nodes with one line per pin;
   enum pins by serde name; a coverage test so a new core field cannot be forgotten.
-- [ ] **M2.2 Band/shank/head/outline nodes** (M, #13).
+- [x] **M2.2 Band/shank/head/outline nodes** (M, #13).
 - [ ] **M2.3 Layer nodes** (M, #14). One per `Layer` variant, the fitters, the `entry` wrapper
   (window/blend/opacity/soft/mask/remap), windows and remaps.
 - [ ] **M2.4 Assembly, generators, alphas** (M, #15). Stack and assemble; pavé/halo/channel nodes


### PR DESCRIPTION
## Summary
- `nodes/band.rs`: `design.new`, `band.size`, `band.size.fit`, `band.profile` (style applied before explicit pins, `flatten_sides`), `band.profile.library`.
- `nodes/shank.rs`: `shank`, `head` (lofted default; `Custom` refused by name), `shank.signet`, `shank.add_head`, `shank.outline`, `outline.custom`, `outline.library`.
- `StructNode` gains `prepare`, `extra` and `default_base`.
- Core: `CustomOutline::from_points` sizes `fair_r` from the plan's hull defect (the exporter's rule), so drawn plans get the lobed-plan dome suggestion on every import path.

## Verification
- `cargo test --workspace` green; graph crate 39 tests (5 new), core gains `fair_r_follows_the_hull_defect`.
- wasm check passes.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)