### PR TITLE
M2.7 RingDesign.graph, template graphs and the exact lift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1484,6 +1484,49 @@ The crate forwards `parallel` to the core and passes the wasm check; the
 editor (`ringdesign-graph-ui`), scripting (`ringdesign-script`), the Python
 module and the solid kernel land as their milestones do (`docs/ROADMAP.md`).
 
+What the runtime settled while being built, each pinned by a test:
+
+- **A struct is a node as a patch over its base** (`nodes/structs.rs`,
+  `StructNode`): unset pins leave the base's fields alone, so a modifier
+  after a node of the same kind is safe; enum pins carry serde names;
+  `coverage()` holds every node to its struct's serialized keys, which is
+  how a field added to the core cannot go unnoticed (it caught `theta_deg`
+  declared on the wrong struct the first day). `prepare` hooks run before
+  the patch (`apply_style` cannot clobber an explicit crown), `finish`
+  hooks after (`fit_length_to`).
+- **Generators emit live groups**: `gen.pave/halo/channel` call `fill`,
+  `halo` and `channel_set`, which stamp the recipe; the evaluator never
+  regenerates. A drawn plan through `outline.custom` gets the lobed-plan
+  dome suggestion because `CustomOutline::from_points` now sizes `fair_r`
+  from the hull defect on every import path, not only in the exporter.
+- **SandRing file sinks are judged first** (`nodes/sink.rs`): `sink.export`
+  and `sink.save_design` take the field report (wired, or computed from the
+  wired design); an unjudged ring is refused as unjudged, a `NotCastable`
+  ring with the notes, and nothing is written. Side-effect nodes run only
+  under `Targets::Everything` and are never cached. `sink.mesh_verdict`
+  (face normals) is Free-only — the field is the verdict in SandRing.
+- **A cluster carries its graph in its params** (`nodes/cluster.rs`), so a
+  design embedding its graph stays whole off-machine; pins come from the
+  cluster's exposed inputs (typed from the inner spec) and outputs; the
+  node's values are *injected* onto the inner pins — handles included, not
+  just literals — one depth down under the outer mode, so a Free-only node
+  is refused through a cluster in a SandRing graph. Any inner failure fails
+  the item: a `Null` must not become a default downstream.
+- **`RingDesign::graph`** is the design's provenance (no ladder bump — an
+  absent key reads `None`, an older build ignores it). Graph, cluster and
+  preset files have their own ladder in `file.rs`, one step per version.
+- **The nine templates are committed graphs** (`graphs/templates/*.graph.json`,
+  bundled by `include_str!`) generated from builders in `templates.rs`;
+  the golden test holds each file to its builder and each evaluation to the
+  code template **byte for byte**. Regenerate with
+  `RD_WRITE_TEMPLATE_GRAPHS=1 cargo test -p ringdesign-graph write_template_graphs`.
+- **The lift is exact by construction** (`lift.rs`, `Graph::from_design`):
+  it wires the nodes a person would, evaluates them, diffs the result
+  against the design field by field, and carries whatever the nodes cannot
+  express (a flange, a tiling warp, the draft settings) as `design.set`
+  patches — so "Convert to graph" never loses a field, and the test that
+  every template lifts back byte-for-byte also caps the patches at four.
+
 ## GUI
 
 `app.rs` owns all state. Geometry-affecting edits call `app.mark_dirty()`; a

--- a/crates/ringdesign-core/src/lib.rs
+++ b/crates/ringdesign-core/src/lib.rs
@@ -91,6 +91,11 @@ pub struct RingDesign {
     /// Parameterized builtin generators, rasterized on load.
     #[serde(default)]
     pub recipes: Vec<alpha::ProcRecipe>,
+    /// The graph this design was evaluated from, carried as provenance the
+    /// way a generated group carries its recipe: live until baked, opaque
+    /// here (`ringdesign-graph` reads it), absent on a hand-made design.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph: Option<serde_json::Value>,
 }
 
 /// One imported alpha embedded in the design file.
@@ -116,6 +121,7 @@ impl Default for RingDesign {
             texts: Vec::new(),
             svgs: Vec::new(),
             recipes: Vec::new(),
+            graph: None,
         }
     }
 }

--- a/crates/ringdesign-core/src/library.rs
+++ b/crates/ringdesign-core/src/library.rs
@@ -31,6 +31,8 @@ pub fn data_root() -> PathBuf {
 
 /// File extension for saved designs.
 pub const DESIGN_EXT: &str = "ring.json";
+/// `RingDesign::graph` joined the file without a version bump: an absent
+/// field reads as `None`, and an older build ignores the key.
 
 /// Version stamped into saved design files; files without one are version 0.
 pub const FORMAT_VERSION: u32 = 1;

--- a/crates/ringdesign-graph/src/lib.rs
+++ b/crates/ringdesign-graph/src/lib.rs
@@ -38,8 +38,10 @@
 pub mod eval;
 pub mod file;
 pub mod graph;
+pub mod lift;
 pub mod nodes;
 pub mod registry;
+pub mod templates;
 pub mod value;
 
 /// Most items one pin accepts; a longer list is truncated with a warning.

--- a/crates/ringdesign-graph/src/lift.rs
+++ b/crates/ringdesign-graph/src/lift.rs
@@ -1,0 +1,441 @@
+//! A design lifted into a graph that evaluates back to it exactly.
+//!
+//! The lift wires the nodes a person would — section, shank, heads, one
+//! node per layer with its gating, the alpha sources, the stack, the
+//! assembly, the output — then evaluates what it built and compares the
+//! result with the design field by field. Whatever the nodes cannot
+//! express (a flange, a tiling warp, a custom outline registry, the draft
+//! and build settings) rides as `design.set` patches at the end, so the
+//! round trip is exact by construction rather than by coverage.
+
+use ringdesign_core::field::{Layer, LayerEntry, Remap, VGate};
+use ringdesign_core::{AlphaLibrary, RingDesign};
+
+use crate::eval::{Evaluator, OUTPUT_DESIGN_PIN, OUTPUT_KIND, Targets};
+use crate::graph::{Graph, GraphError, Mode, NodeId};
+use crate::registry::Registry;
+use crate::value::{Literal, Value};
+
+/// Most `design.set` patches the lift adds before it patches whole
+/// top-level fields instead.
+const MAX_PATCHES: usize = 64;
+
+/// Set a node's field pins from the struct's JSON, for every pin whose name
+/// is a field of the object (and whose value is a literal).
+fn set_fields(g: &mut Graph, id: NodeId, reg: &Registry, json: &serde_json::Value, skip: &[&str]) {
+    let Some(obj) = json.as_object() else { return };
+    let Some((ins, _)) = reg.node_pins(g.node(id).expect("added")) else { return };
+    for pin in ins {
+        if skip.contains(&pin.name.as_str()) {
+            continue;
+        }
+        let Some(v) = obj.get(&pin.name) else { continue };
+        if v.is_null() || v.is_object() {
+            continue;
+        }
+        if let Ok(lit) = serde_json::from_value::<Literal>(v.clone()) {
+            let _ = g.set_input(id, pin.name.clone(), lit);
+        }
+    }
+}
+
+fn json_of<T: serde::Serialize>(t: &T) -> serde_json::Value {
+    serde_json::to_value(t).unwrap_or(serde_json::Value::Null)
+}
+
+fn gem_node(g: &mut Graph, reg: &Registry, gem: &ringdesign_core::gem::Gem) -> Result<NodeId, GraphError> {
+    let id = g.add("gem")?;
+    set_fields(g, id, reg, &json_of(gem), &[]);
+    Ok(id)
+}
+
+fn window_node(g: &mut Graph, w: &ringdesign_core::Window) -> Result<NodeId, GraphError> {
+    let id = g.add("window")?;
+    g.set_input(id, "theta_deg", Literal::Number(w.theta_deg))?;
+    g.set_input(id, "span_deg", Literal::Number(w.span_deg))?;
+    g.set_input(id, "fade_deg", Literal::Number(w.fade_deg))?;
+    g.set_input(id, "invert", Literal::Bool(w.invert))?;
+    g.set_input(id, "enabled", Literal::Bool(w.enabled))?;
+    match &w.v_gate {
+        VGate::Off => {}
+        VGate::Band { center_mm, span_mm, fade_mm } => {
+            g.set_input(id, "v_gate", Literal::Text("band".into()))?;
+            g.set_input(id, "band_center_mm", Literal::Number(*center_mm))?;
+            g.set_input(id, "band_span_mm", Literal::Number(*span_mm))?;
+            g.set_input(id, "band_fade_mm", Literal::Number(*fade_mm))?;
+        }
+        VGate::SideFaces(pick) => {
+            g.set_input(id, "v_gate", Literal::Text("side_faces".into()))?;
+            if let Some(s) = json_of(pick).as_str() {
+                g.set_input(id, "side_pick", Literal::Text(s.into()))?;
+            }
+        }
+    }
+    Ok(id)
+}
+
+fn remap_node(g: &mut Graph, r: &Remap) -> Result<Option<NodeId>, GraphError> {
+    Ok(match r {
+        Remap::Off => None,
+        Remap::Curve { curve, span_mm } => {
+            let id = g.add("remap.curve")?;
+            g.set_input(id, "points", Literal::Json(json_of(&curve.points().to_vec())))?;
+            g.set_input(id, "span_mm", Literal::Number(*span_mm))?;
+            Some(id)
+        }
+        Remap::Terrace { steps, span_mm, riser } => {
+            let id = g.add("remap.terrace")?;
+            g.set_input(id, "steps", Literal::Int(i64::from(*steps)))?;
+            g.set_input(id, "span_mm", Literal::Number(*span_mm))?;
+            g.set_input(id, "riser", Literal::Number(*riser))?;
+            Some(id)
+        }
+    })
+}
+
+/// A layer as its node; nested payloads become nodes wired in.
+fn layer_node(g: &mut Graph, reg: &Registry, layer: &Layer) -> Result<NodeId, GraphError> {
+    let id = match layer {
+        Layer::Tiling(t) => {
+            let id = g.add("layer.tiling")?;
+            set_fields(g, id, reg, &json_of(t), &[]);
+            id
+        }
+        Layer::Border(b) => {
+            let id = g.add("layer.border")?;
+            set_fields(g, id, reg, &json_of(b), &[]);
+            id
+        }
+        Layer::Milgrain(m) => {
+            let id = g.add("layer.milgrain")?;
+            set_fields(g, id, reg, &json_of(m), &[]);
+            id
+        }
+        Layer::SeatPad(s) => {
+            let id = g.add("layer.seat")?;
+            set_fields(g, id, reg, &json_of(s), &["gem"]);
+            if let Some(gem) = &s.gem {
+                let gid = gem_node(g, reg, gem)?;
+                g.connect(gid, "gem", id, "gem")?;
+            }
+            id
+        }
+        Layer::SeatRun(r) => {
+            let id = g.add("layer.seatrun")?;
+            set_fields(g, id, reg, &json_of(r), &["gem", "seat"]);
+            let gid = gem_node(g, reg, &r.gem)?;
+            g.connect(gid, "gem", id, "gem")?;
+            let seat = layer_node(g, reg, &Layer::SeatPad(r.seat))?;
+            g.connect(seat, "layer", id, "seat")?;
+            id
+        }
+        Layer::Signet(s) => {
+            let id = g.add("layer.signet")?;
+            set_fields(g, id, reg, &json_of(s), &[]);
+            id
+        }
+        Layer::Curve(c) => {
+            let id = g.add("layer.curve")?;
+            set_fields(g, id, reg, &json_of(c), &["points"]);
+            g.set_input(id, "points", Literal::Json(json_of(&c.points)))?;
+            id
+        }
+        Layer::Flutes(f) => {
+            let id = g.add("layer.flutes")?;
+            set_fields(g, id, reg, &json_of(f), &[]);
+            id
+        }
+        Layer::Decals(d) => {
+            let id = g.add("layer.decals")?;
+            set_fields(g, id, reg, &json_of(d), &["decals"]);
+            let stamps: Vec<Literal> = d.decals.iter().map(|s| Literal::Json(json_of(s))).collect();
+            g.set_input(id, "decals", Literal::List(stamps))?;
+            id
+        }
+        Layer::Openwork(o) => {
+            let id = g.add("layer.openwork")?;
+            set_fields(g, id, reg, &json_of(o), &["tiling"]);
+            let tl = layer_node(g, reg, &Layer::Tiling(o.tiling.clone()))?;
+            g.connect(tl, "layer", id, "tiling")?;
+            id
+        }
+        Layer::Group(grp) => {
+            let id = g.add("layer.group")?;
+            if let Some(st) = stack_nodes(g, reg, &grp.stack.layers)? {
+                g.connect(st, "stack", id, "stack")?;
+            }
+            id
+        }
+    };
+    Ok(id)
+}
+
+fn entry_node(g: &mut Graph, reg: &Registry, e: &LayerEntry) -> Result<NodeId, GraphError> {
+    let layer = layer_node(g, reg, &e.layer)?;
+    let id = g.add("entry")?;
+    g.connect(layer, "layer", id, "layer")?;
+    g.set_input(id, "name", Literal::Text(e.name.clone()))?;
+    g.set_input(id, "enabled", Literal::Bool(e.enabled))?;
+    if let Some(b) = json_of(&e.blend).as_str() {
+        g.set_input(id, "blend", Literal::Text(b.into()))?;
+    }
+    g.set_input(id, "opacity", Literal::Number(e.opacity))?;
+    g.set_input(id, "soft_mm", Literal::Number(e.soft_mm))?;
+    if let Some(m) = &e.mask {
+        g.set_input(id, "mask", Literal::Text(m.clone()))?;
+    }
+    let w = window_node(g, &e.window)?;
+    g.connect(w, "window", id, "window")?;
+    if let Some(r) = remap_node(g, &e.remap)? {
+        g.connect(r, "remap", id, "remap")?;
+    }
+    Ok(id)
+}
+
+/// A chain of `stack` nodes, one per entry, in order.
+fn stack_nodes(g: &mut Graph, reg: &Registry, entries: &[LayerEntry]) -> Result<Option<NodeId>, GraphError> {
+    let mut last: Option<NodeId> = None;
+    for e in entries {
+        let en = entry_node(g, reg, e)?;
+        let st = g.add("stack")?;
+        if let Some(prev) = last {
+            g.connect(prev, "stack", st, "stack")?;
+        }
+        g.connect(en, "entry", st, "entries")?;
+        last = Some(st);
+    }
+    Ok(last)
+}
+
+fn alpha_nodes(g: &mut Graph, d: &RingDesign) -> Result<Vec<NodeId>, GraphError> {
+    let mut ids = Vec::new();
+    for r in &d.recipes {
+        let id = g.add("alpha.proc")?;
+        g.set_input(id, "name", Literal::Text(r.name.clone()))?;
+        if let Some(k) = json_of(&r.kind).as_str() {
+            g.set_input(id, "kind", Literal::Text(k.into()))?;
+        }
+        g.set_input(id, "repeats", Literal::Int(i64::from(r.repeats)))?;
+        g.set_input(id, "quarter_turns", Literal::Int(i64::from(r.quarter_turns)))?;
+        g.set_input(id, "gamma", Literal::Number(r.gamma))?;
+        g.set_input(id, "invert", Literal::Bool(r.invert))?;
+        ids.push(id);
+    }
+    for t in &d.texts {
+        let id = g.add("alpha.text")?;
+        g.set_input(id, "name", Literal::Text(t.name.clone()))?;
+        g.set_input(id, "text", Literal::Text(t.text.clone()))?;
+        if let Some(f) = json_of(&t.font).as_str() {
+            g.set_input(id, "font", Literal::Text(f.into()))?;
+        }
+        g.set_input(id, "tracking", Literal::Number(t.tracking))?;
+        ids.push(id);
+    }
+    for s in &d.svgs {
+        let id = g.add("alpha.svg")?;
+        g.set_input(id, "name", Literal::Text(s.name.clone()))?;
+        g.set_input(id, "svg", Literal::Text(s.svg.clone()))?;
+        g.set_input(id, "invert", Literal::Bool(s.invert))?;
+        ids.push(id);
+    }
+    for a in &d.drawn {
+        let id = g.add("alpha.drawn")?;
+        g.set_input(id, "name", Literal::Text(a.name.clone()))?;
+        g.set_input(id, "width", Literal::Int(i64::from(a.width)))?;
+        g.set_input(id, "height", Literal::Int(i64::from(a.height)))?;
+        g.set_input(id, "wrap_x", Literal::Bool(a.wrap_x))?;
+        g.set_input(id, "wrap_y", Literal::Bool(a.wrap_y))?;
+        g.set_input(id, "strokes", Literal::List(a.strokes.iter().map(|s| Literal::Json(json_of(s))).collect()))?;
+        ids.push(id);
+    }
+    for e in &d.embedded {
+        let id = g.add("alpha.png")?;
+        g.set_input(id, "name", Literal::Text(e.name.clone()))?;
+        g.set_input(id, "png_base64", Literal::Text(e.png.clone()))?;
+        ids.push(id);
+    }
+    Ok(ids)
+}
+
+/// Up to four sources per `list.merge`, chained.
+fn merge_chain(g: &mut Graph, ids: &[NodeId], out: &str) -> Result<Option<NodeId>, GraphError> {
+    if ids.is_empty() {
+        return Ok(None);
+    }
+    let mut prev: Option<NodeId> = None;
+    for chunk in ids.chunks(3) {
+        let m = g.add("list.merge")?;
+        let mut pins = ["a", "b", "c", "d"].iter();
+        if let Some(p) = prev {
+            g.connect(p, "out", m, *pins.next().expect("four pins"))?;
+        }
+        for id in chunk {
+            g.connect(*id, out, m, *pins.next().expect("four pins"))?;
+        }
+        prev = Some(m);
+    }
+    Ok(prev)
+}
+
+/// The minimal set of pointers at which `got` differs from `want`.
+pub fn diff(got: &serde_json::Value, want: &serde_json::Value, path: &str, out: &mut Vec<(String, serde_json::Value)>) {
+    if got == want {
+        return;
+    }
+    match (got, want) {
+        (serde_json::Value::Object(a), serde_json::Value::Object(b)) => {
+            if a.keys().any(|k| !b.contains_key(k)) {
+                out.push((path.to_string(), want.clone()));
+                return;
+            }
+            for (k, bv) in b {
+                let sub = format!("{path}/{}", k.replace('~', "~0").replace('/', "~1"));
+                match a.get(k) {
+                    Some(av) => diff(av, bv, &sub, out),
+                    None => out.push((sub, bv.clone())),
+                }
+            }
+        }
+        (serde_json::Value::Array(a), serde_json::Value::Array(b)) if a.len() == b.len() => {
+            for (k, (av, bv)) in a.iter().zip(b).enumerate() {
+                diff(av, bv, &format!("{path}/{k}"), out);
+            }
+        }
+        _ => out.push((path.to_string(), want.clone())),
+    }
+}
+
+/// Lift `d` into a graph whose evaluation reproduces it exactly.
+pub fn from_design(d: &RingDesign, reg: &Registry, lib: &AlphaLibrary) -> Result<Graph, GraphError> {
+    let mut g = Graph::new(&d.name, Mode::SandRing);
+    let profile = g.add("band.profile")?;
+    set_fields(&mut g, profile, reg, &json_of(&d.profile), &[]);
+    let shank = g.add("shank")?;
+    set_fields(&mut g, shank, reg, &json_of(&d.shank), &["head", "head_theta_deg", "head_length_mm"]);
+    let head = g.add("head")?;
+    set_fields(&mut g, head, reg, &json_of(&d.shank.head), &[]);
+    g.connect(head, "head", shank, "head")?;
+    let mut shank_out = shank;
+    for h in &d.shank.extra_heads {
+        let hn = g.add("head")?;
+        set_fields(&mut g, hn, reg, &json_of(h), &[]);
+        let add = g.add("shank.add_head")?;
+        g.connect(shank_out, "shank", add, "shank")?;
+        g.connect(hn, "head", add, "head")?;
+        shank_out = add;
+    }
+    let design = g.add("design.new")?;
+    g.set_input(design, "name", Literal::Text(d.name.clone()))?;
+    g.set_input(design, "size", Literal::Number(d.size.0))?;
+    g.connect(profile, "profile", design, "profile")?;
+    g.connect(shank_out, "shank", design, "shank")?;
+
+    let stack = stack_nodes(&mut g, reg, &d.layers.layers)?;
+    let alphas = alpha_nodes(&mut g, d)?;
+    let merged = merge_chain(&mut g, &alphas, "source")?;
+    let mut last = design;
+    if stack.is_some() || merged.is_some() {
+        let asm = g.add("design.assemble")?;
+        g.connect(design, "design", asm, "design")?;
+        if let Some(st) = stack {
+            g.connect(st, "stack", asm, "stack")?;
+        }
+        if let Some(m) = merged {
+            g.connect(m, "out", asm, "alphas")?;
+        }
+        last = asm;
+    }
+
+    // Evaluate what the nodes express and patch the rest.
+    let report = Evaluator::new().evaluate(&g, reg, lib, 0, Targets::Node(last));
+    if let Some(e) = report.errors.first() {
+        return Err(e.clone());
+    }
+    let got = match report.value(last, "design") {
+        Some(Value::Design(x)) => json_of(&**x),
+        _ => {
+            let notes = report.notes(&g).join("; ");
+            return Err(GraphError::at(last, format!("the lifted nodes did not evaluate: {notes}")));
+        }
+    };
+    let mut want = json_of(d);
+    if let Some(obj) = want.as_object_mut() {
+        obj.remove("graph");
+    }
+    let mut patches = Vec::new();
+    diff(&got, &want, "", &mut patches);
+    if patches.len() > MAX_PATCHES || patches.iter().any(|(p, _)| p.is_empty()) {
+        patches.clear();
+        if let (Some(a), Some(b)) = (got.as_object(), want.as_object()) {
+            for (k, bv) in b {
+                if a.get(k) != Some(bv) {
+                    patches.push((format!("/{k}"), bv.clone()));
+                }
+            }
+        }
+    }
+    for (pointer, value) in patches {
+        let set = g.add("design.set")?;
+        g.connect(last, "design", set, "design")?;
+        g.set_input(set, "pointer", Literal::Text(pointer))?;
+        g.set_input(set, "value", Literal::Json(value))?;
+        last = set;
+    }
+    let out = g.add(OUTPUT_KIND)?;
+    g.connect(last, "design", out, OUTPUT_DESIGN_PIN)?;
+    crate::templates::arrange(&mut g);
+    Ok(g)
+}
+
+/// Every design the lift must reproduce byte for byte, for the tests.
+#[cfg(test)]
+pub fn round_trip(d: &RingDesign, reg: &Registry, lib: &AlphaLibrary) -> Result<(Graph, String, String), GraphError> {
+    let g = from_design(d, reg, lib)?;
+    let out = crate::eval::evaluate_design(&mut Evaluator::new(), &g, reg, lib, 0)?;
+    let mut want = d.clone();
+    want.graph = None;
+    Ok((g, serde_json::to_string(&*out.design).unwrap_or_default(), serde_json::to_string(&want).unwrap_or_default()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_template_lifts_and_evaluates_back_byte_for_byte() {
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::builtin();
+        for t in ringdesign_core::templates::all() {
+            let d = t.design();
+            let (g, got, want) = round_trip(&d, &reg, &lib).unwrap_or_else(|e| panic!("{}: {e}", t.name));
+            assert_eq!(got, want, "{}: the lift does not round-trip", t.name);
+            let patches = g.nodes.iter().filter(|n| n.kind == "design.set").count();
+            assert!(patches <= 4, "{}: {patches} design.set patches — the nodes should carry a template: {:?}", t.name, g.nodes.iter().filter(|n| n.kind == "design.set").map(|n| n.inputs.get("pointer").cloned()).collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn a_design_with_sources_and_odd_fields_still_lifts_exactly() {
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::builtin();
+        let mut d = ringdesign_core::templates::all()[2].design();
+        d.texts.push(ringdesign_core::text::TextAlpha { name: "Motto".into(), text: "ever".into(), font: ringdesign_core::text::TextFont::Script, tracking: 0.1 });
+        d.recipes.push(ringdesign_core::alpha::ProcRecipe { name: "R".into(), repeats: 3, ..Default::default() });
+        d.profile.flange.enabled = true;
+        d.draft.min_draft_deg = 4.5;
+        d.build.theta_steps = 321;
+        if let Layer::Tiling(t) = &mut d.layers.layers[0].layer {
+            t.warp = Some(ringdesign_core::tiling::WarpField { points: vec![[0.0, 0.0], [10.0, 1.0]], strength: 0.5, falloff_mm: 2.0 });
+        }
+        d.layers.layers[0].window = ringdesign_core::Window::except(90.0, 80.0);
+        d.layers.layers[0].remap = Remap::Terrace { steps: 3, span_mm: 0.3, riser: 0.4 };
+        let (g, got, want) = round_trip(&d, &reg, &lib).unwrap();
+        assert_eq!(got, want);
+        let pointers: Vec<String> = g.nodes.iter().filter(|n| n.kind == "design.set").filter_map(|n| n.inputs.get("pointer")).filter_map(|l| if let Literal::Text(s) = l { Some(s.clone()) } else { None }).collect();
+        assert!(pointers.iter().any(|p| p.starts_with("/profile/flange")), "{pointers:?}");
+        assert!(pointers.iter().any(|p| p.contains("warp")), "{pointers:?}");
+        assert!(pointers.iter().any(|p| p.starts_with("/draft")), "{pointers:?}");
+        assert_eq!(g.nodes.iter().filter(|n| n.kind == "alpha.text").count(), 1);
+        assert_eq!(g.nodes.iter().filter(|n| n.kind == "remap.terrace").count(), 1);
+    }
+}

--- a/crates/ringdesign-graph/src/nodes/band.rs
+++ b/crates/ringdesign-graph/src/nodes/band.rs
@@ -80,7 +80,7 @@ fn profile_node() -> NodeSpec {
         },
     )
     .base("profile", ValueKind::Profile, "Start from this section; the default band otherwise.")
-    .extra(PinSpec::select("style", enum_names(ProfileStyle::ALL)).doc("Section family: sets the drop law, crown and edge before the pins below."))
+    .field(PinSpec::select("style", enum_names(ProfileStyle::ALL)).doc("Section family: sets the drop law, crown and edge before the pins below."))
     .field(PinSpec::item("width_mm", ValueKind::Number).widget(Widget::Mm { min: 1.0, max: 25.0 }).doc("Width along the finger, mm."))
     .field(PinSpec::item("thickness_mm", ValueKind::Number).widget(Widget::Mm { min: 0.6, max: 8.0 }).doc("Bore to crest, mm."))
     .field(PinSpec::item("crown_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 6.0 }).doc("How much of the thickness is the dome, mm."))
@@ -91,7 +91,7 @@ fn profile_node() -> NodeSpec {
     .field(PinSpec::item("comfort_fit_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 1.0 }).doc("Comfort-fit bore widening at the edges, mm."))
     .field(PinSpec::item("side_draft_deg", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 30.0 }).doc("Side face draft, degrees."))
     .extra(PinSpec::item("flatten_sides", ValueKind::Bool).widget(Widget::Checkbox).doc("Square the side faces for ornament: zero side draft, small edge fillet."))
-    .hidden(&["style", "flange", "drop_curve", "morph"])
+    .hidden(&["flange", "drop_curve", "morph"])
     .prepare(profile_prepare)
     .finish(profile_finish)
     .build()

--- a/crates/ringdesign-graph/src/nodes/shank.rs
+++ b/crates/ringdesign-graph/src/nodes/shank.rs
@@ -47,6 +47,8 @@ fn shank_node() -> NodeSpec {
     .field(PinSpec::item("amount", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("The modulation's strength, 0..1."))
     .field(PinSpec::item("waves", ValueKind::Int).doc("Waves round the ring for Wave and Twist; an integer, so the joint closes."))
     .field(PinSpec::item("head", ValueKind::Head).doc("The signet head."))
+    .field_at(PinSpec::item("head_theta_deg", ValueKind::Number).widget(Widget::Angle).doc("Where the head sits; 90° is the top."), "/head/theta_deg")
+    .field_at(PinSpec::item("head_length_mm", ValueKind::Number).widget(Widget::Mm { min: 2.0, max: 40.0 }).doc("The face's length along the ring, mm."), "/head/length_mm")
     .hidden(&["extra_heads", "keys", "custom_outlines"])
     .build()
 }

--- a/crates/ringdesign-graph/src/templates.rs
+++ b/crates/ringdesign-graph/src/templates.rs
@@ -1,0 +1,420 @@
+//! The File-menu starters as graphs.
+//!
+//! Each template in `ringdesign_core::templates` is re-expressed here with
+//! the same nodes a user would wire, and the result is committed under
+//! `graphs/templates/` and bundled with `include_str!`. The golden test
+//! evaluates every bundled graph and holds the design it produces to the
+//! code template byte for byte, and holds the committed file to what the
+//! builder produces — so neither the registry nor the files can drift.
+
+use ringdesign_core::profile::TOP_DEG;
+
+use crate::eval::{OUTPUT_DESIGN_PIN, OUTPUT_KIND};
+use crate::graph::{Graph, GraphError, Mode, NodeId};
+use crate::value::Literal;
+
+/// A bundled template graph: the template's name and its file.
+pub struct TemplateGraph {
+    pub name: &'static str,
+    pub slug: &'static str,
+    pub json: &'static str,
+}
+
+macro_rules! bundled {
+    ($($name:literal => $slug:literal),* $(,)?) => {
+        pub static BUNDLED: &[TemplateGraph] = &[$(
+            TemplateGraph { name: $name, slug: $slug, json: include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../graphs/templates/", $slug, ".graph.json")) },
+        )*];
+    };
+}
+
+bundled! {
+    "Court band" => "court-band",
+    "Heart signet" => "heart-signet",
+    "Waved hexagon signet" => "waved-hexagon-signet",
+    "Shouldered cushion signet" => "shouldered-cushion-signet",
+    "Braided band" => "braided-band",
+    "Cathedral solitaire stock" => "cathedral-solitaire-stock",
+    "Wishbone wave" => "wishbone-wave",
+    "Split shank" => "split-shank",
+    "Toi et moi" => "toi-et-moi",
+}
+
+/// The bundled starter graph the editor opens on: size, section, shank,
+/// an empty stack and the output, with the design panel's knobs exposed.
+pub static SIMPLE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../graphs/simple.graph.json"));
+
+/// Every bundled template graph, parsed.
+pub fn all() -> Vec<(&'static str, Graph)> {
+    BUNDLED.iter().map(|t| (t.name, crate::file::load_graph_str(t.json, None).expect("bundled graph parses"))).collect()
+}
+
+pub fn graph(name: &str) -> Option<Graph> {
+    BUNDLED.iter().find(|t| t.name == name).and_then(|t| crate::file::load_graph_str(t.json, None).ok())
+}
+
+pub fn simple() -> Graph {
+    crate::file::load_graph_str(SIMPLE, None).expect("bundled graph parses")
+}
+
+/// The builders the committed files come from.
+pub fn build(name: &str) -> Option<Graph> {
+    let g = match name {
+        "Court band" => court_band(),
+        "Heart signet" => heart_signet(),
+        "Waved hexagon signet" => waved_hexagon_signet(),
+        "Shouldered cushion signet" => shouldered_cushion_signet(),
+        "Braided band" => braided_band(),
+        "Cathedral solitaire stock" => cathedral_solitaire_stock(),
+        "Wishbone wave" => wishbone_wave(),
+        "Split shank" => split_shank(),
+        "Toi et moi" => toi_et_moi(),
+        _ => return None,
+    };
+    Some(g.expect("a template builder wires a valid graph"))
+}
+
+pub fn build_simple() -> Graph {
+    simple_graph().expect("the simple graph wires")
+}
+
+fn set(g: &mut Graph, id: NodeId, pins: &[(&str, Literal)]) -> Result<(), GraphError> {
+    for (k, v) in pins {
+        g.set_input(id, *k, v.clone())?;
+    }
+    Ok(())
+}
+
+fn n(x: f64) -> Literal {
+    Literal::Number(x)
+}
+fn i(x: i64) -> Literal {
+    Literal::Int(x)
+}
+fn t(s: &str) -> Literal {
+    Literal::Text(s.into())
+}
+fn b(x: bool) -> Literal {
+    Literal::Bool(x)
+}
+
+/// A flat-sided band: `templates::squared`.
+fn squared(g: &mut Graph, width: f64, thickness: f64) -> Result<NodeId, GraphError> {
+    let p = g.add("band.profile")?;
+    set(g, p, &[("style", t("Flat")), ("width_mm", n(width)), ("thickness_mm", n(thickness)), ("flatten_sides", b(true))])?;
+    Ok(p)
+}
+
+/// A signet on a squared band: `templates::signet`.
+fn signet(g: &mut Graph, outline: &str, width: f64, thickness: f64) -> Result<(NodeId, NodeId), GraphError> {
+    let p = squared(g, width, thickness)?;
+    let s = g.add("shank.signet")?;
+    set(g, s, &[("band_width_mm", n(width)), ("outline", t(outline))])?;
+    Ok((p, s))
+}
+
+fn design(g: &mut Graph, name: &str, profile: NodeId, shank: Option<NodeId>) -> Result<NodeId, GraphError> {
+    let d = g.add("design.new")?;
+    set(g, d, &[("name", t(name))])?;
+    g.connect(profile, "profile", d, "profile")?;
+    if let Some(s) = shank {
+        g.connect(s, "shank", d, "shank")?;
+    }
+    Ok(d)
+}
+
+/// `templates::side_tiling`: fitted to the side faces with square cells,
+/// at a height, then patched.
+fn side_tiling(g: &mut Graph, design: NodeId, alpha: &str, height: f64, patch: &[(&str, Literal)]) -> Result<NodeId, GraphError> {
+    let fit = g.add("layer.tiling.fit")?;
+    g.connect(design, "design", fit, "design")?;
+    set(g, fit, &[("alpha", t(alpha))])?;
+    let tl = g.add("layer.tiling")?;
+    g.connect(fit, "layer", tl, "layer")?;
+    set(g, tl, &[("height_mm", n(height))])?;
+    set(g, tl, patch)?;
+    Ok(tl)
+}
+
+fn entry(g: &mut Graph, layer: NodeId, name: &str) -> Result<NodeId, GraphError> {
+    let e = g.add("entry")?;
+    g.connect(layer, "layer", e, "layer")?;
+    set(g, e, &[("name", t(name))])?;
+    Ok(e)
+}
+
+/// Entries into a stack, assembled onto the design, and the output.
+fn finish(g: &mut Graph, design: NodeId, entries: &[NodeId]) -> Result<NodeId, GraphError> {
+    let mut last: Option<NodeId> = None;
+    for e in entries {
+        let st = g.add("stack")?;
+        if let Some(prev) = last {
+            g.connect(prev, "stack", st, "stack")?;
+        }
+        g.connect(*e, "entry", st, "entries")?;
+        last = Some(st);
+    }
+    let mut out_design = design;
+    if let Some(st) = last {
+        let asm = g.add("design.assemble")?;
+        g.connect(design, "design", asm, "design")?;
+        g.connect(st, "stack", asm, "stack")?;
+        out_design = asm;
+    }
+    let out = g.add(OUTPUT_KIND)?;
+    g.connect(out_design, "design", out, OUTPUT_DESIGN_PIN)?;
+    Ok(out)
+}
+
+fn court_band() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Court band", Mode::SandRing);
+    let p = g.add("band.profile")?;
+    set(&mut g, p, &[("style", t("LowDome")), ("width_mm", n(4.0)), ("thickness_mm", n(2.0))])?;
+    let d = design(&mut g, "Court band", p, None)?;
+    finish(&mut g, d, &[])?;
+    g.expose(p, "width_mm", "Width")?;
+    g.expose(p, "thickness_mm", "Thickness")?;
+    g.expose(p, "style", "Section")?;
+    Ok(g)
+}
+
+fn heart_signet() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Heart signet", Mode::SandRing);
+    let (p, s) = signet(&mut g, "Heart", 15.5, 1.6)?;
+    let d = design(&mut g, "Heart signet", p, Some(s))?;
+    finish(&mut g, d, &[])?;
+    g.expose(s, "outline", "Outline")?;
+    Ok(g)
+}
+
+fn waved_hexagon_signet() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Waved hexagon signet", Mode::SandRing);
+    let (p, s) = signet(&mut g, "Hexagon", 14.0, 2.6)?;
+    let d = design(&mut g, "Waved hexagon signet", p, Some(s))?;
+    let tl = side_tiling(&mut g, d, "Waves", 0.30, &[("repeats_around", i(6)), ("rows", i(1)), ("contrast", n(1.15))])?;
+    let e = entry(&mut g, tl, "Waves")?;
+    finish(&mut g, d, &[e])?;
+    g.expose(tl, "repeats_around", "Waves around")?;
+    g.expose(tl, "height_mm", "Relief")?;
+    Ok(g)
+}
+
+fn shouldered_cushion_signet() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Shouldered cushion signet", Mode::SandRing);
+    let (p, s) = signet(&mut g, "Cushion", 14.5, 2.2)?;
+    let d = design(&mut g, "Shouldered cushion signet", p, Some(s))?;
+    let tl = side_tiling(&mut g, d, "Chevron", 0.28, &[("repeats_around", i(9)), ("rows", i(1))])?;
+    let e = entry(&mut g, tl, "Shoulder ornament")?;
+    let w = g.add("window")?;
+    set(&mut g, w, &[("theta_deg", n(TOP_DEG)), ("span_deg", n(120.0)), ("invert", b(true))])?;
+    g.connect(w, "window", e, "window")?;
+    finish(&mut g, d, &[e])?;
+    g.expose(w, "span_deg", "Blank table arc")?;
+    Ok(g)
+}
+
+fn braided_band() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Braided band", Mode::SandRing);
+    let p = squared(&mut g, 7.5, 2.4)?;
+    let d = design(&mut g, "Braided band", p, None)?;
+    let tl = side_tiling(&mut g, d, "Braid", 0.30, &[("repeats_around", i(8)), ("rows", i(1))])?;
+    let braid = entry(&mut g, tl, "Braid")?;
+    let info = g.add("design.info")?;
+    g.connect(d, "design", info, "design")?;
+    let half = g.add("math.mul")?;
+    g.connect(info, "band_v_len_mm", half, "a")?;
+    set(&mut g, half, &[("b", n(0.5))])?;
+    let m = g.add("layer.milgrain")?;
+    g.connect(half, "out", m, "v_mm")?;
+    set(&mut g, m, &[("bead_diameter_mm", n(0.5)), ("beads_around", i(130)), ("height_mm", n(0.22)), ("mirror", b(false))])?;
+    let mil = entry(&mut g, m, "Milgrain")?;
+    finish(&mut g, d, &[braid, mil])?;
+    g.expose(m, "beads_around", "Beads around")?;
+    Ok(g)
+}
+
+fn cathedral_solitaire_stock() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Cathedral solitaire stock", Mode::SandRing);
+    let p = g.add("band.profile")?;
+    set(&mut g, p, &[("style", t("DShape")), ("width_mm", n(4.0)), ("thickness_mm", n(2.2))])?;
+    let s = g.add("shank")?;
+    set(&mut g, s, &[("kind", t("Cathedral")), ("amount", n(0.8))])?;
+    let d = design(&mut g, "Cathedral solitaire stock", p, Some(s))?;
+    let info = g.add("design.info")?;
+    g.connect(d, "design", info, "design")?;
+    let half = g.add("math.mul")?;
+    g.connect(info, "band_v_len_mm", half, "a")?;
+    set(&mut g, half, &[("b", n(0.5))])?;
+    let seat = g.add("layer.seat")?;
+    g.connect(half, "out", seat, "v_mm")?;
+    set(
+        &mut g,
+        seat,
+        &[("theta_deg", n(TOP_DEG)), ("height_mm", n(0.9)), ("crown", n(0.35)), ("blend_mm", n(2.2)), ("style", t("GypsyMound")), ("prongs", i(4))],
+    )?;
+    let gem = g.add("gem.calibrated")?;
+    set(&mut g, gem, &[("cut", t("Round")), ("w_mm", n(5.0))])?;
+    let fit = g.add("layer.seat.fit")?;
+    g.connect(seat, "layer", fit, "layer")?;
+    g.connect(gem, "gem", fit, "gem")?;
+    let e = entry(&mut g, fit, "Solitaire seat")?;
+    finish(&mut g, d, &[e])?;
+    g.expose(gem, "w_mm", "Stone")?;
+    g.expose(gem, "cut", "Cut")?;
+    Ok(g)
+}
+
+fn wishbone_wave() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Wishbone wave", Mode::SandRing);
+    let p = g.add("band.profile")?;
+    set(&mut g, p, &[("style", t("DShape")), ("width_mm", n(3.6)), ("thickness_mm", n(1.9))])?;
+    let s = g.add("shank")?;
+    set(&mut g, s, &[("kind", t("Wave")), ("amount", n(0.7)), ("waves", i(1))])?;
+    let d = design(&mut g, "Wishbone wave", p, Some(s))?;
+    finish(&mut g, d, &[])?;
+    g.expose(s, "amount", "Swing")?;
+    Ok(g)
+}
+
+fn split_shank() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Split shank", Mode::SandRing);
+    let p = squared(&mut g, 5.5, 2.0)?;
+    let s = g.add("shank")?;
+    set(&mut g, s, &[("kind", t("Split")), ("amount", n(0.85))])?;
+    let d = design(&mut g, "Split shank", p, Some(s))?;
+    finish(&mut g, d, &[])?;
+    g.expose(s, "amount", "Flare")?;
+    Ok(g)
+}
+
+fn toi_et_moi() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Toi et moi", Mode::SandRing);
+    let (p, s0) = signet(&mut g, "Oval", 12.0, 1.8)?;
+    let s = g.add("shank")?;
+    g.connect(s0, "shank", s, "shank")?;
+    set(&mut g, s, &[("amount", n(0.75)), ("head_theta_deg", n(TOP_DEG - 26.0)), ("head_length_mm", n(8.0))])?;
+    let h = g.add("head")?;
+    set(&mut g, h, &[("outline", t("Heart")), ("theta_deg", n(TOP_DEG + 26.0)), ("length_mm", n(6.5))])?;
+    let s2 = g.add("shank.add_head")?;
+    g.connect(s, "shank", s2, "shank")?;
+    g.connect(h, "head", s2, "head")?;
+    let d = design(&mut g, "Toi et moi", p, Some(s2))?;
+    finish(&mut g, d, &[])?;
+    g.expose(h, "outline", "Second head")?;
+    Ok(g)
+}
+
+fn simple_graph() -> Result<Graph, GraphError> {
+    let mut g = Graph::new("Simple ring", Mode::SandRing);
+    let p = g.add("band.profile")?;
+    set(&mut g, p, &[("style", t("LowDome")), ("width_mm", n(6.0)), ("thickness_mm", n(1.8))])?;
+    let s = g.add("shank")?;
+    set(&mut g, s, &[("kind", t("Uniform")), ("amount", n(0.5))])?;
+    let d = g.add("design.new")?;
+    set(&mut g, d, &[("name", t("Simple ring")), ("size", n(7.0))])?;
+    g.connect(p, "profile", d, "profile")?;
+    g.connect(s, "shank", d, "shank")?;
+    let st = g.add("stack")?;
+    let asm = g.add("design.assemble")?;
+    g.connect(d, "design", asm, "design")?;
+    g.connect(st, "stack", asm, "stack")?;
+    let out = g.add(OUTPUT_KIND)?;
+    g.connect(asm, "design", out, OUTPUT_DESIGN_PIN)?;
+    g.expose(d, "size", "Size")?;
+    g.expose(p, "style", "Section")?;
+    g.expose(p, "width_mm", "Width")?;
+    g.expose(p, "thickness_mm", "Thickness")?;
+    g.expose(s, "kind", "Shank")?;
+    g.expose(s, "amount", "Shank amount")?;
+    g.expose(d, "name", "Name")?;
+    for (k, id) in [(p, 0.0f32), (s, 1.0), (d, 2.0), (st, 2.0), (asm, 3.0), (out, 4.0)].iter().map(|(id, col)| (*col, *id)) {
+        g.node_mut(id).expect("just added").pos = [k * 220.0, if id == st { 160.0 } else { 0.0 }];
+    }
+    Ok(g)
+}
+
+/// Tidy positions for a freshly built template: one column per node,
+/// topologically, so the committed file opens readable.
+pub fn arrange(g: &mut Graph) {
+    if let Ok(order) = g.topo() {
+        let mut depth: std::collections::BTreeMap<NodeId, usize> = std::collections::BTreeMap::new();
+        for id in &order {
+            let d = g.wires_into(*id).filter_map(|w| depth.get(&w.from)).max().map(|m| m + 1).unwrap_or(0);
+            depth.insert(*id, d);
+        }
+        let mut rows: std::collections::BTreeMap<usize, usize> = std::collections::BTreeMap::new();
+        for id in &order {
+            let col = depth[id];
+            let row = rows.entry(col).or_insert(0);
+            if let Some(node) = g.node_mut(*id) {
+                node.pos = [col as f32 * 240.0, *row as f32 * 150.0];
+            }
+            *row += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{Evaluator, evaluate_design};
+    use crate::registry::Registry;
+    use ringdesign_core::AlphaLibrary;
+    use ringdesign_core::castability::Verdict;
+
+    fn repo_graphs() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../graphs")
+    }
+
+    /// `RD_WRITE_TEMPLATE_GRAPHS=1 cargo test -p ringdesign-graph write_template_graphs`
+    /// rewrites the committed files from the builders.
+    #[test]
+    fn write_template_graphs() {
+        if std::env::var_os("RD_WRITE_TEMPLATE_GRAPHS").is_none() {
+            return;
+        }
+        let dir = repo_graphs();
+        std::fs::create_dir_all(dir.join("templates")).unwrap();
+        for t in BUNDLED {
+            let mut g = build(t.name).unwrap();
+            arrange(&mut g);
+            std::fs::write(dir.join("templates").join(format!("{}.graph.json", t.slug)), crate::file::graph_to_string(&g).unwrap()).unwrap();
+        }
+        let mut s = build_simple();
+        arrange(&mut s);
+        std::fs::write(dir.join("simple.graph.json"), crate::file::graph_to_string(&s).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn every_bundled_graph_equals_its_builder_and_its_code_template_byte_for_byte() {
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::builtin();
+        let code: Vec<_> = ringdesign_core::templates::all().iter().collect();
+        assert_eq!(BUNDLED.len(), code.len(), "every code template has a graph");
+        for t in BUNDLED {
+            let bundled = crate::file::load_graph_str(t.json, Some(&reg)).unwrap_or_else(|e| panic!("{}: {e}", t.name));
+            let mut built = build(t.name).unwrap();
+            arrange(&mut built);
+            assert_eq!(bundled, built, "{}: the committed file has drifted from its builder — rerun with RD_WRITE_TEMPLATE_GRAPHS=1", t.name);
+            assert!(bundled.validate(Some(&reg)).is_empty(), "{}: {:?}", t.name, bundled.validate(Some(&reg)));
+            let out = evaluate_design(&mut Evaluator::new(), &bundled, &reg, &lib, 0).unwrap_or_else(|e| panic!("{}: {e}", t.name));
+            assert!(out.notes.is_empty(), "{}: {:?}", t.name, out.notes);
+            let want = code.iter().find(|c| c.name == t.name).unwrap_or_else(|| panic!("{} is not a code template", t.name)).design();
+            let got = serde_json::to_string(&*out.design).unwrap();
+            let expect = serde_json::to_string(&want).unwrap();
+            if got != expect {
+                let g: serde_json::Value = serde_json::from_str(&got).unwrap();
+                let e: serde_json::Value = serde_json::from_str(&expect).unwrap();
+                let mut diffs = Vec::new();
+                crate::lift::diff(&g, &e, "", &mut diffs);
+                panic!("{}: the graph's design differs from the code template at {:?}", t.name, diffs.iter().map(|(p, v)| format!("{p} -> {v}")).collect::<Vec<_>>());
+            }
+            assert_ne!(out.field.verdict, Verdict::NotCastable, "{}: {:?}", t.name, out.field.notes);
+        }
+        let simple = simple();
+        assert!(simple.validate(Some(&reg)).is_empty());
+        let out = evaluate_design(&mut Evaluator::new(), &simple, &reg, &lib, 0).unwrap();
+        assert_eq!(out.design.name, "Simple ring");
+        assert_eq!(simple.exposed.len(), 7);
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,7 +98,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - [x] **M2.6 Files, ladder, clusters, presets** (M, #17). `*.graph.json`, `*.cluster.json`,
   `*.preset.json` with a migration ladder like the design's; cluster nodes with exposed
   parameters; presets as parameter sets; user-dir resolution.
-- [ ] **M2.7 Design field, template graphs, golden tests** (M, #18). `RingDesign.graph`; every
+- [x] **M2.7 Design field, template graphs, golden tests** (M, #18). `RingDesign.graph`; every
   template re-expressed as a committed graph whose evaluation equals the code template
   byte-for-byte and fields castable; `Graph::from_design` round-trips every template.
 

--- a/graphs/simple.graph.json
+++ b/graphs/simple.graph.json
@@ -1,0 +1,138 @@
+{
+  "format_version": 1,
+  "name": "Simple ring",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "style": "LowDome",
+        "thickness_mm": 1.8,
+        "width_mm": 6.0
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank",
+      "inputs": {
+        "amount": 0.5,
+        "kind": "Uniform"
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Simple ring",
+        "size": 7.0
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "stack",
+      "pos": [
+        0.0,
+        300.0
+      ]
+    },
+    {
+      "id": 5,
+      "kind": "design.assemble",
+      "pos": [
+        480.0,
+        0.0
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "sink.output",
+      "pos": [
+        720.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 3,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 5,
+      "input": "design"
+    },
+    {
+      "from": 4,
+      "out": "stack",
+      "to": 5,
+      "input": "stack"
+    },
+    {
+      "from": 5,
+      "out": "design",
+      "to": 6,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 3,
+      "input": "size",
+      "name": "Size"
+    },
+    {
+      "node": 1,
+      "input": "style",
+      "name": "Section"
+    },
+    {
+      "node": 1,
+      "input": "width_mm",
+      "name": "Width"
+    },
+    {
+      "node": 1,
+      "input": "thickness_mm",
+      "name": "Thickness"
+    },
+    {
+      "node": 2,
+      "input": "kind",
+      "name": "Shank"
+    },
+    {
+      "node": 2,
+      "input": "amount",
+      "name": "Shank amount"
+    },
+    {
+      "node": 3,
+      "input": "name",
+      "name": "Name"
+    }
+  ],
+  "next_id": 7
+}

--- a/graphs/templates/braided-band.graph.json
+++ b/graphs/templates/braided-band.graph.json
@@ -1,0 +1,237 @@
+{
+  "format_version": 1,
+  "name": "Braided band",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "flatten_sides": true,
+        "style": "Flat",
+        "thickness_mm": 2.4,
+        "width_mm": 7.5
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Braided band"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "layer.tiling.fit",
+      "inputs": {
+        "alpha": "Braid"
+      },
+      "pos": [
+        480.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "layer.tiling",
+      "inputs": {
+        "height_mm": 0.3,
+        "repeats_around": 8,
+        "rows": 1
+      },
+      "pos": [
+        720.0,
+        0.0
+      ]
+    },
+    {
+      "id": 5,
+      "kind": "entry",
+      "inputs": {
+        "name": "Braid"
+      },
+      "pos": [
+        960.0,
+        0.0
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "design.info",
+      "pos": [
+        480.0,
+        150.0
+      ]
+    },
+    {
+      "id": 7,
+      "kind": "math.mul",
+      "inputs": {
+        "b": 0.5
+      },
+      "pos": [
+        720.0,
+        150.0
+      ]
+    },
+    {
+      "id": 8,
+      "kind": "layer.milgrain",
+      "inputs": {
+        "bead_diameter_mm": 0.5,
+        "beads_around": 130,
+        "height_mm": 0.22,
+        "mirror": false
+      },
+      "pos": [
+        960.0,
+        150.0
+      ]
+    },
+    {
+      "id": 9,
+      "kind": "entry",
+      "inputs": {
+        "name": "Milgrain"
+      },
+      "pos": [
+        1200.0,
+        0.0
+      ]
+    },
+    {
+      "id": 10,
+      "kind": "stack",
+      "pos": [
+        1200.0,
+        150.0
+      ]
+    },
+    {
+      "id": 11,
+      "kind": "stack",
+      "pos": [
+        1440.0,
+        0.0
+      ]
+    },
+    {
+      "id": 12,
+      "kind": "design.assemble",
+      "pos": [
+        1680.0,
+        0.0
+      ]
+    },
+    {
+      "id": 13,
+      "kind": "sink.output",
+      "pos": [
+        1920.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 2,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "design",
+      "to": 3,
+      "input": "design"
+    },
+    {
+      "from": 3,
+      "out": "layer",
+      "to": 4,
+      "input": "layer"
+    },
+    {
+      "from": 4,
+      "out": "layer",
+      "to": 5,
+      "input": "layer"
+    },
+    {
+      "from": 2,
+      "out": "design",
+      "to": 6,
+      "input": "design"
+    },
+    {
+      "from": 6,
+      "out": "band_v_len_mm",
+      "to": 7,
+      "input": "a"
+    },
+    {
+      "from": 7,
+      "out": "out",
+      "to": 8,
+      "input": "v_mm"
+    },
+    {
+      "from": 8,
+      "out": "layer",
+      "to": 9,
+      "input": "layer"
+    },
+    {
+      "from": 5,
+      "out": "entry",
+      "to": 10,
+      "input": "entries"
+    },
+    {
+      "from": 10,
+      "out": "stack",
+      "to": 11,
+      "input": "stack"
+    },
+    {
+      "from": 9,
+      "out": "entry",
+      "to": 11,
+      "input": "entries"
+    },
+    {
+      "from": 2,
+      "out": "design",
+      "to": 12,
+      "input": "design"
+    },
+    {
+      "from": 11,
+      "out": "stack",
+      "to": 12,
+      "input": "stack"
+    },
+    {
+      "from": 12,
+      "out": "design",
+      "to": 13,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 8,
+      "input": "beads_around",
+      "name": "Beads around"
+    }
+  ],
+  "next_id": 14
+}

--- a/graphs/templates/cathedral-solitaire-stock.graph.json
+++ b/graphs/templates/cathedral-solitaire-stock.graph.json
@@ -1,0 +1,220 @@
+{
+  "format_version": 1,
+  "name": "Cathedral solitaire stock",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "style": "DShape",
+        "thickness_mm": 2.2,
+        "width_mm": 4.0
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank",
+      "inputs": {
+        "amount": 0.8,
+        "kind": "Cathedral"
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Cathedral solitaire stock"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "design.info",
+      "pos": [
+        480.0,
+        0.0
+      ]
+    },
+    {
+      "id": 5,
+      "kind": "math.mul",
+      "inputs": {
+        "b": 0.5
+      },
+      "pos": [
+        720.0,
+        0.0
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "layer.seat",
+      "inputs": {
+        "blend_mm": 2.2,
+        "crown": 0.35,
+        "height_mm": 0.9,
+        "prongs": 4,
+        "style": "GypsyMound",
+        "theta_deg": 90.0
+      },
+      "pos": [
+        960.0,
+        0.0
+      ]
+    },
+    {
+      "id": 7,
+      "kind": "gem.calibrated",
+      "inputs": {
+        "cut": "Round",
+        "w_mm": 5.0
+      },
+      "pos": [
+        0.0,
+        300.0
+      ]
+    },
+    {
+      "id": 8,
+      "kind": "layer.seat.fit",
+      "pos": [
+        1200.0,
+        0.0
+      ]
+    },
+    {
+      "id": 9,
+      "kind": "entry",
+      "inputs": {
+        "name": "Solitaire seat"
+      },
+      "pos": [
+        1440.0,
+        0.0
+      ]
+    },
+    {
+      "id": 10,
+      "kind": "stack",
+      "pos": [
+        1680.0,
+        0.0
+      ]
+    },
+    {
+      "id": 11,
+      "kind": "design.assemble",
+      "pos": [
+        1920.0,
+        0.0
+      ]
+    },
+    {
+      "id": 12,
+      "kind": "sink.output",
+      "pos": [
+        2160.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 3,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 4,
+      "input": "design"
+    },
+    {
+      "from": 4,
+      "out": "band_v_len_mm",
+      "to": 5,
+      "input": "a"
+    },
+    {
+      "from": 5,
+      "out": "out",
+      "to": 6,
+      "input": "v_mm"
+    },
+    {
+      "from": 6,
+      "out": "layer",
+      "to": 8,
+      "input": "layer"
+    },
+    {
+      "from": 7,
+      "out": "gem",
+      "to": 8,
+      "input": "gem"
+    },
+    {
+      "from": 8,
+      "out": "layer",
+      "to": 9,
+      "input": "layer"
+    },
+    {
+      "from": 9,
+      "out": "entry",
+      "to": 10,
+      "input": "entries"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 11,
+      "input": "design"
+    },
+    {
+      "from": 10,
+      "out": "stack",
+      "to": 11,
+      "input": "stack"
+    },
+    {
+      "from": 11,
+      "out": "design",
+      "to": 12,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 7,
+      "input": "w_mm",
+      "name": "Stone"
+    },
+    {
+      "node": 7,
+      "input": "cut",
+      "name": "Cut"
+    }
+  ],
+  "next_id": 13
+}

--- a/graphs/templates/court-band.graph.json
+++ b/graphs/templates/court-band.graph.json
@@ -1,0 +1,71 @@
+{
+  "format_version": 1,
+  "name": "Court band",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "style": "LowDome",
+        "thickness_mm": 2.0,
+        "width_mm": 4.0
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Court band"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "sink.output",
+      "pos": [
+        480.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 2,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "design",
+      "to": 3,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 1,
+      "input": "width_mm",
+      "name": "Width"
+    },
+    {
+      "node": 1,
+      "input": "thickness_mm",
+      "name": "Thickness"
+    },
+    {
+      "node": 1,
+      "input": "style",
+      "name": "Section"
+    }
+  ],
+  "next_id": 4
+}

--- a/graphs/templates/heart-signet.graph.json
+++ b/graphs/templates/heart-signet.graph.json
@@ -1,0 +1,80 @@
+{
+  "format_version": 1,
+  "name": "Heart signet",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "flatten_sides": true,
+        "style": "Flat",
+        "thickness_mm": 1.6,
+        "width_mm": 15.5
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank.signet",
+      "inputs": {
+        "band_width_mm": 15.5,
+        "outline": "Heart"
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Heart signet"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "sink.output",
+      "pos": [
+        480.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 3,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 4,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 2,
+      "input": "outline",
+      "name": "Outline"
+    }
+  ],
+  "next_id": 5
+}

--- a/graphs/templates/shouldered-cushion-signet.graph.json
+++ b/graphs/templates/shouldered-cushion-signet.graph.json
@@ -1,0 +1,186 @@
+{
+  "format_version": 1,
+  "name": "Shouldered cushion signet",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "flatten_sides": true,
+        "style": "Flat",
+        "thickness_mm": 2.2,
+        "width_mm": 14.5
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank.signet",
+      "inputs": {
+        "band_width_mm": 14.5,
+        "outline": "Cushion"
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Shouldered cushion signet"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "layer.tiling.fit",
+      "inputs": {
+        "alpha": "Chevron"
+      },
+      "pos": [
+        480.0,
+        0.0
+      ]
+    },
+    {
+      "id": 5,
+      "kind": "layer.tiling",
+      "inputs": {
+        "height_mm": 0.28,
+        "repeats_around": 9,
+        "rows": 1
+      },
+      "pos": [
+        720.0,
+        0.0
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "entry",
+      "inputs": {
+        "name": "Shoulder ornament"
+      },
+      "pos": [
+        960.0,
+        0.0
+      ]
+    },
+    {
+      "id": 7,
+      "kind": "window",
+      "inputs": {
+        "invert": true,
+        "span_deg": 120.0,
+        "theta_deg": 90.0
+      },
+      "pos": [
+        0.0,
+        300.0
+      ]
+    },
+    {
+      "id": 8,
+      "kind": "stack",
+      "pos": [
+        1200.0,
+        0.0
+      ]
+    },
+    {
+      "id": 9,
+      "kind": "design.assemble",
+      "pos": [
+        1440.0,
+        0.0
+      ]
+    },
+    {
+      "id": 10,
+      "kind": "sink.output",
+      "pos": [
+        1680.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 3,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 4,
+      "input": "design"
+    },
+    {
+      "from": 4,
+      "out": "layer",
+      "to": 5,
+      "input": "layer"
+    },
+    {
+      "from": 5,
+      "out": "layer",
+      "to": 6,
+      "input": "layer"
+    },
+    {
+      "from": 7,
+      "out": "window",
+      "to": 6,
+      "input": "window"
+    },
+    {
+      "from": 6,
+      "out": "entry",
+      "to": 8,
+      "input": "entries"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 9,
+      "input": "design"
+    },
+    {
+      "from": 8,
+      "out": "stack",
+      "to": 9,
+      "input": "stack"
+    },
+    {
+      "from": 9,
+      "out": "design",
+      "to": 10,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 7,
+      "input": "span_deg",
+      "name": "Blank table arc"
+    }
+  ],
+  "next_id": 11
+}

--- a/graphs/templates/split-shank.graph.json
+++ b/graphs/templates/split-shank.graph.json
@@ -1,0 +1,80 @@
+{
+  "format_version": 1,
+  "name": "Split shank",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "flatten_sides": true,
+        "style": "Flat",
+        "thickness_mm": 2.0,
+        "width_mm": 5.5
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank",
+      "inputs": {
+        "amount": 0.85,
+        "kind": "Split"
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Split shank"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "sink.output",
+      "pos": [
+        480.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 3,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 4,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 2,
+      "input": "amount",
+      "name": "Flare"
+    }
+  ],
+  "next_id": 5
+}

--- a/graphs/templates/toi-et-moi.graph.json
+++ b/graphs/templates/toi-et-moi.graph.json
@@ -1,0 +1,132 @@
+{
+  "format_version": 1,
+  "name": "Toi et moi",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "flatten_sides": true,
+        "style": "Flat",
+        "thickness_mm": 1.8,
+        "width_mm": 12.0
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank.signet",
+      "inputs": {
+        "band_width_mm": 12.0,
+        "outline": "Oval"
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "shank",
+      "inputs": {
+        "amount": 0.75,
+        "head_length_mm": 8.0,
+        "head_theta_deg": 64.0
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "head",
+      "inputs": {
+        "length_mm": 6.5,
+        "outline": "Heart",
+        "theta_deg": 116.0
+      },
+      "pos": [
+        0.0,
+        300.0
+      ]
+    },
+    {
+      "id": 5,
+      "kind": "shank.add_head",
+      "pos": [
+        480.0,
+        0.0
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Toi et moi"
+      },
+      "pos": [
+        720.0,
+        0.0
+      ]
+    },
+    {
+      "id": 7,
+      "kind": "sink.output",
+      "pos": [
+        960.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "shank",
+      "to": 5,
+      "input": "shank"
+    },
+    {
+      "from": 4,
+      "out": "head",
+      "to": 5,
+      "input": "head"
+    },
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 6,
+      "input": "profile"
+    },
+    {
+      "from": 5,
+      "out": "shank",
+      "to": 6,
+      "input": "shank"
+    },
+    {
+      "from": 6,
+      "out": "design",
+      "to": 7,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 4,
+      "input": "outline",
+      "name": "Second head"
+    }
+  ],
+  "next_id": 8
+}

--- a/graphs/templates/waved-hexagon-signet.graph.json
+++ b/graphs/templates/waved-hexagon-signet.graph.json
@@ -1,0 +1,173 @@
+{
+  "format_version": 1,
+  "name": "Waved hexagon signet",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "flatten_sides": true,
+        "style": "Flat",
+        "thickness_mm": 2.6,
+        "width_mm": 14.0
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank.signet",
+      "inputs": {
+        "band_width_mm": 14.0,
+        "outline": "Hexagon"
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Waved hexagon signet"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "layer.tiling.fit",
+      "inputs": {
+        "alpha": "Waves"
+      },
+      "pos": [
+        480.0,
+        0.0
+      ]
+    },
+    {
+      "id": 5,
+      "kind": "layer.tiling",
+      "inputs": {
+        "contrast": 1.15,
+        "height_mm": 0.3,
+        "repeats_around": 6,
+        "rows": 1
+      },
+      "pos": [
+        720.0,
+        0.0
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "entry",
+      "inputs": {
+        "name": "Waves"
+      },
+      "pos": [
+        960.0,
+        0.0
+      ]
+    },
+    {
+      "id": 7,
+      "kind": "stack",
+      "pos": [
+        1200.0,
+        0.0
+      ]
+    },
+    {
+      "id": 8,
+      "kind": "design.assemble",
+      "pos": [
+        1440.0,
+        0.0
+      ]
+    },
+    {
+      "id": 9,
+      "kind": "sink.output",
+      "pos": [
+        1680.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 3,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 4,
+      "input": "design"
+    },
+    {
+      "from": 4,
+      "out": "layer",
+      "to": 5,
+      "input": "layer"
+    },
+    {
+      "from": 5,
+      "out": "layer",
+      "to": 6,
+      "input": "layer"
+    },
+    {
+      "from": 6,
+      "out": "entry",
+      "to": 7,
+      "input": "entries"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 8,
+      "input": "design"
+    },
+    {
+      "from": 7,
+      "out": "stack",
+      "to": 8,
+      "input": "stack"
+    },
+    {
+      "from": 8,
+      "out": "design",
+      "to": 9,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 5,
+      "input": "repeats_around",
+      "name": "Waves around"
+    },
+    {
+      "node": 5,
+      "input": "height_mm",
+      "name": "Relief"
+    }
+  ],
+  "next_id": 10
+}

--- a/graphs/templates/wishbone-wave.graph.json
+++ b/graphs/templates/wishbone-wave.graph.json
@@ -1,0 +1,80 @@
+{
+  "format_version": 1,
+  "name": "Wishbone wave",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "band.profile",
+      "inputs": {
+        "style": "DShape",
+        "thickness_mm": 1.9,
+        "width_mm": 3.6
+      },
+      "pos": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "shank",
+      "inputs": {
+        "amount": 0.7,
+        "kind": "Wave",
+        "waves": 1
+      },
+      "pos": [
+        0.0,
+        150.0
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "design.new",
+      "inputs": {
+        "name": "Wishbone wave"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 4,
+      "kind": "sink.output",
+      "pos": [
+        480.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "profile",
+      "to": 3,
+      "input": "profile"
+    },
+    {
+      "from": 2,
+      "out": "shank",
+      "to": 3,
+      "input": "shank"
+    },
+    {
+      "from": 3,
+      "out": "design",
+      "to": 4,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 2,
+      "input": "amount",
+      "name": "Swing"
+    }
+  ],
+  "next_id": 5
+}


### PR DESCRIPTION
## Summary
- `RingDesign::graph` (serde default, no ladder bump).
- `templates.rs`: the nine starters as graph builders; committed `graphs/templates/*.graph.json` + `graphs/simple.graph.json` generated from them and bundled; golden test: file == builder, evaluation == code template byte-for-byte, castable.
- `lift.rs`: `Graph::from_design` — nodes for everything expressible, `design.set` patches for the residue found by diffing the evaluated result; every template round-trips exactly with ≤ 4 patches.
- `band.profile.style` is a field pin; `shank` gains `head_theta_deg`/`head_length_mm`.
- CLAUDE.md: what the runtime settled during M2.

## Verification
- `cargo test --workspace` green; graph crate 59 tests.
- wasm check passes.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)