### PR TITLE
M2.4 Assembly, generators and alpha sources

### DIFF
--- a/crates/ringdesign-graph/src/eval.rs
+++ b/crates/ringdesign-graph/src/eval.rs
@@ -301,6 +301,10 @@ fn run_node(
         };
         let (mut items, is_list) = match raw {
             Value::List(v) => (v, true),
+            // A JSON array on a list pin is a list of JSON items.
+            Value::Json(j) if pin.access == Access::List && j.is_array() => {
+                (j.as_array().map(|a| a.iter().cloned().map(|x| Value::Json(Arc::new(x))).collect()).unwrap_or_default(), true)
+            }
             Value::Null if pin.access == Access::List => (Vec::new(), true),
             other => (vec![other], false),
         };

--- a/crates/ringdesign-graph/src/nodes/alpha.rs
+++ b/crates/ringdesign-graph/src/nodes/alpha.rs
@@ -1,0 +1,262 @@
+//! Alpha sources: what the design carries and bakes into its library.
+
+use std::sync::Arc;
+
+use ringdesign_core::alpha::{ProcRecipe, Procedural};
+use ringdesign_core::drawn::{DrawnAlpha, Stroke};
+use ringdesign_core::svg::SvgAlpha;
+use ringdesign_core::text::{TextAlpha, TextFont};
+use ringdesign_core::EmbeddedAlpha;
+
+use super::structs::enum_names;
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::{AlphaSource, Value, ValueKind};
+
+fn name_of(i: &Inputs) -> Result<String, NodeError> {
+    let name = i.text("name")?.trim().to_string();
+    if name.is_empty() {
+        return Err(NodeError::input("name", "an alpha needs a name for layers to refer to"));
+    }
+    Ok(name)
+}
+
+fn out(src: AlphaSource) -> Outputs {
+    let name = src.name().to_string();
+    Outputs::one("source", Value::AlphaSource(Arc::new(src))).with("alpha", Value::AlphaRef(name))
+}
+
+fn proc_(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let kind_name = i.text("kind")?;
+    let kind: Procedural = serde_json::from_value(serde_json::Value::String(kind_name.to_string()))
+        .map_err(|_| NodeError::input("kind", format!("{kind_name:?} is not a procedural pattern")))?;
+    let repeats = i.int("repeats")?;
+    if !(1..=64).contains(&repeats) {
+        return Err(NodeError::input("repeats", format!("{repeats} is not between 1 and 64")));
+    }
+    Ok(out(AlphaSource::Procedural(ProcRecipe {
+        name: name_of(i)?,
+        kind,
+        repeats: repeats as u32,
+        quarter_turns: (i.int("quarter_turns")?.rem_euclid(4)) as u32,
+        gamma: i.number("gamma")?.clamp(0.1, 10.0),
+        invert: i.bool("invert")?,
+    })))
+}
+
+fn text(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let font_name = i.text("font")?;
+    let font: TextFont = serde_json::from_value(serde_json::Value::String(font_name.to_string()))
+        .map_err(|_| NodeError::input("font", format!("{font_name:?} is not a bundled font")))?;
+    let t = TextAlpha { name: name_of(i)?, text: i.text("text")?.to_string(), font, tracking: i.number("tracking")? };
+    if t.is_empty() {
+        return Err(NodeError::input("text", "nothing to set"));
+    }
+    Ok(out(AlphaSource::Text(t)))
+}
+
+fn svg(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let s = SvgAlpha { name: name_of(i)?, svg: i.text("svg")?.to_string(), invert: i.bool("invert")? };
+    if s.is_empty() {
+        return Err(NodeError::input("svg", "no drawing"));
+    }
+    Ok(out(AlphaSource::Svg(s)))
+}
+
+fn drawn(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let (w, h) = (i.int("width")?, i.int("height")?);
+    if !(8..=4096).contains(&w) || !(8..=4096).contains(&h) {
+        return Err(NodeError::input("width", "a drawing is 8..4096 texels each way"));
+    }
+    let mut d = DrawnAlpha::new(name_of(i)?, w as u32, h as u32);
+    d.wrap_x = i.bool("wrap_x")?;
+    d.wrap_y = i.bool("wrap_y")?;
+    for (k, v) in i.list("strokes").into_iter().enumerate() {
+        let j = v.to_json_any().ok_or_else(|| NodeError::input("strokes", format!("item {k} is not a stroke")))?;
+        let s: Stroke = serde_json::from_value(j).map_err(|e| NodeError::input("strokes", format!("item {k}: {e}")))?;
+        d.strokes.push(s);
+    }
+    Ok(out(AlphaSource::Drawn(d)))
+}
+
+fn png(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let png = i.text("png_base64")?.trim().to_string();
+    if png.is_empty() {
+        return Err(NodeError::input("png_base64", "no image"));
+    }
+    Ok(out(AlphaSource::Embedded(EmbeddedAlpha { name: name_of(i)?, png })))
+}
+
+fn library(ctx: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let name = name_of(i)?;
+    if ctx.lib.get(&name).is_none() {
+        let mut names = ctx.lib.names();
+        names.sort();
+        let near: Vec<&String> = names.iter().filter(|n| n.to_lowercase().contains(&name.to_lowercase())).take(6).collect();
+        return Err(NodeError::input(
+            "name",
+            if near.is_empty() { format!("no alpha named {name:?}; the library has {} alphas", names.len()) } else { format!("no alpha named {name:?}; near it: {near:?}") },
+        ));
+    }
+    Ok(Outputs::one("alpha", Value::AlphaRef(name)))
+}
+
+pub fn register(reg: &mut Registry) {
+    let specs = [
+        NodeSpec::new("alpha.proc", "Procedural alpha", Category::Alpha)
+            .doc("A builtin seamless pattern with knobs that cannot break its seam: integer repeats, quarter turns, gamma.")
+            .input(PinSpec::item("name", ValueKind::Text).default("Pattern").widget(Widget::TextLine).doc("The name layers refer to."))
+            .input(PinSpec::select("kind", enum_names(Procedural::ALL)).default("Waves").doc("The pattern."))
+            .input(PinSpec::item("repeats", ValueKind::Int).default(1i64).doc("Periods per tile, 1..64."))
+            .input(PinSpec::item("quarter_turns", ValueKind::Int).default(0i64).doc("Rotation in quarter turns."))
+            .input(PinSpec::item("gamma", ValueKind::Number).default(1.0).widget(Widget::Slider { min: 0.1, max: 4.0 }).doc("Value gamma."))
+            .input(PinSpec::item("invert", ValueKind::Bool).default(false).widget(Widget::Checkbox).doc("Invert."))
+            .output(PinSpec::item("source", ValueKind::AlphaSource).doc("The source, for design.assemble."))
+            .output(PinSpec::item("alpha", ValueKind::AlphaRef).doc("Its name, for layers."))
+            .eval(proc_),
+        NodeSpec::new("alpha.text", "Text alpha", Category::Alpha)
+            .doc("An inscription set in a bundled font, rasterized on load.")
+            .input(PinSpec::item("name", ValueKind::Text).default("Inscription").widget(Widget::TextLine).doc("The name layers refer to."))
+            .input(PinSpec::item("text", ValueKind::Text).default("").widget(Widget::TextLine).doc("The words."))
+            .input(PinSpec::select("font", enum_names(TextFont::ALL)).default("Serif").doc("The face."))
+            .input(PinSpec::item("tracking", ValueKind::Number).default(0.0).widget(Widget::Slider { min: -0.2, max: 1.0 }).doc("Letter spacing, em."))
+            .output(PinSpec::item("source", ValueKind::AlphaSource).doc("The source, for design.assemble."))
+            .output(PinSpec::item("alpha", ValueKind::AlphaRef).doc("Its name, for layers."))
+            .eval(text),
+        NodeSpec::new("alpha.svg", "SVG alpha", Category::Alpha)
+            .doc("Vector art as relief: ink coverage reads as height; <text> is deliberately not rendered.")
+            .input(PinSpec::item("name", ValueKind::Text).default("Art").widget(Widget::TextLine).doc("The name layers refer to."))
+            .input(PinSpec::item("svg", ValueKind::Text).default("").widget(Widget::TextArea).doc("The SVG document."))
+            .input(PinSpec::item("invert", ValueKind::Bool).default(false).widget(Widget::Checkbox).doc("Carve instead of raise."))
+            .output(PinSpec::item("source", ValueKind::AlphaSource).doc("The source, for design.assemble."))
+            .output(PinSpec::item("alpha", ValueKind::AlphaRef).doc("Its name, for layers."))
+            .eval(svg),
+        NodeSpec::new("alpha.drawn", "Drawn alpha", Category::Alpha)
+            .doc("Brush strokes on a canvas, the band-painting format both apps share.")
+            .input(PinSpec::item("name", ValueKind::Text).default("band").widget(Widget::TextLine).doc("The name layers refer to."))
+            .input(PinSpec::item("width", ValueKind::Int).default(2048i64).doc("Canvas width, texels."))
+            .input(PinSpec::item("height", ValueKind::Int).default(320i64).doc("Canvas height, texels."))
+            .input(PinSpec::item("wrap_x", ValueKind::Bool).default(true).doc("Seam-wrap round the ring."))
+            .input(PinSpec::item("wrap_y", ValueKind::Bool).default(false).doc("Seam-wrap across the band."))
+            .input(PinSpec::list("strokes", ValueKind::Json).doc("Strokes as JSON ({points: [[x, y, pressure]…], radius, soft, erase})."))
+            .output(PinSpec::item("source", ValueKind::AlphaSource).doc("The source, for design.assemble."))
+            .output(PinSpec::item("alpha", ValueKind::AlphaRef).doc("Its name, for layers."))
+            .eval(drawn),
+        NodeSpec::new("alpha.png", "Embedded PNG alpha", Category::Alpha)
+            .doc("A height image carried in the design as base64 PNG, so the file survives moving machines.")
+            .input(PinSpec::item("name", ValueKind::Text).default("Image").widget(Widget::TextLine).doc("The name layers refer to."))
+            .input(PinSpec::item("png_base64", ValueKind::Text).default("").widget(Widget::TextArea).doc("The PNG, base64."))
+            .output(PinSpec::item("source", ValueKind::AlphaSource).doc("The source, for design.assemble."))
+            .output(PinSpec::item("alpha", ValueKind::AlphaRef).doc("Its name, for layers."))
+            .eval(png),
+        NodeSpec::new("alpha.library", "Library alpha", Category::Alpha)
+            .doc("An alpha already in the library — a builtin or one in the user's alpha folder — by name.")
+            .input(PinSpec::item("name", ValueKind::Text).default("Scales").widget(Widget::TextLine).doc("The library name."))
+            .output(PinSpec::item("alpha", ValueKind::AlphaRef).doc("The name, checked."))
+            .eval(library),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{Evaluator, Targets, evaluate_design};
+    use crate::graph::Graph;
+    use crate::registry::Registry;
+    use crate::value::Literal;
+    use ringdesign_core::AlphaLibrary;
+
+    #[test]
+    fn sources_assemble_into_the_design_and_bake_for_the_verdict() {
+        let mut g = Graph::default();
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "style", Literal::Text("Flat".into())).unwrap();
+        g.set_input(p, "width_mm", Literal::Number(7.0)).unwrap();
+        g.set_input(p, "thickness_mm", Literal::Number(2.0)).unwrap();
+        g.set_input(p, "flatten_sides", Literal::Bool(true)).unwrap();
+        let d = g.add("design.new").unwrap();
+        g.connect(p, "profile", d, "profile").unwrap();
+        let motto = g.add("alpha.text").unwrap();
+        g.set_input(motto, "name", Literal::Text("Motto".into())).unwrap();
+        g.set_input(motto, "text", Literal::Text("ever".into())).unwrap();
+        let waves = g.add("alpha.proc").unwrap();
+        g.set_input(waves, "name", Literal::Text("Ripple".into())).unwrap();
+        g.set_input(waves, "repeats", Literal::Int(3)).unwrap();
+        let tiling = g.add("layer.tiling.fit").unwrap();
+        g.connect(d, "design", tiling, "design").unwrap();
+        g.connect(motto, "alpha", tiling, "alpha").unwrap();
+        g.set_input(tiling, "square_cells", Literal::Bool(false)).unwrap();
+        let entry = g.add("entry").unwrap();
+        g.connect(tiling, "layer", entry, "layer").unwrap();
+        let stack = g.add("stack").unwrap();
+        g.connect(entry, "entry", stack, "entries").unwrap();
+        let alphas = g.add("list.merge").unwrap();
+        g.connect(motto, "source", alphas, "a").unwrap();
+        g.connect(waves, "source", alphas, "b").unwrap();
+        let asm = g.add("design.assemble").unwrap();
+        g.connect(d, "design", asm, "design").unwrap();
+        g.connect(stack, "stack", asm, "stack").unwrap();
+        g.connect(alphas, "out", asm, "alphas").unwrap();
+        g.set_input(asm, "name", Literal::Text("Posy".into())).unwrap();
+        let out = g.add(crate::eval::OUTPUT_KIND).unwrap();
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::builtin();
+        // The sink is registered by M2.5; until then a test spec stands in.
+        let mut reg2 = Registry::empty();
+        for key in reg.keys() {
+            reg2.register(reg.get(key).unwrap().clone()).unwrap();
+        }
+        reg2.register(NodeSpec::new(crate::eval::OUTPUT_KIND, "Output", Category::Sink).input(PinSpec::item(crate::eval::OUTPUT_DESIGN_PIN, ValueKind::Design))).unwrap();
+        g.connect(asm, "design", out, crate::eval::OUTPUT_DESIGN_PIN).unwrap();
+        let res = evaluate_design(&mut Evaluator::new(), &g, &reg2, &lib, 0).unwrap();
+        assert_eq!(res.design.name, "Posy");
+        assert_eq!(res.design.texts.len(), 1);
+        assert_eq!(res.design.recipes.len(), 1);
+        assert_eq!(res.design.layers.layers.len(), 1);
+        assert_eq!(res.design.layers.layers[0].name, "Tiling");
+        let tiling_alpha = match &res.design.layers.layers[0].layer {
+            ringdesign_core::Layer::Tiling(t) => t.alpha.clone(),
+            other => panic!("{other:?}"),
+        };
+        assert_eq!(tiling_alpha, "Motto");
+        assert!(res.notes.iter().any(|n| n.contains("no alpha named \"Motto\" in the library now")), "{:?}", res.notes);
+        assert_ne!(res.field.verdict, ringdesign_core::castability::Verdict::NotCastable, "{:?}", res.field.notes);
+        // The baked motto was read: the field is not flat where the text sits.
+        let mut baked = lib.clone();
+        res.design.bake_all(&mut baked);
+        assert!(baked.get("Motto").is_some() && baked.get("Ripple").is_some());
+
+        // A same-named source replaces rather than duplicates.
+        let again = g.add("design.assemble").unwrap();
+        g.connect(asm, "design", again, "design").unwrap();
+        g.connect(motto, "source", again, "alphas").unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg2, &lib, 0, Targets::AllPure);
+        let Some(Value::Design(d2)) = r.value(again, "design") else { panic!() };
+        assert_eq!(d2.texts.len(), 1);
+    }
+
+    #[test]
+    fn library_alphas_are_checked_and_bad_sources_refused() {
+        let mut g = Graph::default();
+        let ok = g.add("alpha.library").unwrap();
+        let bad = g.add("alpha.library").unwrap();
+        g.set_input(bad, "name", Literal::Text("scal".into())).unwrap();
+        let svg = g.add("alpha.svg").unwrap();
+        let drawn = g.add("alpha.drawn").unwrap();
+        g.set_input(drawn, "strokes", Literal::Json(serde_json::json!([{"points": [[0.1, 0.1, 1.0], [0.5, 0.5, 1.0]], "radius": 8.0, "soft": 0.5, "erase": false}]))).unwrap();
+        let r = Evaluator::new().evaluate(&g, &Registry::builtin(), &AlphaLibrary::builtin(), 0, Targets::AllPure);
+        assert_eq!(r.value(ok, "alpha"), Some(&Value::AlphaRef("Scales".into())));
+        assert!(r.status[&bad].errors[0].1.contains("Scales"), "near-misses are suggested: {:?}", r.status[&bad].errors);
+        assert!(r.status[&svg].errors[0].1.contains("no drawing"));
+        match r.value(drawn, "source") {
+            Some(Value::AlphaSource(a)) => match &**a {
+                AlphaSource::Drawn(d) => assert_eq!(d.strokes.len(), 1),
+                other => panic!("{other:?}"),
+            },
+            other => panic!("{other:?} {:?}", r.status[&drawn]),
+        }
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/assembly.rs
+++ b/crates/ringdesign-graph/src/nodes/assembly.rs
@@ -1,0 +1,215 @@
+//! Stacks, and the design as the thing that carries them.
+
+use std::sync::Arc;
+
+use ringdesign_core::{LayerStack, RingDesign};
+
+use crate::graph::{Node, set_pointer};
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::{AlphaSource, Value, ValueKind};
+
+fn design_of(i: &Inputs, pin: &str) -> Result<RingDesign, NodeError> {
+    match i.get(pin) {
+        Value::Design(d) => Ok((**d).clone()),
+        other => Err(NodeError::input(pin, format!("expected a design, got {}", other.summary()))),
+    }
+}
+
+fn stack(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut s = match i.get("stack") {
+        Value::Stack(s) => (**s).clone(),
+        Value::Null => LayerStack::default(),
+        other => return Err(NodeError::input("stack", format!("expected a stack, got {}", other.summary()))),
+    };
+    for (k, v) in i.list("entries").into_iter().enumerate() {
+        match v {
+            Value::Entry(e) => s.layers.push((*e).clone()),
+            Value::Stack(inner) => s.layers.extend(inner.layers.iter().cloned()),
+            Value::Null => return Err(NodeError::input("entries", format!("item {k} failed upstream"))),
+            other => return Err(NodeError::input("entries", format!("item {k} is {}, not an entry", other.summary()))),
+        }
+    }
+    Ok(Outputs::one("stack", Value::Stack(Arc::new(s))))
+}
+
+/// Put a source into the design, replacing a same-named one.
+fn adopt_source(d: &mut RingDesign, src: &AlphaSource) {
+    match src {
+        AlphaSource::Procedural(p) => {
+            d.recipes.retain(|r| r.name != p.name);
+            d.recipes.push(p.clone());
+        }
+        AlphaSource::Text(t) => {
+            d.texts.retain(|x| x.name != t.name);
+            d.texts.push(t.clone());
+        }
+        AlphaSource::Svg(s) => {
+            d.svgs.retain(|x| x.name != s.name);
+            d.svgs.push(s.clone());
+        }
+        AlphaSource::Drawn(a) => {
+            d.drawn.retain(|x| x.name != a.name);
+            d.drawn.push(a.clone());
+        }
+        AlphaSource::Embedded(e) => {
+            d.embedded.retain(|x| x.name != e.name);
+            d.embedded.push(e.clone());
+        }
+    }
+}
+
+fn assemble(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut d = design_of(i, "design")?;
+    match i.get("stack") {
+        Value::Stack(s) => d.layers = (**s).clone(),
+        Value::Null => {}
+        other => return Err(NodeError::input("stack", format!("expected a stack, got {}", other.summary()))),
+    }
+    for (k, v) in i.list("alphas").into_iter().enumerate() {
+        match v {
+            Value::AlphaSource(a) => adopt_source(&mut d, &a),
+            Value::Null => return Err(NodeError::input("alphas", format!("item {k} failed upstream"))),
+            other => return Err(NodeError::input("alphas", format!("item {k} is {}, not an alpha source", other.summary()))),
+        }
+    }
+    if let Some(name) = i.get("name").as_text() {
+        if !name.trim().is_empty() {
+            d.name = name.to_string();
+        }
+    }
+    Ok(Outputs::one("design", d))
+}
+
+fn design_get(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let d = design_of(i, "design")?;
+    let pointer = i.text("pointer")?;
+    let json = serde_json::to_value(&d).map_err(|e| NodeError::new(e.to_string()))?;
+    let v = if pointer.is_empty() { Some(&json) } else { json.pointer(pointer) };
+    let v = v.ok_or_else(|| NodeError::input("pointer", format!("nothing at {pointer:?}")))?.clone();
+    Ok(Outputs::one("value", v))
+}
+
+fn design_set(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let d = design_of(i, "design")?;
+    let pointer = i.text("pointer")?;
+    if pointer.is_empty() {
+        return Err(NodeError::input("pointer", "set needs a field pointer such as /profile/width_mm"));
+    }
+    let value = i.get("value").to_json_any().ok_or_else(|| NodeError::input("value", format!("{} has no JSON form", i.get("value").summary())))?;
+    let mut json = serde_json::to_value(&d).map_err(|e| NodeError::new(e.to_string()))?;
+    if json.pointer(pointer).is_none() {
+        return Err(NodeError::input("pointer", format!("a design has nothing at {pointer:?}")));
+    }
+    set_pointer(&mut json, pointer, value).map_err(|m| NodeError::input("pointer", m))?;
+    let d: RingDesign = serde_json::from_value(json).map_err(|e| NodeError::input("value", format!("the design would not read back: {e}")))?;
+    Ok(Outputs::one("design", d))
+}
+
+fn design_info(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let d = design_of(i, "design")?;
+    let ctx = d.field_context();
+    Ok(Outputs::one("name", d.name.clone())
+        .with("size", d.size.0)
+        .with("inner_diameter_mm", d.size.inner_diameter_mm())
+        .with("width_mm", d.profile.width_mm)
+        .with("thickness_mm", d.profile.thickness_mm)
+        .with("circumference_mm", ctx.circumference_mm)
+        .with("band_v_len_mm", ctx.band_v_len_mm)
+        .with("layers", d.layers.layers.len() as i64)
+        .with("stack", Value::Stack(Arc::new(d.layers.clone()))))
+}
+
+pub fn register(reg: &mut Registry) {
+    let specs = [
+        NodeSpec::new("stack", "Stack", Category::Assembly)
+            .doc("Entries in order, bottom first. A bare layer becomes an entry named after its kind; a stack splices in.")
+            .input(PinSpec::item("stack", ValueKind::Stack).optional().doc("Append to this stack."))
+            .input(PinSpec::list("entries", ValueKind::Entry).doc("The entries (or layers) to add."))
+            .output(PinSpec::item("stack", ValueKind::Stack).doc("The stack."))
+            .eval(stack),
+        NodeSpec::new("design.assemble", "Assemble", Category::Assembly)
+            .doc("The design with its layer stack and the alpha sources its layers name; sources bake into the library when the design loads.")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design to fill."))
+            .input(PinSpec::item("stack", ValueKind::Stack).optional().doc("The layer stack; the design's own if unset."))
+            .input(PinSpec::list("alphas", ValueKind::AlphaSource).doc("Alpha sources the layers refer to by name."))
+            .input(PinSpec::item("name", ValueKind::Text).optional().widget(Widget::TextLine).doc("Rename the design."))
+            .output(PinSpec::item("design", ValueKind::Design).doc("The assembled design."))
+            .eval(assemble),
+        NodeSpec::new("design.get", "Design field", Category::Assembly)
+            .doc("Read any field of the design by JSON pointer (/profile/width_mm, /shank/head/outline).")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design."))
+            .input(PinSpec::item("pointer", ValueKind::Text).default("/profile/width_mm").widget(Widget::TextLine).doc("An RFC 6901 pointer."))
+            .output(PinSpec::item("value", ValueKind::Json).doc("The field, as JSON."))
+            .eval(design_get),
+        NodeSpec::new("design.set", "Set design field", Category::Assembly)
+            .doc("Write any existing field of the design by JSON pointer — the escape hatch for what has no node yet.")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design."))
+            .input(PinSpec::item("pointer", ValueKind::Text).default("").widget(Widget::TextLine).doc("An RFC 6901 pointer to an existing field."))
+            .input(PinSpec::item("value", ValueKind::Any).doc("The new value."))
+            .output(PinSpec::item("design", ValueKind::Design).doc("The changed design."))
+            .eval(design_set),
+        NodeSpec::new("design.info", "Design info", Category::Assembly)
+            .doc("What a design is: name, size, band dimensions, chart lengths, and its stack.")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design."))
+            .output(PinSpec::item("name", ValueKind::Text).doc("Its name."))
+            .output(PinSpec::item("size", ValueKind::Number).doc("US ring size."))
+            .output(PinSpec::item("inner_diameter_mm", ValueKind::Number).doc("Bore diameter, mm."))
+            .output(PinSpec::item("width_mm", ValueKind::Number).doc("Band width, mm."))
+            .output(PinSpec::item("thickness_mm", ValueKind::Number).doc("Band thickness, mm."))
+            .output(PinSpec::item("circumference_mm", ValueKind::Number).doc("The chart's u length: circumference at the crest, mm."))
+            .output(PinSpec::item("band_v_len_mm", ValueKind::Number).doc("The chart's v length: section arc edge to edge, mm."))
+            .output(PinSpec::item("layers", ValueKind::Int).doc("How many entries the stack holds."))
+            .output(PinSpec::item("stack", ValueKind::Stack).doc("The stack."))
+            .eval(design_info),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{Evaluator, Targets};
+    use crate::graph::Graph;
+    use crate::value::Literal;
+    use ringdesign_core::AlphaLibrary;
+
+    #[test]
+    fn stacks_assemble_and_pointers_read_and_write_the_design() {
+        let mut g = Graph::default();
+        let d = g.add("design.new").unwrap();
+        let m = g.add("layer.milgrain").unwrap();
+        let b = g.add("layer.border").unwrap();
+        let st = g.add("stack").unwrap();
+        let entries = g.add("list.merge").unwrap();
+        g.connect(m, "layer", entries, "a").unwrap();
+        g.connect(b, "layer", entries, "b").unwrap();
+        g.connect(entries, "out", st, "entries").unwrap();
+        let asm = g.add("design.assemble").unwrap();
+        g.connect(d, "design", asm, "design").unwrap();
+        g.connect(st, "stack", asm, "stack").unwrap();
+        let get = g.add("design.get").unwrap();
+        g.connect(asm, "design", get, "design").unwrap();
+        g.set_input(get, "pointer", Literal::Text("/layers/layers/1/name".into())).unwrap();
+        let set = g.add("design.set").unwrap();
+        g.connect(asm, "design", set, "design").unwrap();
+        g.set_input(set, "pointer", Literal::Text("/profile/width_mm".into())).unwrap();
+        g.set_input(set, "value", Literal::Number(9.5)).unwrap();
+        let info = g.add("design.info").unwrap();
+        g.connect(set, "design", info, "design").unwrap();
+        let bad = g.add("design.set").unwrap();
+        g.connect(asm, "design", bad, "design").unwrap();
+        g.set_input(bad, "pointer", Literal::Text("/profile/nope".into())).unwrap();
+        g.set_input(bad, "value", Literal::Number(1.0)).unwrap();
+        let r = Evaluator::new().evaluate(&g, &Registry::builtin(), &AlphaLibrary::default(), 0, Targets::AllPure);
+        let Some(Value::Stack(s)) = r.value(st, "stack") else { panic!("{:?}", r.status[&st]) };
+        assert_eq!(s.layers.len(), 2, "bare layers coerce into entries");
+        assert_eq!((s.layers[0].name.as_str(), s.layers[1].name.as_str()), ("Milgrain", "Border"));
+        assert_eq!(r.value(get, "value"), Some(&Value::Json(Arc::new(serde_json::json!("Border")))));
+        assert_eq!(r.value(info, "width_mm"), Some(&Value::Number(9.5)));
+        assert_eq!(r.value(info, "layers"), Some(&Value::Int(2)));
+        assert!(r.value(info, "circumference_mm").unwrap().as_number().unwrap() > 50.0);
+        assert!(r.status[&bad].errors[0].1.contains("nothing at"), "{:?}", r.status[&bad].errors);
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/generator.rs
+++ b/crates/ringdesign-graph/src/nodes/generator.rs
@@ -1,0 +1,207 @@
+//! Generators: pavé, halo and channel, emitting live groups. The recipe
+//! rides in the group, so the app re-solves the layout when the band
+//! moves; the evaluator itself never regenerates.
+
+use std::sync::Arc;
+
+use ringdesign_core::field::{SeatStyle, SideFacePick};
+use ringdesign_core::gem::Gem;
+use ringdesign_core::pave::{self, HaloSpec, PaveRegion, PaveSpec};
+use ringdesign_core::RingDesign;
+
+use super::structs::enum_names;
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::{Value, ValueKind};
+
+fn design_of(i: &Inputs) -> Result<Arc<RingDesign>, NodeError> {
+    match i.get("design") {
+        Value::Design(d) => Ok(d.clone()),
+        other => Err(NodeError::input("design", format!("expected a design, got {}", other.summary()))),
+    }
+}
+
+fn gem_of(i: &Inputs, pin: &str) -> Result<Gem, NodeError> {
+    match i.get(pin) {
+        Value::Gem(g) => Ok(*g),
+        Value::Null => Ok(Gem::default()),
+        other => Err(NodeError::input(pin, format!("expected a gem, got {}", other.summary()))),
+    }
+}
+
+fn enum_of<E: serde::de::DeserializeOwned>(i: &Inputs, pin: &str, what: &str) -> Result<E, NodeError> {
+    let name = i.text(pin)?;
+    serde_json::from_value(serde_json::Value::String(name.to_string())).map_err(|_| NodeError::input(pin, format!("{name:?} is not a {what}")))
+}
+
+fn pave(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let design = design_of(i)?;
+    let region = match i.text("region")? {
+        "side_face" => PaveRegion::SideFace(enum_of::<SideFacePick>(i, "side_pick", "side face pick")?),
+        "band" => PaveRegion::VBand { center_mm: i.number("band_center_mm")?, width_mm: i.number("band_width_mm")? },
+        other => return Err(NodeError::input("region", format!("{other:?} is not side_face or band"))),
+    };
+    let spec = PaveSpec {
+        gem: gem_of(i, "gem")?,
+        bridge_mm: i.number("bridge_mm")?,
+        theta_deg: i.number("theta_deg")?,
+        span_deg: i.number("span_deg")?,
+        region,
+        stagger: i.bool("stagger")?,
+        style: enum_of::<SeatStyle>(i, "style", "seat style")?,
+        rot_deg: i.number("rot_deg")?,
+        blend_mm: i.number("blend_mm")?,
+        recess_mm: i.number("recess_mm")?,
+        pinned: Vec::new(),
+    };
+    let (entry, outcome) = pave::fill(&design, &spec)
+        .ok_or_else(|| NodeError::new("the pavé does not fit: no region of that band takes a row of these stones at this bridge"))?;
+    Ok(Outputs::one("entry", entry)
+        .with("seats", outcome.seats as i64)
+        .with("rows", outcome.rows as i64)
+        .with("note", outcome.note.unwrap_or_default()))
+}
+
+fn halo(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let design = design_of(i)?;
+    let spec = HaloSpec {
+        center: gem_of(i, "center")?,
+        accent: gem_of(i, "accent")?,
+        theta_deg: i.number("theta_deg")?,
+        v_mm: i.get("v_mm").as_number(),
+        gap_mm: i.number("gap_mm")?,
+        bridge_mm: i.number("bridge_mm")?,
+        count: i.int("count")?.max(0) as u32,
+        rot_deg: i.number("rot_deg")?,
+    };
+    let (entry, accents) = pave::halo(&design, &spec).ok_or_else(|| NodeError::new("the halo does not fit this band: the plate would overrun the band's width"))?;
+    Ok(Outputs::one("entry", entry).with("accents", i64::from(accents)))
+}
+
+fn channel(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let design = design_of(i)?;
+    let gem = gem_of(i, "gem")?;
+    let entry = pave::channel_set(&design, gem, i.number("recess_mm")?).ok_or_else(|| {
+        NodeError::new(format!(
+            "a channel for a {:.1} mm stone needs a thick, squared band: stone plus two rails want about {:.1} mm of side face, and this band's face is not that deep",
+            gem.w_mm,
+            gem.w_mm + 1.4
+        ))
+    })?;
+    Ok(Outputs::one("entry", entry))
+}
+
+pub fn register(reg: &mut Registry) {
+    let side_picks: Vec<String> = enum_names(&[SideFacePick::Low, SideFacePick::High, SideFacePick::Wider, SideFacePick::Both]);
+    let specs = [
+        NodeSpec::new("gen.pave", "Pavé", Category::Generator)
+            .doc("Gypsy seats packed over an arc of a side face or a v-band, hex-staggered, wrap-exact on a full ring. A live group: the app re-packs it when the band moves.")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design the pavé sits on."))
+            .input(PinSpec::item("gem", ValueKind::Gem).optional().doc("The melee; the default 3 mm round if unset."))
+            .input(PinSpec::item("bridge_mm", ValueKind::Number).default(0.4).widget(Widget::Mm { min: 0.2, max: 2.0 }).doc("Metal between stones, mm."))
+            .input(PinSpec::item("theta_deg", ValueKind::Number).default(90.0).widget(Widget::Angle).doc("Arc centre."))
+            .input(PinSpec::item("span_deg", ValueKind::Number).default(360.0).widget(Widget::Slider { min: 10.0, max: 360.0 }).doc("Arc width; 360 is the whole ring."))
+            .input(PinSpec::select("region", vec!["side_face".into(), "band".into()]).default("side_face").doc("Where across the band."))
+            .input(PinSpec::select("side_pick", side_picks.clone()).default("Wider").doc("Which side face."))
+            .input(PinSpec::item("band_center_mm", ValueKind::Number).default(0.0).doc("Band region centre, mm of section arc."))
+            .input(PinSpec::item("band_width_mm", ValueKind::Number).default(3.0).doc("Band region width, mm."))
+            .input(PinSpec::item("stagger", ValueKind::Bool).default(true).widget(Widget::Checkbox).doc("Hex-stagger the rows."))
+            .input(PinSpec::select("style", enum_names(SeatStyle::ALL)).default("GypsyMound").doc("The seat style."))
+            .input(PinSpec::item("rot_deg", ValueKind::Number).default(0.0).doc("Stone bearing, degrees."))
+            .input(PinSpec::item("blend_mm", ValueKind::Number).default(0.5).doc("Seat skirt, mm."))
+            .input(PinSpec::item("recess_mm", ValueKind::Number).default(0.5).doc("Bezel recess, mm."))
+            .output(PinSpec::item("entry", ValueKind::Entry).doc("The live group."))
+            .output(PinSpec::item("seats", ValueKind::Int).doc("Seats placed."))
+            .output(PinSpec::item("rows", ValueKind::Int).doc("Rows packed."))
+            .output(PinSpec::item("note", ValueKind::Text).doc("What the packer had to say, if anything."))
+            .eval(pave),
+        NodeSpec::new("gen.halo", "Halo", Category::Generator)
+            .doc("A centre stone on a gypsy plate ringed by melee markers, cast as one clean dome. A live group.")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design."))
+            .input(PinSpec::item("center", ValueKind::Gem).optional().doc("The centre stone."))
+            .input(PinSpec::item("accent", ValueKind::Gem).optional().doc("The melee."))
+            .input(PinSpec::item("theta_deg", ValueKind::Number).default(90.0).widget(Widget::Angle).doc("Where round the ring."))
+            .input(PinSpec::item("v_mm", ValueKind::Number).optional().doc("Where across the band; the crest if unset."))
+            .input(PinSpec::item("gap_mm", ValueKind::Number).default(0.5).doc("Centre to melee gap, mm."))
+            .input(PinSpec::item("bridge_mm", ValueKind::Number).default(0.4).doc("Melee bridge, mm."))
+            .input(PinSpec::item("count", ValueKind::Int).default(0i64).doc("Melee count; 0 lets the ring decide."))
+            .input(PinSpec::item("rot_deg", ValueKind::Number).default(0.0).doc("Centre stone bearing, degrees."))
+            .output(PinSpec::item("entry", ValueKind::Entry).doc("The live group."))
+            .output(PinSpec::item("accents", ValueKind::Int).doc("Melee placed."))
+            .eval(halo),
+        NodeSpec::new("gen.channel", "Channel set", Category::Generator)
+            .doc("Two rails flanking a recessed channel on the wider side face — a thick-band feature. A live group.")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design."))
+            .input(PinSpec::item("gem", ValueKind::Gem).optional().doc("The stone the channel is cut for."))
+            .input(PinSpec::item("recess_mm", ValueKind::Number).default(0.5).doc("Channel depth, mm."))
+            .output(PinSpec::item("entry", ValueKind::Entry).doc("The live group."))
+            .eval(channel),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{Evaluator, Targets};
+    use crate::graph::Graph;
+    use crate::registry::Registry;
+    use crate::value::Literal;
+    use ringdesign_core::pave::GenRecipe;
+    use ringdesign_core::{AlphaLibrary, Layer};
+
+    fn squared_design(g: &mut Graph, width: f64, thickness: f64) -> crate::graph::NodeId {
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "style", Literal::Text("Flat".into())).unwrap();
+        g.set_input(p, "width_mm", Literal::Number(width)).unwrap();
+        g.set_input(p, "thickness_mm", Literal::Number(thickness)).unwrap();
+        g.set_input(p, "flatten_sides", Literal::Bool(true)).unwrap();
+        let d = g.add("design.new").unwrap();
+        g.connect(p, "profile", d, "profile").unwrap();
+        d
+    }
+
+    #[test]
+    fn generators_emit_live_groups_and_say_when_they_do_not_fit() {
+        let mut g = Graph::default();
+        let d = squared_design(&mut g, 7.0, 4.0);
+        let gem = g.add("gem.calibrated").unwrap();
+        g.set_input(gem, "w_mm", Literal::Number(1.5)).unwrap();
+        let pave_ = g.add("gen.pave").unwrap();
+        g.connect(d, "design", pave_, "design").unwrap();
+        g.connect(gem, "gem", pave_, "gem").unwrap();
+        g.set_input(pave_, "span_deg", Literal::Number(90.0)).unwrap();
+        let centre = g.add("gem.calibrated").unwrap();
+        g.set_input(centre, "w_mm", Literal::Number(2.5)).unwrap();
+        let melee = g.add("gem.calibrated").unwrap();
+        g.set_input(melee, "w_mm", Literal::Number(1.0)).unwrap();
+        let halo_ = g.add("gen.halo").unwrap();
+        g.connect(d, "design", halo_, "design").unwrap();
+        g.connect(centre, "gem", halo_, "center").unwrap();
+        g.connect(melee, "gem", halo_, "accent").unwrap();
+        let channel_ = g.add("gen.channel").unwrap();
+        g.connect(d, "design", channel_, "design").unwrap();
+        g.connect(gem, "gem", channel_, "gem").unwrap();
+        let thin = squared_design(&mut g, 3.0, 1.2);
+        let no_channel = g.add("gen.channel").unwrap();
+        g.connect(thin, "design", no_channel, "design").unwrap();
+        let r = Evaluator::new().evaluate(&g, &Registry::builtin(), &AlphaLibrary::builtin(), 0, Targets::AllPure);
+        let Some(Value::Entry(pe)) = r.value(pave_, "entry") else { panic!("{:?}", r.status[&pave_]) };
+        match &pe.layer {
+            Layer::Group(grp) => {
+                assert!(matches!(grp.recipe, Some(GenRecipe::Pave(_))), "the group carries its recipe");
+                assert!(!grp.stack.layers.is_empty());
+            }
+            other => panic!("{other:?}"),
+        }
+        assert!(r.value(pave_, "seats").unwrap().as_int().unwrap() > 0);
+        let Some(Value::Entry(he)) = r.value(halo_, "entry") else { panic!("{:?}", r.status[&halo_]) };
+        assert!(matches!(&he.layer, Layer::Group(grp) if matches!(grp.recipe, Some(GenRecipe::Halo(_)))));
+        assert!(r.value(halo_, "accents").unwrap().as_int().unwrap() > 0);
+        let Some(Value::Entry(ce)) = r.value(channel_, "entry") else { panic!("{:?}", r.status[&channel_]) };
+        assert!(matches!(&ce.layer, Layer::Group(grp) if matches!(grp.recipe, Some(GenRecipe::Channel(_)))));
+        assert!(r.status[&no_channel].errors[0].1.contains("squared band"), "{:?}", r.status[&no_channel].errors);
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/layer.rs
+++ b/crates/ringdesign-graph/src/nodes/layer.rs
@@ -104,7 +104,7 @@ fn tiling_fit(ctx: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, No
     let fc = ctx_of(i, "design")?;
     let alpha = i.text("alpha")?.to_string();
     if ctx.lib.get(&alpha).is_none() {
-        return Err(NodeError::input("alpha", format!("no alpha named {alpha:?} in the library")));
+        ctx.warn(format!("no alpha named {alpha:?} in the library now; a source assembled into the design bakes one on load"));
     }
     let mut t = TilingLayer::default_for(alpha, &fc);
     if i.bool("side_faces")? {
@@ -639,7 +639,7 @@ mod tests {
         assert!(r.status[&t2].warnings.iter().any(|w| w.contains("no side face")), "{:?}", r.status[&t2]);
         g.set_input(t2, "alpha", Literal::Text("NoSuchAlpha".into())).unwrap();
         let r = run(&g);
-        assert!(r.status[&t2].errors[0].1.contains("no alpha named"));
+        assert!(r.status[&t2].warnings.iter().any(|w| w.contains("no alpha named")), "{:?}", r.status[&t2]);
     }
 
     #[test]

--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -7,8 +7,11 @@
 
 use crate::registry::Registry;
 
+pub mod alpha;
+pub mod assembly;
 pub mod band;
 pub mod gem;
+pub mod generator;
 pub mod layer;
 pub mod list;
 pub mod math;
@@ -27,6 +30,9 @@ pub fn register_all(reg: &mut Registry) {
     shank::register(reg);
     gem::register(reg);
     layer::register(reg);
+    assembly::register(reg);
+    generator::register(reg);
+    alpha::register(reg);
 }
 
 #[cfg(test)]
@@ -46,7 +52,7 @@ mod tests {
             let spec = reg.get(key).unwrap();
             assert!(!spec.doc.is_empty(), "{key} has no doc");
             assert!(!spec.label.is_empty(), "{key} has no label");
-            assert!(key.contains('.') || matches!(key, "number" | "int" | "bool" | "text" | "series" | "range" | "shank" | "head" | "gem" | "entry" | "window"), "{key} is not family.name");
+            assert!(key.contains('.') || matches!(key, "number" | "int" | "bool" | "text" | "series" | "range" | "shank" | "head" | "gem" | "entry" | "window" | "stack"), "{key} is not family.name");
             // Inputs and outputs are separate namespaces: a wire names one of each.
             for pins in [&spec.inputs, &spec.outputs] {
                 let mut seen = BTreeSet::new();

--- a/crates/ringdesign-graph/src/value.rs
+++ b/crates/ringdesign-graph/src/value.rs
@@ -197,10 +197,12 @@ impl ValueKind {
 
     /// Whether a value of kind `from` may be wired into a pin of this kind,
     /// directly or through [`ValueKind::coerce`]. `Null` is accepted
-    /// everywhere: it is the per-item failure marker and must flow.
+    /// everywhere: it is the per-item failure marker and must flow. An
+    /// `Any` output (a list utility's) is wirable anywhere; each item is
+    /// checked when it arrives.
     pub fn accepts(self, from: ValueKind) -> bool {
         use ValueKind::*;
-        if self == Any || from == Null || self == from {
+        if self == Any || from == Null || from == Any || self == from {
             return true;
         }
         matches!(

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,7 +90,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - [x] **M2.2 Band/shank/head/outline nodes** (M, #13).
 - [x] **M2.3 Layer nodes** (M, #14). One per `Layer` variant, the fitters, the `entry` wrapper
   (window/blend/opacity/soft/mask/remap), windows and remaps.
-- [ ] **M2.4 Assembly, generators, alphas** (M, #15). Stack and assemble; pavé/halo/channel nodes
+- [x] **M2.4 Assembly, generators, alphas** (M, #15). Stack and assemble; pavé/halo/channel nodes
   emitting live groups (the evaluator never regenerates); procedural/text/SVG/drawn alphas.
 - [ ] **M2.5 Sinks, verdict gate, modes** (M, #16). Output, verdict, gate, build, refine, stones, DFM,
   sheet, exports, render, save; SandRing refuses `NotCastable` on file-writing sinks; Free adds


### PR DESCRIPTION
## Summary
- `nodes/assembly.rs`: `stack`, `design.assemble`, `design.get`, `design.set`, `design.info`.
- `nodes/generator.rs`: `gen.pave`, `gen.halo`, `gen.channel` — live groups with their recipe, clear refusals.
- `nodes/alpha.rs`: `alpha.proc/text/svg/drawn/png` sources + `alpha.library`.
- Evaluator: `Any` outputs wirable anywhere (checked per item); JSON arrays expand on list pins.

## Verification
- `cargo test --workspace` green; graph crate 46 tests (4 new).
- wasm check passes.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)