### PR TITLE
M3.2 Editor core: NodeCard, build/extract, pin widgets, palette

### DIFF
--- a/crates/ringdesign-graph-ui/src/editor.rs
+++ b/crates/ringdesign-graph-ui/src/editor.rs
@@ -1,1 +1,589 @@
 //! The editor widget: build a snarl from the graph, show it, extract it back.
+//!
+//! [`Editor`] owns a [`Graph`] and the `Snarl` that views it. The snarl is
+//! rebuilt whenever the graph is replaced from outside ([`Editor::set_graph`])
+//! and extracted after every frame it is shown; when what comes back differs
+//! from what went in, the graph is updated and the revision moves. Nodes
+//! added in the view carry no id until extraction hands them a fresh one.
+
+use std::collections::BTreeMap;
+
+use egui::{Color32, RichText, Ui};
+use egui_snarl::ui::{PinInfo, SnarlStyle, SnarlViewer};
+use egui_snarl::{InPin, InPinId, NodeId as SnarlId, OutPin, OutPinId, Snarl};
+use ringdesign_graph::graph::{Access, Graph, GraphError, Node, NodeId, Wire};
+use ringdesign_graph::registry::{Category, NodeSpec, PinSpec, Registry};
+use ringdesign_graph::value::{Literal, ValueKind};
+
+use crate::widgets::{kind_color, pin_widget};
+
+/// A node as the view holds it: the graph's data plus the pins resolved
+/// from the registry, so drawing needs no registry at all.
+#[derive(Clone, Debug)]
+pub struct NodeCard {
+    /// The graph id; 0 until extraction assigns one.
+    pub id: u64,
+    pub kind: String,
+    pub label: Option<String>,
+    pub title: String,
+    pub params: serde_json::Value,
+    pub inputs: BTreeMap<String, Literal>,
+    pub pins_in: Vec<PinSpec>,
+    pub pins_out: Vec<PinSpec>,
+    pub doc: String,
+    /// Errors and per-item failures attributed to this node.
+    pub diag: Vec<String>,
+    /// Output value summaries from the last evaluation, by pin.
+    pub values: BTreeMap<String, String>,
+}
+
+impl NodeCard {
+    pub fn from_node(node: &Node, reg: &Registry) -> Self {
+        let spec = reg.get(&node.kind);
+        let (pins_in, pins_out) = reg.node_pins(node).unwrap_or_default();
+        Self {
+            id: node.id.0,
+            kind: node.kind.clone(),
+            label: node.label.clone(),
+            title: node.label.clone().unwrap_or_else(|| spec.map(|s| s.label.clone()).unwrap_or_else(|| node.kind.clone())),
+            params: node.params.clone(),
+            inputs: node.inputs.clone(),
+            pins_in,
+            pins_out,
+            doc: spec.map(|s| s.doc.clone()).unwrap_or_default(),
+            diag: Vec::new(),
+            values: BTreeMap::new(),
+        }
+    }
+
+    /// A fresh card for a kind picked from the palette.
+    pub fn new_of(spec: &NodeSpec, reg: &Registry) -> Self {
+        let node = Node { id: NodeId(0), kind: spec.key.clone(), params: serde_json::Value::Null, inputs: BTreeMap::new(), pos: [0.0; 2], label: None };
+        Self::from_node(&node, reg)
+    }
+
+    pub fn graph_id(&self) -> Option<NodeId> {
+        (self.id != 0).then_some(NodeId(self.id))
+    }
+
+    fn to_node(&self, id: NodeId, pos: egui::Pos2) -> Node {
+        Node { id, kind: self.kind.clone(), params: self.params.clone(), inputs: self.inputs.clone(), pos: [pos.x.round(), pos.y.round()], label: self.label.clone() }
+    }
+}
+
+/// Graph ids to snarl ids and back, for one snarl.
+#[derive(Clone, Debug, Default)]
+pub struct IdMap {
+    pub to_snarl: BTreeMap<NodeId, SnarlId>,
+    pub to_graph: BTreeMap<SnarlId, NodeId>,
+}
+
+/// A snarl viewing `g`, pins resolved through `reg`.
+pub fn build_snarl(g: &Graph, reg: &Registry) -> (Snarl<NodeCard>, IdMap) {
+    let mut snarl = Snarl::new();
+    let mut ids = IdMap::default();
+    for n in &g.nodes {
+        let sid = snarl.insert_node(egui::pos2(n.pos[0], n.pos[1]), NodeCard::from_node(n, reg));
+        ids.to_snarl.insert(n.id, sid);
+        ids.to_graph.insert(sid, n.id);
+    }
+    for w in &g.wires {
+        let (Some(&from), Some(&to)) = (ids.to_snarl.get(&w.from), ids.to_snarl.get(&w.to)) else { continue };
+        let out = snarl.get_node(from).and_then(|c| c.pins_out.iter().position(|p| p.name == w.out));
+        let inp = snarl.get_node(to).and_then(|c| c.pins_in.iter().position(|p| p.name == w.input));
+        if let (Some(output), Some(input)) = (out, inp) {
+            snarl.connect(OutPinId { node: from, output }, InPinId { node: to, input });
+        }
+    }
+    (snarl, ids)
+}
+
+/// The graph the snarl shows, with `template` supplying everything that is
+/// not a node or a wire (name, mode, exposures, the id counter). Nodes
+/// without an id get fresh ones; exposures of nodes no longer present drop.
+pub fn extract_graph(snarl: &Snarl<NodeCard>, template: &Graph) -> Graph {
+    let mut g = Graph::new(&template.name, template.mode);
+    g.next_id = template.next_id.max(template.nodes.iter().map(|n| n.id.0 + 1).max().unwrap_or(1));
+    let mut by_snarl: BTreeMap<SnarlId, NodeId> = BTreeMap::new();
+    let mut nodes: Vec<(NodeId, Node)> = Vec::new();
+    let mut fresh: Vec<(SnarlId, egui::Pos2, NodeCard)> = Vec::new();
+    for (sid, pos, card) in snarl.nodes_pos_ids() {
+        match card.graph_id() {
+            Some(id) => {
+                by_snarl.insert(sid, id);
+                nodes.push((id, card.to_node(id, pos)));
+            }
+            None => fresh.push((sid, pos, card.clone())),
+        }
+    }
+    nodes.sort_by_key(|(id, _)| *id);
+    fresh.sort_by_key(|(sid, _, _)| sid.0);
+    for (sid, pos, card) in fresh {
+        let id = NodeId(g.next_id);
+        g.next_id += 1;
+        by_snarl.insert(sid, id);
+        nodes.push((id, card.to_node(id, pos)));
+    }
+    g.nodes = nodes.into_iter().map(|(_, n)| n).collect();
+    let mut present: Vec<Wire> = snarl
+        .wires()
+        .filter_map(|(out, inp)| {
+            let from = *by_snarl.get(&out.node)?;
+            let to = *by_snarl.get(&inp.node)?;
+            let out_name = snarl.get_node(out.node)?.pins_out.get(out.output)?.name.clone();
+            let in_name = snarl.get_node(inp.node)?.pins_in.get(inp.input)?.name.clone();
+            Some(Wire { from, out: out_name, to, input: in_name })
+        })
+        .collect();
+    // The template's order for wires that survive, new ones after, sorted:
+    // a view must not invent a revision by reordering what it was given.
+    let mut wires: Vec<Wire> = Vec::with_capacity(present.len());
+    for w in &template.wires {
+        if let Some(i) = present.iter().position(|p| p == w) {
+            wires.push(present.remove(i));
+        }
+    }
+    present.sort_by(|a, b| (a.to, &a.input, a.from, &a.out).cmp(&(b.to, &b.input, b.from, &b.out)));
+    wires.extend(present);
+    g.wires = wires;
+    let live: std::collections::BTreeSet<NodeId> = g.nodes.iter().map(|n| n.id).collect();
+    g.exposed = template.exposed.iter().filter(|e| live.contains(&e.node)).cloned().collect();
+    g.outputs = template.outputs.iter().filter(|e| live.contains(&e.node)).cloned().collect();
+    g
+}
+
+/// What one frame of the editor reported.
+#[derive(Clone, Debug, Default)]
+pub struct EditorResponse {
+    /// The graph changed this frame.
+    pub changed: bool,
+    /// The node under the last click, if any.
+    pub selected: Option<NodeId>,
+    /// A wire the editor refused, in words.
+    pub refused: Option<String>,
+}
+
+/// The editor: a graph, its snarl, and the bookkeeping between them.
+pub struct Editor {
+    graph: Graph,
+    snarl: Snarl<NodeCard>,
+    ids: IdMap,
+    /// Moves whenever the graph changes through the editor or set_graph.
+    pub revision: u64,
+    pub selected: Option<NodeId>,
+    pub editable: bool,
+    style: SnarlStyle,
+}
+
+impl Editor {
+    pub fn new(graph: Graph, reg: &Registry) -> Self {
+        let (snarl, ids) = build_snarl(&graph, reg);
+        Self { graph, snarl, ids, revision: 0, selected: None, editable: true, style: SnarlStyle::new() }
+    }
+
+    pub fn graph(&self) -> &Graph {
+        &self.graph
+    }
+
+    pub fn snarl(&self) -> &Snarl<NodeCard> {
+        &self.snarl
+    }
+
+    /// Replace the graph from outside (a file, history, MCP) and rebuild the view.
+    pub fn set_graph(&mut self, graph: Graph, reg: &Registry) {
+        let (snarl, ids) = build_snarl(&graph, reg);
+        self.graph = graph;
+        self.snarl = snarl;
+        self.ids = ids;
+        self.revision += 1;
+        if let Some(sel) = self.selected {
+            if !self.graph.contains(sel) {
+                self.selected = None;
+            }
+        }
+    }
+
+    /// Re-resolve pins (the registry changed) without losing the view.
+    pub fn refresh(&mut self, reg: &Registry) {
+        let graph = self.graph.clone();
+        self.set_graph(graph, reg);
+    }
+
+    /// Attach diagnostics to the cards they name.
+    pub fn set_diagnostics(&mut self, errors: &[GraphError], per_node: &BTreeMap<NodeId, Vec<String>>) {
+        for (sid, card) in self.snarl.nodes_ids_mut() {
+            card.diag.clear();
+            if let Some(gid) = self.ids.to_graph.get(&sid) {
+                card.diag.extend(errors.iter().filter(|e| e.node == Some(*gid)).map(|e| e.message.clone()));
+                if let Some(lines) = per_node.get(gid) {
+                    card.diag.extend(lines.iter().cloned());
+                }
+            }
+        }
+    }
+
+    /// Attach output value summaries for badges.
+    pub fn set_values(&mut self, values: &BTreeMap<NodeId, BTreeMap<String, String>>) {
+        for (sid, card) in self.snarl.nodes_ids_mut() {
+            card.values.clear();
+            if let Some(v) = self.ids.to_graph.get(&sid).and_then(|gid| values.get(gid)) {
+                card.values = v.clone();
+            }
+        }
+    }
+
+    /// Draw the editor and extract any change.
+    pub fn show(&mut self, reg: &Registry, ui: &mut Ui, id_salt: &str) -> EditorResponse {
+        let mut viewer = Viewer { reg, editable: self.editable, clicked: None, refused: None, search: String::new(), ids: &self.ids };
+        self.snarl.show(&mut viewer, &self.style, id_salt, ui);
+        let clicked = viewer.clicked;
+        let refused = viewer.refused.take();
+        let mut resp = EditorResponse { refused, ..Default::default() };
+        if let Some(sid) = clicked {
+            self.selected = self.ids.to_graph.get(&sid).copied();
+        }
+        resp.selected = self.selected;
+        let extracted = extract_graph(&self.snarl, &self.graph);
+        if extracted != self.graph {
+            self.graph = extracted;
+            self.revision += 1;
+            resp.changed = true;
+            // Fresh nodes got ids; re-key the map without rebuilding the view.
+            let (_, ids) = build_snarl(&self.graph, reg);
+            let _ = ids;
+            self.ids = IdMap::default();
+            for (sid, card) in self.snarl.nodes_ids_mut() {
+                if let Some(gid) = card.graph_id() {
+                    self.ids.to_snarl.insert(gid, sid);
+                    self.ids.to_graph.insert(sid, gid);
+                }
+            }
+            self.assign_fresh_ids();
+        }
+        resp
+    }
+
+    /// Cards that were inserted this frame carry id 0 in the snarl; give
+    /// them the ids extraction chose, so the next frame agrees.
+    fn assign_fresh_ids(&mut self) {
+        let mut fresh: Vec<SnarlId> = self.snarl.nodes_ids_mut().filter(|(_, c)| c.id == 0).map(|(sid, _)| sid).collect();
+        fresh.sort_by_key(|s| s.0);
+        let unmapped: Vec<NodeId> = self.graph.nodes.iter().map(|n| n.id).filter(|id| !self.ids.to_snarl.contains_key(id)).collect();
+        for (sid, gid) in fresh.into_iter().zip(unmapped) {
+            if let Some(card) = self.snarl.get_node_mut(sid) {
+                card.id = gid.0;
+            }
+            self.ids.to_snarl.insert(gid, sid);
+            self.ids.to_graph.insert(sid, gid);
+        }
+    }
+
+    /// Insert a node of `kind` at a view position; it gets its id on the
+    /// next extraction.
+    pub fn insert(&mut self, kind: &str, pos: [f32; 2], reg: &Registry) -> bool {
+        let Some(spec) = reg.get(kind) else { return false };
+        self.snarl.insert_node(egui::pos2(pos[0], pos[1]), NodeCard::new_of(spec, reg));
+        true
+    }
+
+    pub fn remove(&mut self, id: NodeId) -> bool {
+        let Some(&sid) = self.ids.to_snarl.get(&id) else { return false };
+        self.snarl.remove_node(sid);
+        if self.selected == Some(id) {
+            self.selected = None;
+        }
+        true
+    }
+}
+
+struct Viewer<'a> {
+    reg: &'a Registry,
+    editable: bool,
+    clicked: Option<SnarlId>,
+    refused: Option<String>,
+    search: String,
+    ids: &'a IdMap,
+}
+
+fn pin_info(pin: &PinSpec) -> PinInfo {
+    let color = kind_color(pin.kind);
+    let info = match pin.access {
+        Access::Item => PinInfo::circle(),
+        Access::List => PinInfo::square(),
+    };
+    info.with_fill(color).with_stroke(egui::Stroke::new(1.0, color.gamma_multiply(0.6)))
+}
+
+impl SnarlViewer<NodeCard> for Viewer<'_> {
+    fn title(&mut self, node: &NodeCard) -> String {
+        node.title.clone()
+    }
+
+    fn node_frame(&mut self, default: egui::Frame, node: SnarlId, _inputs: &[InPin], _outputs: &[OutPin], snarl: &Snarl<NodeCard>) -> egui::Frame {
+        match snarl.get_node(node) {
+            Some(c) if !c.diag.is_empty() => default.stroke(egui::Stroke::new(2.0, Color32::from_rgb(220, 70, 70))),
+            Some(c) if self.ids.to_graph.get(&node).is_some_and(|g| c.graph_id() == Some(*g)) => default,
+            _ => default,
+        }
+    }
+
+    fn inputs(&mut self, node: &NodeCard) -> usize {
+        node.pins_in.len()
+    }
+
+    fn outputs(&mut self, node: &NodeCard) -> usize {
+        node.pins_out.len()
+    }
+
+    fn show_input(&mut self, pin: &InPin, ui: &mut Ui, snarl: &mut Snarl<NodeCard>) -> impl egui_snarl::ui::SnarlPin + 'static {
+        let card = &mut snarl[pin.id.node];
+        let Some(spec) = card.pins_in.get(pin.id.input).cloned() else { return PinInfo::circle() };
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(&spec.name).small().color(kind_color(spec.kind))).on_hover_text(format!("{}\n{}", spec.kind.label(), spec.doc));
+            if pin.remotes.is_empty() && self.editable {
+                let mut lit = card.inputs.get(&spec.name).cloned();
+                if pin_widget(ui, &spec, &mut lit) {
+                    match lit {
+                        Some(l) => {
+                            card.inputs.insert(spec.name.clone(), l);
+                        }
+                        None => {
+                            card.inputs.remove(&spec.name);
+                        }
+                    }
+                }
+            }
+        });
+        pin_info(&spec)
+    }
+
+    fn show_output(&mut self, pin: &OutPin, ui: &mut Ui, snarl: &mut Snarl<NodeCard>) -> impl egui_snarl::ui::SnarlPin + 'static {
+        let card = &snarl[pin.id.node];
+        let Some(spec) = card.pins_out.get(pin.id.output).cloned() else { return PinInfo::circle() };
+        ui.horizontal(|ui| {
+            if let Some(v) = card.values.get(&spec.name) {
+                ui.weak(RichText::new(v).small());
+            }
+            ui.label(RichText::new(&spec.name).small().color(kind_color(spec.kind))).on_hover_text(format!("{}\n{}", spec.kind.label(), spec.doc));
+        });
+        pin_info(&spec)
+    }
+
+    fn has_on_hover_popup(&mut self, node: &NodeCard) -> bool {
+        !node.diag.is_empty()
+    }
+
+    fn show_on_hover_popup(&mut self, node: SnarlId, _inputs: &[InPin], _outputs: &[OutPin], ui: &mut Ui, snarl: &mut Snarl<NodeCard>) {
+        for d in &snarl[node].diag {
+            ui.colored_label(Color32::from_rgb(220, 90, 90), d);
+        }
+    }
+
+    fn final_node_rect(&mut self, node: SnarlId, rect: egui::Rect, ui: &mut Ui, _snarl: &mut Snarl<NodeCard>) {
+        let clicked = ui.input(|i| i.pointer.primary_clicked() && i.pointer.interact_pos().is_some_and(|p| rect.contains(p)));
+        if clicked {
+            self.clicked = Some(node);
+        }
+    }
+
+    fn connect(&mut self, from: &OutPin, to: &InPin, snarl: &mut Snarl<NodeCard>) {
+        if !self.editable {
+            return;
+        }
+        let out_kind = snarl.get_node(from.id.node).and_then(|c| c.pins_out.get(from.id.output)).map(|p| p.kind);
+        let in_pin = snarl.get_node(to.id.node).and_then(|c| c.pins_in.get(to.id.input)).cloned();
+        let (Some(out_kind), Some(in_pin)) = (out_kind, in_pin) else { return };
+        let ok = in_pin.kind.accepts(out_kind) || in_pin.access == Access::List || in_pin.kind == ValueKind::List;
+        if !ok {
+            self.refused = Some(format!("{} takes {}, not {}", in_pin.name, in_pin.kind.label(), out_kind.label()));
+            return;
+        }
+        if from.id.node == to.id.node {
+            self.refused = Some("a node cannot feed itself".into());
+            return;
+        }
+        snarl.drop_inputs(to.id);
+        snarl.connect(from.id, to.id);
+    }
+
+    fn disconnect(&mut self, from: &OutPin, to: &InPin, snarl: &mut Snarl<NodeCard>) {
+        if self.editable {
+            snarl.disconnect(from.id, to.id);
+        }
+    }
+
+    fn drop_outputs(&mut self, pin: &OutPin, snarl: &mut Snarl<NodeCard>) {
+        if self.editable {
+            snarl.drop_outputs(pin.id);
+        }
+    }
+
+    fn drop_inputs(&mut self, pin: &InPin, snarl: &mut Snarl<NodeCard>) {
+        if self.editable {
+            snarl.drop_inputs(pin.id);
+        }
+    }
+
+    fn has_graph_menu(&mut self, _pos: egui::Pos2, _snarl: &mut Snarl<NodeCard>) -> bool {
+        self.editable
+    }
+
+    fn show_graph_menu(&mut self, pos: egui::Pos2, ui: &mut Ui, snarl: &mut Snarl<NodeCard>) {
+        ui.set_min_width(220.0);
+        ui.label(RichText::new("Add node").small().weak());
+        ui.add(egui::TextEdit::singleline(&mut self.search).hint_text("search…"));
+        let mode = ringdesign_graph::graph::Mode::SandRing;
+        let specs = self.reg.list(mode);
+        let needle = self.search.trim().to_lowercase();
+        if !needle.is_empty() {
+            egui::ScrollArea::vertical().max_height(260.0).show(ui, |ui| {
+                for spec in specs.iter().filter(|s| s.key.to_lowercase().contains(&needle) || s.label.to_lowercase().contains(&needle)) {
+                    if ui.button(format!("{}  ({})", spec.label, spec.key)).on_hover_text(&spec.doc).clicked() {
+                        snarl.insert_node(pos, NodeCard::new_of(spec, self.reg));
+                        self.search.clear();
+                        ui.close();
+                    }
+                }
+            });
+            return;
+        }
+        for cat in Category::ALL {
+            let in_cat: Vec<&&NodeSpec> = specs.iter().filter(|s| s.category == *cat).collect();
+            if in_cat.is_empty() {
+                continue;
+            }
+            ui.menu_button(cat.label(), |ui| {
+                for spec in in_cat {
+                    if ui.button(&spec.label).on_hover_text(format!("{}\n{}", spec.key, spec.doc)).clicked() {
+                        snarl.insert_node(pos, NodeCard::new_of(spec, self.reg));
+                        ui.close();
+                    }
+                }
+            });
+        }
+    }
+
+    fn has_node_menu(&mut self, _node: &NodeCard) -> bool {
+        self.editable
+    }
+
+    fn show_node_menu(&mut self, node: SnarlId, inputs: &[InPin], outputs: &[OutPin], ui: &mut Ui, snarl: &mut Snarl<NodeCard>) {
+        if ui.button("Delete").clicked() {
+            snarl.remove_node(node);
+            ui.close();
+            return;
+        }
+        if ui.button("Duplicate").clicked() {
+            if let Some(info) = snarl.get_node_info(node) {
+                let pos = info.pos + egui::vec2(40.0, 40.0);
+                let mut card = info.value.clone();
+                card.id = 0;
+                card.diag.clear();
+                card.values.clear();
+                snarl.insert_node(pos, card);
+            }
+            ui.close();
+            return;
+        }
+        if ui.button("Disconnect all").clicked() {
+            for p in inputs {
+                snarl.drop_inputs(p.id);
+            }
+            for p in outputs {
+                snarl.drop_outputs(p.id);
+            }
+            ui.close();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ringdesign_graph::graph::Mode;
+
+    #[test]
+    fn extract_of_build_is_the_graph_for_every_template() {
+        let reg = Registry::builtin();
+        for (name, g) in ringdesign_graph::templates::all() {
+            let (snarl, _) = build_snarl(&g, &reg);
+            let back = extract_graph(&snarl, &g);
+            assert_eq!(back, g, "{name}");
+        }
+        let simple = ringdesign_graph::templates::simple();
+        let (snarl, _) = build_snarl(&simple, &reg);
+        assert_eq!(extract_graph(&snarl, &simple), simple);
+    }
+
+    #[test]
+    fn a_palette_insert_gets_a_fresh_id_and_a_refused_wire_leaves_none() {
+        let reg = Registry::builtin();
+        let mut g = Graph::new("t", Mode::SandRing);
+        let n = g.add("number").unwrap();
+        let t = g.add("text").unwrap();
+        let a = g.add("math.add").unwrap();
+        g.connect(n, "out", a, "a").unwrap();
+        let mut ed = Editor::new(g.clone(), &reg);
+        assert!(ed.insert("math.mul", [300.0, 0.0], &reg));
+        let extracted = extract_graph(ed.snarl(), ed.graph());
+        assert_eq!(extracted.nodes.len(), 4);
+        let fresh = extracted.nodes.iter().find(|x| x.kind == "math.mul").unwrap();
+        assert_eq!(fresh.id, NodeId(4), "above every id the graph handed out");
+        assert_eq!(extracted.next_id, 5);
+
+        // Text -> Number is refused by the viewer; Number -> Number replaces.
+        let (mut snarl, ids) = build_snarl(&g, &reg);
+        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids };
+        let text_out = OutPin { id: OutPinId { node: ids.to_snarl[&t], output: 0 }, remotes: vec![] };
+        let add_b = InPin { id: InPinId { node: ids.to_snarl[&a], input: 1 }, remotes: vec![] };
+        viewer.connect(&text_out, &add_b, &mut snarl);
+        assert!(viewer.refused.as_deref().unwrap_or("").contains("takes number"), "{:?}", viewer.refused);
+        let back = extract_graph(&snarl, &g);
+        assert_eq!(back.wires.len(), 1, "no wire was made");
+        let num_out = OutPin { id: OutPinId { node: ids.to_snarl[&n], output: 0 }, remotes: vec![] };
+        let add_a = InPin { id: InPinId { node: ids.to_snarl[&a], input: 0 }, remotes: vec![] };
+        viewer.refused = None;
+        viewer.connect(&num_out, &add_a, &mut snarl);
+        assert!(viewer.refused.is_none());
+        let back = extract_graph(&snarl, &g);
+        assert_eq!(back.wires.len(), 1, "one wire per input: the new one replaced the old");
+        assert!(back.validate(Some(&reg)).is_empty());
+    }
+
+    #[test]
+    fn editing_a_literal_on_a_card_moves_the_graph() {
+        let reg = Registry::builtin();
+        let mut g = Graph::new("t", Mode::SandRing);
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "width_mm", Literal::Number(6.0)).unwrap();
+        let mut ed = Editor::new(g.clone(), &reg);
+        let sid = ed.ids.to_snarl[&p];
+        ed.snarl.get_node_mut(sid).unwrap().inputs.insert("width_mm".into(), Literal::Number(8.0));
+        let extracted = extract_graph(ed.snarl(), ed.graph());
+        assert_eq!(extracted.node(p).unwrap().inputs.get("width_mm"), Some(&Literal::Number(8.0)));
+        assert_ne!(extracted, g);
+        // set_graph rebuilds the view and bumps the revision; removal drops exposures.
+        g.expose(p, "width_mm", "Width").unwrap();
+        ed.set_graph(g.clone(), &reg);
+        assert_eq!(ed.revision, 1);
+        assert!(ed.remove(p));
+        let extracted = extract_graph(ed.snarl(), ed.graph());
+        assert!(extracted.nodes.is_empty() && extracted.exposed.is_empty());
+    }
+
+    #[test]
+    fn the_editor_draws_headless_and_finds_its_nodes() {
+        let reg = Registry::builtin();
+        let simple = ringdesign_graph::templates::simple();
+        let mut ed = Editor::new(simple, &reg);
+        let mut harness = egui_kittest::Harness::new_ui(|ui| {
+            ed.show(&reg, ui, "test-editor");
+        });
+        harness.set_size(egui::vec2(1400.0, 700.0));
+        harness.run();
+        use egui_kittest::kittest::Queryable;
+        for want in ["Band profile", "Shank", "New design", "Output"] {
+            assert!(harness.query_by_label(want).is_some(), "{want} not drawn");
+        }
+    }
+}

--- a/crates/ringdesign-graph-ui/src/lib.rs
+++ b/crates/ringdesign-graph-ui/src/lib.rs
@@ -10,6 +10,9 @@
 //! tree. [`editor`] is filled in by M3.2.
 
 pub mod editor;
+pub mod widgets;
+
+pub use editor::{Editor, EditorResponse, NodeCard, build_snarl, extract_graph};
 
 /// The egui-snarl this editor is built on, for sanity checks and the diff
 /// guard against the sibling copies.

--- a/crates/ringdesign-graph-ui/src/widgets.rs
+++ b/crates/ringdesign-graph-ui/src/widgets.rs
@@ -1,0 +1,159 @@
+//! Inline widgets for unwired pins, chosen from the registry's hints.
+
+use egui::Ui;
+use ringdesign_graph::registry::{PinSpec, Widget};
+use ringdesign_graph::value::{Literal, ValueKind};
+
+/// Draw the widget for an unwired pin over its literal. Returns whether
+/// the literal changed.
+pub fn pin_widget(ui: &mut Ui, pin: &PinSpec, literal: &mut Option<Literal>) -> bool {
+    let effective = literal.clone().or_else(|| pin.default.clone());
+    if let Some(Literal::List(items)) = &effective {
+        ui.weak(format!("list ×{}", items.len()));
+        return false;
+    }
+    if let Some(Literal::Json(_)) = &effective {
+        ui.weak("json");
+        return false;
+    }
+    let mut changed = false;
+    match (&pin.widget, pin.kind) {
+        (Widget::Checkbox, _) | (Widget::Auto, ValueKind::Bool) => {
+            let mut v = effective.as_ref().and_then(as_bool).unwrap_or(false);
+            if ui.checkbox(&mut v, "").changed() {
+                *literal = Some(Literal::Bool(v));
+                changed = true;
+            }
+        }
+        (Widget::Select(names), _) => {
+            let mut v = effective.as_ref().and_then(as_text).unwrap_or_default();
+            let id = ui.id().with(&pin.name);
+            egui::ComboBox::from_id_salt(id).selected_text(if v.is_empty() { "…".to_string() } else { v.clone() }).width(110.0).show_ui(ui, |ui| {
+                for n in names {
+                    if ui.selectable_value(&mut v, n.clone(), n).changed() {
+                        changed = true;
+                    }
+                }
+            });
+            if changed {
+                *literal = Some(Literal::Text(v));
+            }
+        }
+        (Widget::Slider { min, max }, _) => {
+            let mut v = effective.as_ref().and_then(as_f64).unwrap_or(*min);
+            if ui.add_sized([120.0, 18.0], egui::Slider::new(&mut v, *min..=*max).show_value(true)).changed() {
+                *literal = Some(number_like(pin.kind, v));
+                changed = true;
+            }
+        }
+        (Widget::Mm { min, max }, _) => {
+            let mut v = effective.as_ref().and_then(as_f64).unwrap_or(*min);
+            if ui.add_sized([90.0, 18.0], egui::DragValue::new(&mut v).range(*min..=*max).speed(0.05).suffix(" mm").fixed_decimals(2)).changed() {
+                *literal = Some(number_like(pin.kind, v));
+                changed = true;
+            }
+        }
+        (Widget::Angle, _) => {
+            let mut v = effective.as_ref().and_then(as_f64).unwrap_or(90.0);
+            if ui.add_sized([80.0, 18.0], egui::DragValue::new(&mut v).speed(0.5).suffix("°").fixed_decimals(1)).changed() {
+                *literal = Some(number_like(pin.kind, v));
+                changed = true;
+            }
+        }
+        (Widget::TextLine, _) | (Widget::Auto, ValueKind::Text | ValueKind::AlphaRef) => {
+            let mut v = effective.as_ref().and_then(as_text).unwrap_or_default();
+            if ui.add_sized([120.0, 18.0], egui::TextEdit::singleline(&mut v)).changed() {
+                *literal = Some(Literal::Text(v));
+                changed = true;
+            }
+        }
+        (Widget::TextArea, _) => {
+            let mut v = effective.as_ref().and_then(as_text).unwrap_or_default();
+            if ui.add_sized([160.0, 60.0], egui::TextEdit::multiline(&mut v)).changed() {
+                *literal = Some(Literal::Text(v));
+                changed = true;
+            }
+        }
+        (Widget::Auto, ValueKind::Int) => {
+            let mut v = effective.as_ref().and_then(as_i64).unwrap_or(0);
+            if ui.add_sized([70.0, 18.0], egui::DragValue::new(&mut v).speed(0.1)).changed() {
+                *literal = Some(Literal::Int(v));
+                changed = true;
+            }
+        }
+        (Widget::Auto, ValueKind::Number) => {
+            let mut v = effective.as_ref().and_then(as_f64).unwrap_or(0.0);
+            if ui.add_sized([80.0, 18.0], egui::DragValue::new(&mut v).speed(0.05).max_decimals(4)).changed() {
+                *literal = Some(Literal::Number(v));
+                changed = true;
+            }
+        }
+        _ => {
+            // A handle: nothing to type in; the pin wants a wire.
+            ui.weak("—");
+        }
+    }
+    changed
+}
+
+fn number_like(kind: ValueKind, v: f64) -> Literal {
+    if kind == ValueKind::Int { Literal::Int(v.round() as i64) } else { Literal::Number(v) }
+}
+
+fn as_f64(l: &Literal) -> Option<f64> {
+    match l {
+        Literal::Number(x) => Some(*x),
+        Literal::Int(i) => Some(*i as f64),
+        Literal::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
+fn as_i64(l: &Literal) -> Option<i64> {
+    match l {
+        Literal::Int(i) => Some(*i),
+        Literal::Number(x) => Some(x.round() as i64),
+        _ => None,
+    }
+}
+
+fn as_bool(l: &Literal) -> Option<bool> {
+    match l {
+        Literal::Bool(b) => Some(*b),
+        Literal::Int(i) => Some(*i != 0),
+        Literal::Number(x) => Some(*x != 0.0),
+        _ => None,
+    }
+}
+
+fn as_text(l: &Literal) -> Option<String> {
+    match l {
+        Literal::Text(s) => Some(s.clone()),
+        Literal::Number(x) => Some(x.to_string()),
+        Literal::Int(i) => Some(i.to_string()),
+        Literal::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// The colour a pin of this kind draws in.
+pub fn kind_color(kind: ValueKind) -> egui::Color32 {
+    use ValueKind::*;
+    match kind {
+        Any => egui::Color32::from_rgb(170, 170, 170),
+        Null => egui::Color32::DARK_GRAY,
+        Number => egui::Color32::from_rgb(120, 190, 255),
+        Int => egui::Color32::from_rgb(90, 160, 235),
+        Bool => egui::Color32::from_rgb(235, 120, 120),
+        Text | AlphaRef => egui::Color32::from_rgb(230, 200, 110),
+        List | Json | Path => egui::Color32::from_rgb(190, 190, 120),
+        Design => egui::Color32::from_rgb(255, 215, 120),
+        Profile | Shank | Head | Outline => egui::Color32::from_rgb(255, 170, 90),
+        Gem => egui::Color32::from_rgb(140, 230, 230),
+        Window | Remap => egui::Color32::from_rgb(200, 160, 255),
+        Layer | Entry | Stack | Recipe => egui::Color32::from_rgb(140, 220, 140),
+        AlphaSource => egui::Color32::from_rgb(220, 190, 150),
+        Build | Mesh | Solid => egui::Color32::from_rgb(200, 200, 210),
+        Field | Stones => egui::Color32::from_rgb(255, 140, 140),
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,7 +107,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - [x] **M3.1 Vendoring** (S, #39). The egui-0.36 `egui-snarl` + `egui-scale` under `patches/` with
   root `[patch.crates-io]` entries; exactly one egui in the tree; a diff guard against the sibling
   copy.
-- [ ] **M3.2 Editor core** (L, #40). Snarl payload `NodeCard`, `build_snarl`/`extract_graph` (truth
+- [x] **M3.2 Editor core** (L, #40). Snarl payload `NodeCard`, `build_snarl`/`extract_graph` (truth
   = the graph), pin widgets by value kind, type-checked wiring, category palette, node menu,
   diagnostics on the node frame.
 - [ ] **M3.3 Desktop integration** (M, #41). `PaneKind::Graph` + a node-inspector dock tool; graph


### PR DESCRIPTION
## Summary
- `editor.rs`: `NodeCard`, `build_snarl`/`extract_graph` (graph is truth; fresh ids; wire order preserved), `Editor` with revision tracking, `Viewer` (typed pins, inline widgets, value badges, diagnostics, type-checked connect, palette with search, node menu).
- `widgets.rs`: registry `Widget` hints → egui widgets; pin colours by kind.

## Verification
- `cargo test -p ringdesign-graph-ui`: 5 tests — `extract(build(g)) == g` for every template graph, palette insert gets a fresh id, a Text→Number drag leaves no wire, literal edits move the graph, and a headless egui_kittest render finds the node titles.
- `cargo test --workspace` green.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)