### PR TITLE
M2.6 Graph files, the ladder, clusters and presets

### DIFF
--- a/crates/ringdesign-graph/src/eval.rs
+++ b/crates/ringdesign-graph/src/eval.rs
@@ -46,6 +46,8 @@ pub enum Targets {
     Design,
     /// One node and everything above it.
     Node(NodeId),
+    /// These nodes and everything above them.
+    Nodes(Vec<NodeId>),
     /// Every node without side effects.
     AllPure,
     /// Every node, side effects included.
@@ -156,6 +158,21 @@ impl Evaluator {
     /// Evaluate `targets` of `g`. `lib_epoch` changes whenever the alpha
     /// library's contents do, so nodes that read it re-run.
     pub fn evaluate(&mut self, g: &Graph, reg: &Registry, lib: &AlphaLibrary, lib_epoch: u64, targets: Targets) -> EvalReport {
+        self.evaluate_injected(g, reg, lib, lib_epoch, targets, &BTreeMap::new())
+    }
+
+    /// [`Evaluator::evaluate`] with values pushed straight onto inputs —
+    /// how a cluster's pins reach the nodes inside it, handles included.
+    /// An injected input overrides its wire and its literal.
+    pub fn evaluate_injected(
+        &mut self,
+        g: &Graph,
+        reg: &Registry,
+        lib: &AlphaLibrary,
+        lib_epoch: u64,
+        targets: Targets,
+        injected: &BTreeMap<(NodeId, String), Value>,
+    ) -> EvalReport {
         let mut report = EvalReport::default();
         report.errors = g.validate(Some(reg));
         if !report.errors.is_empty() {
@@ -191,6 +208,14 @@ impl Evaluator {
                 w.out.hash(&mut h);
                 sigs.get(&w.from).copied().unwrap_or(0).hash(&mut h);
             }
+            for ((nid, pin), v) in injected {
+                if *nid == id {
+                    pin.hash(&mut h);
+                    v.summary().hash(&mut h);
+                    // A handle's identity, not its summary, is what moves.
+                    (v as *const Value as usize).hash(&mut h);
+                }
+            }
             sigs.insert(id, h.finish());
         }
 
@@ -204,7 +229,7 @@ impl Evaluator {
             let spec = reg.get(&node.kind).expect("validated");
             let sig = sigs[&id];
             if spec.side_effect && !run_side_effects {
-                let outputs: BTreeMap<String, Value> = spec.pins_for(node).1.into_iter().map(|p| (p.name, Value::Null)).collect();
+                let outputs: BTreeMap<String, Value> = spec.pins_for(node, reg).1.into_iter().map(|p| (p.name, Value::Null)).collect();
                 report.values.insert(id, outputs);
                 report.status.insert(id, NodeStatus { skipped: true, ..Default::default() });
                 continue;
@@ -218,7 +243,7 @@ impl Evaluator {
                     }
                 }
             }
-            let (outputs, status) = run_node(g, spec, node, &report.values, lib, lib_epoch, run_side_effects);
+            let (outputs, status) = run_node(g, reg, spec, node, &report.values, lib, lib_epoch, run_side_effects, self.depth, injected);
             report.values.insert(id, outputs.clone());
             report.status.insert(id, status.clone());
             if !spec.side_effect {
@@ -241,6 +266,7 @@ impl Evaluator {
             Targets::Everything => order.iter().copied().collect(),
             Targets::AllPure => order.iter().copied().filter(pure).collect(),
             Targets::Node(id) => closure(vec![*id]),
+            Targets::Nodes(ids) => closure(ids.clone()),
             Targets::Design => {
                 let sinks: Vec<NodeId> = g.nodes.iter().filter(|n| n.kind == OUTPUT_KIND).map(|n| n.id).collect();
                 if sinks.is_empty() { order.iter().copied().filter(pure).collect() } else { closure(sinks) }
@@ -271,18 +297,22 @@ struct Resolved {
     failed: Vec<bool>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_node(
     g: &Graph,
+    reg: &Registry,
     spec: &NodeSpec,
     node: &crate::graph::Node,
     values: &BTreeMap<NodeId, BTreeMap<String, Value>>,
     lib: &AlphaLibrary,
-    _lib_epoch: u64,
+    lib_epoch: u64,
     run_side_effects: bool,
+    depth: usize,
+    injected: &BTreeMap<(NodeId, String), Value>,
 ) -> (BTreeMap<String, Value>, NodeStatus) {
     let start = tick();
     let mut status = NodeStatus::default();
-    let (in_pins, out_pins) = spec.pins_for(node);
+    let (in_pins, out_pins) = spec.pins_for(node, reg);
     let record = |status: &mut NodeStatus, item: usize, msg: String| {
         status.error_count += 1;
         if status.errors.len() < MAX_RECORDED_ERRORS {
@@ -292,11 +322,14 @@ fn run_node(
 
     let mut resolved: BTreeMap<String, Resolved> = BTreeMap::new();
     for pin in &in_pins {
-        let raw: Value = match g.wire_into(node.id, &pin.name) {
-            Some(w) => values.get(&w.from).and_then(|o| o.get(&w.out)).cloned().unwrap_or(Value::Null),
-            None => match node.inputs.get(&pin.name) {
-                Some(lit) => Value::from(lit.clone()),
-                None => pin.default.clone().map(Value::from).unwrap_or(Value::Null),
+        let raw: Value = match injected.get(&(node.id, pin.name.clone())) {
+            Some(v) => v.clone(),
+            None => match g.wire_into(node.id, &pin.name) {
+                Some(w) => values.get(&w.from).and_then(|o| o.get(&w.out)).cloned().unwrap_or(Value::Null),
+                None => match node.inputs.get(&pin.name) {
+                    Some(lit) => Value::from(lit.clone()),
+                    None => pin.default.clone().map(Value::from).unwrap_or(Value::Null),
+                },
             },
         };
         let (mut items, is_list) = match raw {
@@ -341,8 +374,10 @@ fn run_node(
     status.items = n;
 
     let mut columns: BTreeMap<String, Vec<Value>> = out_pins.iter().map(|p| (p.name.clone(), Vec::with_capacity(n))).collect();
-    let mut ctx = EvalCtx::new(lib, g.mode);
+    let mut ctx = EvalCtx::new(lib, reg, g.mode);
     ctx.run_side_effects = run_side_effects;
+    ctx.depth = depth;
+    ctx.lib_epoch = lib_epoch;
     ctx.items = n;
     for t in 0..n {
         ctx.item = t;

--- a/crates/ringdesign-graph/src/file.rs
+++ b/crates/ringdesign-graph/src/file.rs
@@ -1,0 +1,296 @@
+//! Graph, cluster and preset files, with their own version ladder.
+//!
+//! The same shape as the design file's: a `format_version` beside the
+//! document, one migration step per version so a step can never be
+//! skipped, and a newer file refused with a clear line. Clusters are graphs
+//! with exposed inputs and outputs; presets are named values for a
+//! cluster's exposed inputs. Bundled graphs live in the repository; the
+//! user's live under the data root beside designs, profiles and outlines.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use ringdesign_core::library;
+use serde::{Deserialize, Serialize};
+
+use crate::graph::{Graph, Node};
+use crate::registry::Registry;
+use crate::value::Literal;
+
+pub const GRAPH_EXT: &str = "graph.json";
+pub const CLUSTER_EXT: &str = "cluster.json";
+pub const PRESET_EXT: &str = "preset.json";
+pub const GRAPH_FORMAT_VERSION: u32 = 1;
+const VERSION_KEY: &str = "format_version";
+
+/// One step per version, index `v` taking a version-`v` document to `v + 1`.
+static MIGRATIONS: &[fn(&mut serde_json::Value)] = &[migrate_v0_to_v1];
+
+/// Version 0 is a bare `Graph` with no version key at all.
+fn migrate_v0_to_v1(_doc: &mut serde_json::Value) {}
+
+#[derive(Serialize)]
+struct Versioned<'a, T: Serialize> {
+    format_version: u32,
+    #[serde(flatten)]
+    doc: &'a T,
+}
+
+pub fn graph_dir() -> PathBuf {
+    library::data_root().join("graphs")
+}
+
+pub fn cluster_dir() -> PathBuf {
+    library::data_root().join("clusters")
+}
+
+pub fn preset_dir() -> PathBuf {
+    library::data_root().join("presets")
+}
+
+pub fn graph_to_string(g: &Graph) -> anyhow::Result<String> {
+    Ok(serde_json::to_string_pretty(&Versioned { format_version: GRAPH_FORMAT_VERSION, doc: g })?)
+}
+
+pub fn save_graph(path: impl AsRef<Path>, g: &Graph) -> anyhow::Result<()> {
+    if let Some(parent) = path.as_ref().parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, graph_to_string(g)?)?;
+    Ok(())
+}
+
+/// Read a graph file, walking it up the ladder, then giving every node
+/// its kind's own migration when a registry is at hand.
+pub fn load_graph_str(text: &str, reg: Option<&Registry>) -> anyhow::Result<Graph> {
+    let mut doc: serde_json::Value = serde_json::from_str(text)?;
+    let version = doc.get(VERSION_KEY).and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    if version > GRAPH_FORMAT_VERSION {
+        anyhow::bail!(
+            "graph file is format version {version}, but this build reads up to {GRAPH_FORMAT_VERSION} — it was saved by a newer RingDesigner"
+        );
+    }
+    for step in &MIGRATIONS[version as usize..] {
+        step(&mut doc);
+    }
+    if let Some(obj) = doc.as_object_mut() {
+        obj.remove(VERSION_KEY);
+    }
+    let mut g: Graph = serde_json::from_value(doc)?;
+    if version < GRAPH_FORMAT_VERSION {
+        if let Some(reg) = reg {
+            for node in &mut g.nodes {
+                if let Some(f) = reg.get(&node.kind).and_then(|s| s.migrate) {
+                    f(node, version);
+                }
+            }
+        }
+    }
+    Ok(g)
+}
+
+pub fn load_graph(path: impl AsRef<Path>, reg: Option<&Registry>) -> anyhow::Result<Graph> {
+    load_graph_str(&std::fs::read_to_string(path)?, reg)
+}
+
+fn list_in(dir: &Path, ext: &str, reg: Option<&Registry>) -> Vec<Graph> {
+    let Ok(rd) = std::fs::read_dir(dir) else { return Vec::new() };
+    let suffix = format!(".{ext}");
+    let mut out: Vec<Graph> = rd
+        .flatten()
+        .filter(|e| e.path().to_string_lossy().ends_with(&suffix))
+        .filter_map(|e| load_graph(e.path(), reg).ok())
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// A file name from a graph's name: lowercase, dashes for what is not
+/// alphanumeric.
+pub fn slug(name: &str) -> String {
+    let s: String = name.trim().to_lowercase().chars().map(|c| if c.is_alphanumeric() { c } else { '-' }).collect();
+    let s = s.trim_matches('-').to_string();
+    if s.is_empty() { "untitled".into() } else { s }
+}
+
+pub fn save_cluster_in(dir: &Path, g: &Graph) -> anyhow::Result<PathBuf> {
+    let path = dir.join(format!("{}.{CLUSTER_EXT}", slug(&g.name)));
+    save_graph(&path, g)?;
+    Ok(path)
+}
+
+pub fn save_cluster(g: &Graph) -> anyhow::Result<PathBuf> {
+    save_cluster_in(&cluster_dir(), g)
+}
+
+pub fn list_clusters_in(dir: &Path, reg: Option<&Registry>) -> Vec<Graph> {
+    list_in(dir, CLUSTER_EXT, reg)
+}
+
+pub fn list_clusters(reg: Option<&Registry>) -> Vec<Graph> {
+    list_clusters_in(&cluster_dir(), reg)
+}
+
+pub fn load_cluster_in(dir: &Path, name: &str, reg: Option<&Registry>) -> Option<Graph> {
+    let path = dir.join(format!("{}.{CLUSTER_EXT}", slug(name)));
+    if path.exists() {
+        return load_graph(path, reg).ok();
+    }
+    list_clusters_in(dir, reg).into_iter().find(|g| g.name == name)
+}
+
+pub fn load_cluster(name: &str, reg: Option<&Registry>) -> Option<Graph> {
+    load_cluster_in(&cluster_dir(), name, reg)
+}
+
+pub fn save_graph_in(dir: &Path, g: &Graph) -> anyhow::Result<PathBuf> {
+    let path = dir.join(format!("{}.{GRAPH_EXT}", slug(&g.name)));
+    save_graph(&path, g)?;
+    Ok(path)
+}
+
+pub fn list_graphs_in(dir: &Path, reg: Option<&Registry>) -> Vec<Graph> {
+    list_in(dir, GRAPH_EXT, reg)
+}
+
+pub fn list_graphs(reg: Option<&Registry>) -> Vec<Graph> {
+    list_graphs_in(&graph_dir(), reg)
+}
+
+/// Named values for a cluster's exposed inputs.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Preset {
+    pub name: String,
+    pub cluster: String,
+    #[serde(default)]
+    pub values: BTreeMap<String, Literal>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub doc: String,
+}
+
+impl Preset {
+    /// Set this preset's values on a cluster node's inputs; other inputs
+    /// are left alone. Returns the names the node had no pin for.
+    pub fn apply(&self, node: &mut Node, reg: &Registry) -> Vec<String> {
+        let pins: Vec<String> = reg.node_pins(node).map(|(ins, _)| ins.into_iter().map(|p| p.name).collect()).unwrap_or_default();
+        let mut unknown = Vec::new();
+        for (k, v) in &self.values {
+            if pins.contains(k) {
+                node.inputs.insert(k.clone(), v.clone());
+            } else {
+                unknown.push(k.clone());
+            }
+        }
+        unknown
+    }
+}
+
+pub fn preset_to_string(p: &Preset) -> anyhow::Result<String> {
+    Ok(serde_json::to_string_pretty(&Versioned { format_version: GRAPH_FORMAT_VERSION, doc: p })?)
+}
+
+pub fn load_preset_str(text: &str) -> anyhow::Result<Preset> {
+    let mut doc: serde_json::Value = serde_json::from_str(text)?;
+    let version = doc.get(VERSION_KEY).and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    if version > GRAPH_FORMAT_VERSION {
+        anyhow::bail!("preset file is format version {version}, but this build reads up to {GRAPH_FORMAT_VERSION} — it was saved by a newer RingDesigner");
+    }
+    if let Some(obj) = doc.as_object_mut() {
+        obj.remove(VERSION_KEY);
+    }
+    Ok(serde_json::from_value(doc)?)
+}
+
+pub fn save_preset_in(dir: &Path, p: &Preset) -> anyhow::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(format!("{}.{PRESET_EXT}", slug(&p.name)));
+    std::fs::write(&path, preset_to_string(p)?)?;
+    Ok(path)
+}
+
+pub fn save_preset(p: &Preset) -> anyhow::Result<PathBuf> {
+    save_preset_in(&preset_dir(), p)
+}
+
+pub fn list_presets_in(dir: &Path) -> Vec<Preset> {
+    let Ok(rd) = std::fs::read_dir(dir) else { return Vec::new() };
+    let suffix = format!(".{PRESET_EXT}");
+    let mut out: Vec<Preset> = rd
+        .flatten()
+        .filter(|e| e.path().to_string_lossy().ends_with(&suffix))
+        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+        .filter_map(|t| load_preset_str(&t).ok())
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+pub fn list_presets() -> Vec<Preset> {
+    list_presets_in(&preset_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::Mode;
+
+    fn tmp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("ringdesign-graph-files-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn every_version_has_a_migration_step() {
+        assert_eq!(MIGRATIONS.len(), GRAPH_FORMAT_VERSION as usize, "one step per version, none skipped");
+    }
+
+    #[test]
+    fn graphs_round_trip_with_their_version_and_refuse_a_newer_one() {
+        let reg = Registry::builtin();
+        let mut g = Graph::new("Court band", Mode::SandRing);
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "width_mm", Literal::Number(6.0)).unwrap();
+        g.expose(p, "width_mm", "Width").unwrap();
+        g.expose_output(p, "profile", "profile").unwrap();
+        let text = graph_to_string(&g).unwrap();
+        assert!(text.contains("\"format_version\": 1"));
+        let back = load_graph_str(&text, Some(&reg)).unwrap();
+        assert_eq!(back, g);
+        // A bare graph (version 0) reads, walking the ladder.
+        let bare = serde_json::to_string(&g).unwrap();
+        assert_eq!(load_graph_str(&bare, Some(&reg)).unwrap(), g);
+        let newer = text.replace("\"format_version\": 1", "\"format_version\": 99");
+        let err = load_graph_str(&newer, None).unwrap_err();
+        assert!(err.to_string().contains("newer RingDesigner"), "{err}");
+        let dir = tmp("graphs");
+        let path = save_graph_in(&dir, &g).unwrap();
+        assert!(path.to_string_lossy().ends_with("court-band.graph.json"));
+        assert_eq!(list_graphs_in(&dir, Some(&reg)).len(), 1);
+        let cpath = save_cluster_in(&dir, &g).unwrap();
+        assert!(cpath.to_string_lossy().ends_with("court-band.cluster.json"));
+        assert_eq!(load_cluster_in(&dir, "Court band", Some(&reg)).unwrap().outputs.len(), 1);
+        assert!(load_cluster_in(&dir, "nope", None).is_none());
+    }
+
+    #[test]
+    fn presets_name_values_for_a_cluster_and_apply_to_its_node() {
+        let dir = tmp("presets");
+        let p = Preset {
+            name: "Wide court".into(),
+            cluster: "Court band".into(),
+            values: [("Width".to_string(), Literal::Number(8.0)), ("Nope".to_string(), Literal::Bool(true))].into_iter().collect(),
+            doc: "an 8 mm court".into(),
+        };
+        let path = save_preset_in(&dir, &p).unwrap();
+        assert!(path.to_string_lossy().ends_with("wide-court.preset.json"));
+        let listed = list_presets_in(&dir);
+        assert_eq!(listed, vec![p.clone()]);
+        let err = load_preset_str(&preset_to_string(&p).unwrap().replace("\"format_version\": 1", "\"format_version\": 7")).unwrap_err();
+        assert!(err.to_string().contains("newer"), "{err}");
+        assert_eq!(slug("  Wide  Court / 2 "), "wide--court---2");
+    }
+}

--- a/crates/ringdesign-graph/src/graph.rs
+++ b/crates/ringdesign-graph/src/graph.rs
@@ -85,6 +85,17 @@ pub struct Exposed {
     pub doc: String,
 }
 
+/// An output promoted to the graph's own — what a cluster hands out when
+/// it is used as a node.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExposedOut {
+    pub node: NodeId,
+    pub out: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub doc: String,
+}
+
 /// The document.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Graph {
@@ -97,6 +108,8 @@ pub struct Graph {
     pub wires: Vec<Wire>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exposed: Vec<Exposed>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outputs: Vec<ExposedOut>,
     /// The next id to hand out; never decremented.
     #[serde(default)]
     pub next_id: u64,
@@ -168,7 +181,7 @@ pub trait PinLookup {
 
 impl Graph {
     pub fn new(name: impl Into<String>, mode: Mode) -> Self {
-        Self { name: name.into(), mode, nodes: Vec::new(), wires: Vec::new(), exposed: Vec::new(), next_id: 1 }
+        Self { name: name.into(), mode, nodes: Vec::new(), wires: Vec::new(), exposed: Vec::new(), outputs: Vec::new(), next_id: 1 }
     }
 
     pub fn node(&self, id: NodeId) -> Option<&Node> {
@@ -210,6 +223,7 @@ impl Graph {
         let node = self.nodes.remove(i);
         self.wires.retain(|w| w.from != id && w.to != id);
         self.exposed.retain(|e| e.node != id);
+        self.outputs.retain(|e| e.node != id);
         Ok(node)
     }
 
@@ -321,6 +335,28 @@ impl Graph {
         Some(self.exposed.remove(i))
     }
 
+    /// Promote an output to the graph's own under `name`.
+    pub fn expose_output(&mut self, node: NodeId, out: impl Into<String>, name: impl Into<String>) -> Result<(), GraphError> {
+        if !self.contains(node) {
+            return Err(GraphError::at(node, "no such node"));
+        }
+        let (out, name) = (out.into(), name.into());
+        if let Some(e) = self.outputs.iter().find(|e| e.name == name) {
+            if e.node != node || e.out != out {
+                return Err(GraphError::at(node, format!("{name:?} is already an output from {}.{}", e.node, e.out)));
+            }
+            return Ok(());
+        }
+        self.outputs.retain(|e| !(e.node == node && e.out == out));
+        self.outputs.push(ExposedOut { node, out, name, doc: String::new() });
+        Ok(())
+    }
+
+    pub fn unexpose_output(&mut self, name: &str) -> Option<ExposedOut> {
+        let i = self.outputs.iter().position(|e| e.name == name)?;
+        Some(self.outputs.remove(i))
+    }
+
     /// Nodes in an order every wire runs forward, or the node a cycle
     /// passes through. Ties break by id, so the order is deterministic.
     pub fn topo(&self) -> Result<Vec<NodeId>, GraphError> {
@@ -425,6 +461,11 @@ impl Graph {
                 errs.push(GraphError::global(format!("exposed {:?} names a node that does not exist ({})", e.name, e.node)));
             }
         }
+        for e in &self.outputs {
+            if !ids.contains(&e.node) {
+                errs.push(GraphError::global(format!("output {:?} names a node that does not exist ({})", e.name, e.node)));
+            }
+        }
         if let Err(e) = self.topo() {
             errs.push(e);
         }
@@ -475,6 +516,13 @@ impl Graph {
                 if let Some(Some(p)) = pins.get(&e.node) {
                     if p.input(&e.input).is_none() {
                         errs.push(GraphError::at(e.node, format!("exposed {:?} names no input {:?}", e.name, e.input)));
+                    }
+                }
+            }
+            for e in &self.outputs {
+                if let Some(Some(p)) = pins.get(&e.node) {
+                    if p.output(&e.out).is_none() {
+                        errs.push(GraphError::at(e.node, format!("output {:?} names no output {:?}", e.name, e.out)));
                     }
                 }
             }

--- a/crates/ringdesign-graph/src/lib.rs
+++ b/crates/ringdesign-graph/src/lib.rs
@@ -36,6 +36,7 @@
 //! [`eval`], then the node library under [`nodes`].
 
 pub mod eval;
+pub mod file;
 pub mod graph;
 pub mod nodes;
 pub mod registry;

--- a/crates/ringdesign-graph/src/nodes/cluster.rs
+++ b/crates/ringdesign-graph/src/nodes/cluster.rs
@@ -1,0 +1,253 @@
+//! A graph as a node.
+//!
+//! A cluster node carries the cluster graph in its params — a copy, so a
+//! design that embeds its graph still opens on a machine without the
+//! cluster file — and takes its pins from that graph's exposed inputs and
+//! outputs. Evaluation runs the inner graph with the node's input values
+//! injected straight onto the exposed pins (handles included), at one
+//! cluster depth more than the graph it sits in.
+
+use std::collections::BTreeMap;
+
+use crate::MAX_CLUSTER_DEPTH;
+use crate::eval::{Evaluator, Targets};
+use crate::graph::{Graph, Node, NodeId};
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry};
+use crate::value::{Value, ValueKind};
+
+pub const CLUSTER_KIND: &str = "cluster";
+
+/// The params a cluster node carries for `cluster`.
+pub fn params_for(cluster: &Graph) -> serde_json::Value {
+    serde_json::json!({ "cluster": cluster.name, "graph": cluster })
+}
+
+/// The embedded graph, if the params hold one.
+pub fn embedded(node: &Node) -> Option<Graph> {
+    serde_json::from_value(node.params.get("graph")?.clone()).ok()
+}
+
+/// Add a cluster node for `cluster` to `g`.
+pub fn add_cluster(g: &mut Graph, cluster: &Graph) -> Result<NodeId, crate::graph::GraphError> {
+    let id = g.add(CLUSTER_KIND)?;
+    let node = g.node_mut(id).expect("just added");
+    node.params = params_for(cluster);
+    node.label = Some(cluster.name.clone());
+    Ok(id)
+}
+
+/// Bring a node's embedded copy up to date with `cluster`.
+pub fn resync(node: &mut Node, cluster: &Graph) {
+    node.params = params_for(cluster);
+}
+
+fn pins(_: &NodeSpec, node: &Node, reg: &Registry) -> (Vec<PinSpec>, Vec<PinSpec>) {
+    let Some(inner) = embedded(node) else { return (Vec::new(), Vec::new()) };
+    let mut ins = Vec::new();
+    for e in &inner.exposed {
+        let Some(target) = inner.node(e.node) else { continue };
+        let spec_pin = reg.node_pins(target).and_then(|(i, _)| i.into_iter().find(|p| p.name == e.input));
+        let mut pin = match spec_pin {
+            Some(p) => PinSpec { name: e.name.clone(), ..p },
+            None => PinSpec::item(e.name.clone(), ValueKind::Any),
+        };
+        if let Some(lit) = target.inputs.get(&e.input) {
+            pin.default = Some(lit.clone());
+        }
+        if !e.doc.is_empty() {
+            pin.doc = e.doc.clone();
+        }
+        pin.optional = true;
+        ins.push(pin);
+    }
+    let mut outs = Vec::new();
+    for o in &inner.outputs {
+        let Some(target) = inner.node(o.node) else { continue };
+        let spec_pin = reg.node_pins(target).and_then(|(_, p)| p.into_iter().find(|p| p.name == o.out));
+        let pin = match spec_pin {
+            Some(p) => PinSpec { name: o.name.clone(), ..p },
+            None => PinSpec::item(o.name.clone(), ValueKind::Any),
+        };
+        outs.push(if o.doc.is_empty() { pin } else { pin.doc(o.doc.clone()) });
+    }
+    (ins, outs)
+}
+
+fn run(ctx: &mut EvalCtx<'_>, node: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut inner = embedded(node).ok_or_else(|| NodeError::new("the cluster node carries no graph; re-sync it from its cluster"))?;
+    if ctx.depth + 1 > MAX_CLUSTER_DEPTH {
+        return Err(NodeError::new(format!("clusters nest deeper than {MAX_CLUSTER_DEPTH}")));
+    }
+    // The mode is the outer graph's, so its rules hold all the way down.
+    inner.mode = ctx.mode;
+    let mut injected: BTreeMap<(NodeId, String), Value> = BTreeMap::new();
+    for e in &inner.exposed {
+        let v = i.get(&e.name);
+        if !v.is_null() {
+            injected.insert((e.node, e.input.clone()), v.clone());
+        }
+    }
+    let targets: Vec<NodeId> = inner.outputs.iter().map(|o| o.node).collect();
+    if targets.is_empty() {
+        return Err(NodeError::new(format!("cluster {:?} exposes no outputs", inner.name)));
+    }
+    let mut ev = Evaluator::new();
+    ev.depth = ctx.depth + 1;
+    let report = ev.evaluate_injected(&inner, ctx.reg, ctx.lib, ctx.lib_epoch, Targets::Nodes(targets), &injected);
+    if let Some(e) = report.errors.first() {
+        return Err(NodeError::new(format!("inside {:?}: {e}", inner.name)));
+    }
+    let notes = report.notes(&inner);
+    // A cluster is one unit: a failure anywhere inside fails this item,
+    // rather than letting a Null quietly become a default downstream.
+    if report.any_failed() {
+        let first = report
+            .order
+            .iter()
+            .filter_map(|id| report.status.get(id).filter(|s| s.failed()).map(|s| (id, s)))
+            .map(|(id, s)| format!("{id} {}: {}", inner.node(*id).map(|n| n.kind.as_str()).unwrap_or("?"), s.errors.first().map(|e| e.1.clone()).unwrap_or_default()))
+            .next()
+            .unwrap_or_default();
+        return Err(NodeError::new(format!("inside {:?}: {first}", inner.name)));
+    }
+    for n in &notes {
+        ctx.warn(format!("inside {:?}: {n}", inner.name));
+    }
+    let mut out = Outputs::default();
+    for o in &inner.outputs {
+        let v = report.value(o.node, &o.out).cloned().unwrap_or(Value::Null);
+        out.values.insert(o.name.clone(), v);
+    }
+    Ok(out)
+}
+
+pub fn register(reg: &mut Registry) {
+    reg.register(
+        NodeSpec::new(CLUSTER_KIND, "Cluster", Category::Assembly)
+            .doc("A saved graph used as one node: its exposed inputs are the pins, its exposed outputs the results. The graph rides in the node, so the design stays whole.")
+            .resolve(pins)
+            .eval(run),
+    )
+    .expect("unique");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file::Preset;
+    use crate::graph::Mode;
+    use crate::value::Literal;
+    use ringdesign_core::AlphaLibrary;
+
+    /// A cluster: width in, a flat-sided design out.
+    fn band_cluster() -> Graph {
+        let mut c = Graph::new("Squared band", Mode::SandRing);
+        let p = c.add("band.profile").unwrap();
+        c.set_input(p, "style", Literal::Text("Flat".into())).unwrap();
+        c.set_input(p, "width_mm", Literal::Number(6.0)).unwrap();
+        c.set_input(p, "flatten_sides", Literal::Bool(true)).unwrap();
+        let d = c.add("design.new").unwrap();
+        c.connect(p, "profile", d, "profile").unwrap();
+        c.expose(p, "width_mm", "Width").unwrap();
+        c.expose(d, "name", "Name").unwrap();
+        c.expose(p, "profile", "Base profile").unwrap();
+        c.expose_output(d, "design", "design").unwrap();
+        c.expose_output(p, "profile", "profile").unwrap();
+        c
+    }
+
+    #[test]
+    fn a_cluster_node_takes_its_pins_from_the_graph_and_runs_it() {
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::default();
+        let cluster = band_cluster();
+        let mut g = Graph::default();
+        let n = add_cluster(&mut g, &cluster).unwrap();
+        let (ins, outs) = reg.node_pins(g.node(n).unwrap()).unwrap();
+        assert_eq!(ins.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(), vec!["Width", "Name", "Base profile"]);
+        assert_eq!(ins[0].kind, ValueKind::Number);
+        assert_eq!(ins[0].default, Some(Literal::Number(6.0)), "the inner literal is the pin's default");
+        assert_eq!(ins[2].kind, ValueKind::Profile);
+        assert_eq!(outs.iter().map(|p| (p.name.as_str(), p.kind)).collect::<Vec<_>>(), vec![("design", ValueKind::Design), ("profile", ValueKind::Profile)]);
+        assert!(g.validate(Some(&reg)).is_empty());
+
+        // Unset: the cluster's own literals.
+        let info = g.add("design.info").unwrap();
+        g.connect(n, "design", info, "design").unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        assert_eq!(r.value(info, "width_mm"), Some(&Value::Number(6.0)));
+
+        // Set, and as a list: implicit lists pass through a cluster.
+        g.set_input(n, "Width", Literal::List(vec![Literal::Number(5.0), Literal::Number(9.0)])).unwrap();
+        g.set_input(n, "Name", Literal::Text("Wide".into())).unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        match r.value(info, "width_mm") {
+            Some(Value::List(v)) => assert_eq!(v, &vec![Value::Number(5.0), Value::Number(9.0)]),
+            other => panic!("{other:?}"),
+        }
+        assert_eq!(r.value(info, "name"), Some(&Value::List(vec![Value::Text("Wide".into()), Value::Text("Wide".into())])));
+
+        // A handle goes in through an exposed pin.
+        let base = g.add("band.profile").unwrap();
+        g.set_input(base, "thickness_mm", Literal::Number(3.3)).unwrap();
+        g.connect(base, "profile", n, "Base profile").unwrap();
+        g.set_input(n, "Width", Literal::Number(7.0)).unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        assert_eq!(r.value(info, "thickness_mm"), Some(&Value::Number(3.3)));
+        assert_eq!(r.value(info, "width_mm"), Some(&Value::Number(7.0)));
+
+        // A preset sets the exposed inputs and reports what it could not.
+        let preset = Preset { name: "Eight".into(), cluster: cluster.name.clone(), values: [("Width".to_string(), Literal::Number(8.0)), ("Gone".to_string(), Literal::Null)].into_iter().collect(), doc: String::new() };
+        let unknown = preset.apply(g.node_mut(n).unwrap(), &reg);
+        assert_eq!(unknown, vec!["Gone"]);
+        assert_eq!(g.node(n).unwrap().inputs.get("Width"), Some(&Literal::Number(8.0)));
+
+        // A failure inside is reported from inside.
+        g.set_input(n, "Width", Literal::Number(0.0)).unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(r.status[&n].failed());
+        assert!(r.status[&n].errors[0].1.contains("inside \"Squared band\""), "{:?}", r.status[&n].errors);
+    }
+
+    #[test]
+    fn clusters_nest_to_the_cap_and_carry_the_outer_mode() {
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::default();
+        // Wrap the band cluster in itself, MAX_CLUSTER_DEPTH + 1 times.
+        let mut inner = band_cluster();
+        for level in 0..=MAX_CLUSTER_DEPTH {
+            let mut outer = Graph::new(format!("Level {level}"), Mode::SandRing);
+            let n = add_cluster(&mut outer, &inner).unwrap();
+            outer.expose(n, "Width", "Width").unwrap();
+            outer.expose_output(n, "design", "design").unwrap();
+            inner = outer;
+        }
+        let mut g = Graph::default();
+        let n = add_cluster(&mut g, &inner).unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(r.status[&n].failed());
+        assert!(r.status[&n].errors[0].1.contains("deeper than"), "{:?}", r.status[&n].errors);
+
+        // A Free-only node inside a cluster is refused in a SandRing graph.
+        let mut c = Graph::new("Free inside", Mode::Free);
+        let d = c.add("design.new").unwrap();
+        let b = c.add("sink.build").unwrap();
+        c.connect(d, "design", b, "design").unwrap();
+        c.set_input(b, "preset", Literal::Text("Draft".into())).unwrap();
+        let mv = c.add("sink.mesh_verdict").unwrap();
+        c.connect(b, "mesh", mv, "mesh").unwrap();
+        c.connect(d, "design", mv, "design").unwrap();
+        c.expose_output(mv, "verdict", "verdict").unwrap();
+        let mut g = Graph::new("outer", Mode::SandRing);
+        let n = add_cluster(&mut g, &c).unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(r.status[&n].errors[0].1.contains("does not run in SandRing"), "{:?}", r.status[&n].errors);
+        g.mode = Mode::Free;
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        assert!(matches!(r.value(n, "verdict"), Some(Value::Text(_))));
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -10,6 +10,7 @@ use crate::registry::Registry;
 pub mod alpha;
 pub mod assembly;
 pub mod band;
+pub mod cluster;
 pub mod gem;
 pub mod generator;
 pub mod layer;
@@ -35,6 +36,7 @@ pub fn register_all(reg: &mut Registry) {
     generator::register(reg);
     alpha::register(reg);
     sink::register(reg);
+    cluster::register(reg);
 }
 
 #[cfg(test)]
@@ -54,7 +56,7 @@ mod tests {
             let spec = reg.get(key).unwrap();
             assert!(!spec.doc.is_empty(), "{key} has no doc");
             assert!(!spec.label.is_empty(), "{key} has no label");
-            assert!(key.contains('.') || matches!(key, "number" | "int" | "bool" | "text" | "series" | "range" | "shank" | "head" | "gem" | "entry" | "window" | "stack"), "{key} is not family.name");
+            assert!(key.contains('.') || matches!(key, "number" | "int" | "bool" | "text" | "series" | "range" | "shank" | "head" | "gem" | "entry" | "window" | "stack" | "cluster"), "{key} is not family.name");
             // Inputs and outputs are separate namespaces: a wire names one of each.
             for pins in [&spec.inputs, &spec.outputs] {
                 let mut seen = BTreeSet::new();

--- a/crates/ringdesign-graph/src/registry.rs
+++ b/crates/ringdesign-graph/src/registry.rs
@@ -160,7 +160,12 @@ impl From<String> for Literal {
 /// What one evaluation of a node sees besides its inputs.
 pub struct EvalCtx<'a> {
     pub lib: &'a AlphaLibrary,
+    pub reg: &'a Registry,
     pub mode: Mode,
+    /// How deep in clusters this evaluation runs; the root is 0.
+    pub depth: usize,
+    /// The alpha library's epoch, for nested evaluations.
+    pub lib_epoch: u64,
     /// Whether sinks that write files or spawn work may do so this run.
     pub run_side_effects: bool,
     /// Which item of an implicit list this run is, and how many there are.
@@ -171,8 +176,8 @@ pub struct EvalCtx<'a> {
 }
 
 impl<'a> EvalCtx<'a> {
-    pub fn new(lib: &'a AlphaLibrary, mode: Mode) -> Self {
-        Self { lib, mode, run_side_effects: false, item: 0, items: 1, warnings: Vec::new() }
+    pub fn new(lib: &'a AlphaLibrary, reg: &'a Registry, mode: Mode) -> Self {
+        Self { lib, reg, mode, depth: 0, lib_epoch: 0, run_side_effects: false, item: 0, items: 1, warnings: Vec::new() }
     }
 
     pub fn warn(&mut self, message: impl Into<String>) {
@@ -287,8 +292,9 @@ impl From<anyhow::Error> for NodeError {
 /// Evaluate one item of a node. A closure, so an adapter built over a
 /// table (a struct's fields, a script's pins) can carry it.
 pub type EvalFn = Arc<dyn Fn(&mut EvalCtx<'_>, &Node, &Inputs) -> Result<Outputs, NodeError> + Send + Sync>;
-/// Pins for one instance, read from its params.
-pub type ResolveFn = fn(&NodeSpec, &Node) -> (Vec<PinSpec>, Vec<PinSpec>);
+/// Pins for one instance, read from its params (and, for a cluster, the
+/// registry that types the nodes inside it).
+pub type ResolveFn = fn(&NodeSpec, &Node, &Registry) -> (Vec<PinSpec>, Vec<PinSpec>);
 /// Rewrite a node saved under an older graph format version.
 pub type MigrateFn = fn(&mut Node, u32);
 
@@ -388,9 +394,9 @@ impl NodeSpec {
 
     /// The pins this instance has: the static ones, or what `resolve`
     /// reads from the node's params.
-    pub fn pins_for(&self, node: &Node) -> (Vec<PinSpec>, Vec<PinSpec>) {
+    pub fn pins_for(&self, node: &Node, reg: &Registry) -> (Vec<PinSpec>, Vec<PinSpec>) {
         match self.resolve {
-            Some(f) => f(self, node),
+            Some(f) => f(self, node, reg),
             None => (self.inputs.clone(), self.outputs.clone()),
         }
     }
@@ -456,14 +462,14 @@ impl Registry {
 
     /// The resolved pins of a node, or `None` for an unknown kind.
     pub fn node_pins(&self, node: &Node) -> Option<(Vec<PinSpec>, Vec<PinSpec>)> {
-        self.get(&node.kind).map(|s| s.pins_for(node))
+        self.get(&node.kind).map(|s| s.pins_for(node, self))
     }
 }
 
 impl PinLookup for Registry {
     fn pins(&self, node: &Node) -> Option<NodePins> {
         let spec = self.get(&node.kind)?;
-        let (inputs, outputs) = spec.pins_for(node);
+        let (inputs, outputs) = spec.pins_for(node, self);
         Some(NodePins {
             inputs: inputs.iter().map(PinSpec::info).collect(),
             outputs: outputs.iter().map(PinSpec::info).collect(),
@@ -486,7 +492,7 @@ mod tests {
     }
 
     /// A script-like node: pins named in params.
-    fn script_pins(_: &NodeSpec, node: &Node) -> (Vec<PinSpec>, Vec<PinSpec>) {
+    fn script_pins(_: &NodeSpec, node: &Node, _: &Registry) -> (Vec<PinSpec>, Vec<PinSpec>) {
         let names = |key: &str| -> Vec<PinSpec> {
             node.params
                 .get(key)
@@ -565,7 +571,7 @@ mod tests {
     fn eval_functions_read_inputs_and_attribute_errors() {
         let reg = specs();
         let lib = AlphaLibrary::default();
-        let mut ctx = EvalCtx::new(&lib, Mode::SandRing);
+        let mut ctx = EvalCtx::new(&lib, &reg, Mode::SandRing);
         let node = Node { id: crate::graph::NodeId(1), kind: "math.add".into(), params: serde_json::Value::Null, inputs: Default::default(), pos: [0.0; 2], label: None };
         let mut inputs = Inputs::default();
         inputs.values.insert("a".into(), Value::Number(1.5));

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -95,7 +95,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - [x] **M2.5 Sinks, verdict gate, modes** (M, #16). Output, verdict, gate, build, refine, stones, DFM,
   sheet, exports, render, save; SandRing refuses `NotCastable` on file-writing sinks; Free adds
   solid nodes and the mesh verifier.
-- [ ] **M2.6 Files, ladder, clusters, presets** (M, #17). `*.graph.json`, `*.cluster.json`,
+- [x] **M2.6 Files, ladder, clusters, presets** (M, #17). `*.graph.json`, `*.cluster.json`,
   `*.preset.json` with a migration ladder like the design's; cluster nodes with exposed
   parameters; presets as parameter sets; user-dir resolution.
 - [ ] **M2.7 Design field, template graphs, golden tests** (M, #18). `RingDesign.graph`; every


### PR DESCRIPTION
## Summary
- `file.rs`: versioned graph/cluster/preset files (one migration step per version, newer refused), user dirs, slugs, `Preset::apply`.
- `Graph::outputs` (exposed outputs); `nodes/cluster.rs`: a graph as a node with its graph embedded, pins from exposed inputs/outputs, injected evaluation at depth+1 under the outer mode, depth cap, inner failures fail the item.
- `ResolveFn`/`EvalCtx` carry the registry; `Evaluator::evaluate_injected`; `Targets::Nodes`.

## Verification
- `cargo test --workspace` green; graph crate 55 tests (5 new).
- wasm check passes.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)