### PR TITLE
M3.3 Desktop integration: Graph pane, Node tool, worker evaluation

### DIFF
--- a/crates/ringdesign-graph-ui/src/editor.rs
+++ b/crates/ringdesign-graph-ui/src/editor.rs
@@ -279,7 +279,7 @@ impl Editor {
     }
 
     /// Insert a node of `kind` at a view position; it gets its id on the
-    /// next extraction.
+    /// next extraction (or [`Editor::commit`]).
     pub fn insert(&mut self, kind: &str, pos: [f32; 2], reg: &Registry) -> bool {
         let Some(spec) = reg.get(kind) else { return false };
         self.snarl.insert_node(egui::pos2(pos[0], pos[1]), NodeCard::new_of(spec, reg));
@@ -292,7 +292,83 @@ impl Editor {
         if self.selected == Some(id) {
             self.selected = None;
         }
+        self.commit();
         true
+    }
+
+    /// Extract the view now and adopt any change; true if the graph moved.
+    pub fn commit(&mut self) -> bool {
+        let extracted = extract_graph(&self.snarl, &self.graph);
+        if extracted == self.graph {
+            return false;
+        }
+        self.graph = extracted;
+        self.revision += 1;
+        self.ids = IdMap::default();
+        for (sid, card) in self.snarl.nodes_ids_mut() {
+            if let Some(gid) = card.graph_id() {
+                self.ids.to_snarl.insert(gid, sid);
+                self.ids.to_graph.insert(sid, gid);
+            }
+        }
+        self.assign_fresh_ids();
+        true
+    }
+
+    pub fn card(&self, id: NodeId) -> Option<&NodeCard> {
+        self.ids.to_snarl.get(&id).and_then(|sid| self.snarl.get_node(*sid))
+    }
+
+    pub fn node(&self, id: NodeId) -> Option<&Node> {
+        self.graph.node(id)
+    }
+
+    /// Set (or clear) a literal on a node's input, through the view so the
+    /// card and the graph agree.
+    pub fn set_input(&mut self, id: NodeId, input: &str, value: Option<Literal>) -> bool {
+        let Some(&sid) = self.ids.to_snarl.get(&id) else { return false };
+        if let Some(card) = self.snarl.get_node_mut(sid) {
+            match value {
+                Some(v) => {
+                    card.inputs.insert(input.to_string(), v);
+                }
+                None => {
+                    card.inputs.remove(input);
+                }
+            }
+        }
+        self.commit()
+    }
+
+    pub fn set_label(&mut self, id: NodeId, label: Option<String>) -> bool {
+        let Some(&sid) = self.ids.to_snarl.get(&id) else { return false };
+        if let Some(card) = self.snarl.get_node_mut(sid) {
+            card.label = label.clone().filter(|l| !l.trim().is_empty());
+            card.title = card.label.clone().unwrap_or_else(|| card.kind.clone());
+        }
+        self.commit()
+    }
+
+    /// Promote an input to the graph's parameter panel.
+    pub fn expose(&mut self, id: NodeId, input: &str, name: &str) -> Result<(), GraphError> {
+        self.graph.expose(id, input, name)?;
+        self.revision += 1;
+        Ok(())
+    }
+
+    pub fn unexpose(&mut self, name: &str) -> bool {
+        let hit = self.graph.unexpose(name).is_some();
+        if hit {
+            self.revision += 1;
+        }
+        hit
+    }
+
+    /// Lay the nodes out by depth, as the template files are.
+    pub fn arrange(&mut self, reg: &Registry) {
+        let mut g = self.graph.clone();
+        ringdesign_graph::templates::arrange(&mut g);
+        self.set_graph(g, reg);
     }
 }
 

--- a/crates/ringdesign-gui/src/app.rs
+++ b/crates/ringdesign-gui/src/app.rs
@@ -1,6 +1,6 @@
 //! Application state and the background rebuild pipeline.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -10,6 +10,10 @@ use ringdesign_core::castability::{self, CastReport};
 use ringdesign_core::field::{Layer, LayerEntry};
 use ringdesign_core::mesh::{BuildParams, BuildResult};
 use ringdesign_core::{RingDesign, library};
+use ringdesign_graph::eval::{Evaluator, evaluate_design};
+use ringdesign_graph::graph::{Graph, GraphError, NodeId as GraphNodeId};
+use ringdesign_graph::registry::Registry;
+use ringdesign_graph_ui::Editor;
 
 use crate::alpha_editor::AlphaEditor;
 use crate::dock::Dock;
@@ -205,6 +209,15 @@ pub struct RingDesignerApp {
     pub auto_rebuild: bool,
     /// Named undo timeline over the design.
     pub history: History,
+    /// The node library, built once; the worker builds its own.
+    pub graph_reg: Arc<Registry>,
+    /// The editor over `design.graph`, present while the design is graph-driven.
+    pub graph_ed: Option<Editor>,
+    /// `design.graph` as last synced into the editor.
+    pub graph_json: Option<serde_json::Value>,
+    /// Graph-level errors from the last evaluation, when nothing ran.
+    pub graph_errors: Vec<String>,
+    pub selected_node: Option<GraphNodeId>,
 
     /// Embedded MCP server, `None` until the user starts it.
     pub mcp: Option<McpHost>,
@@ -300,6 +313,11 @@ impl RingDesignerApp {
             status: "Ready".into(),
             auto_rebuild: true,
             history: History::new(&design_for_history),
+            graph_reg: Arc::new(Registry::builtin()),
+            graph_ed: None,
+            graph_json: None,
+            graph_errors: Vec::new(),
+            selected_node: None,
 
             mcp: None,
             mcp_port: ws.mcp_port,
@@ -369,7 +387,9 @@ impl RingDesignerApp {
         let has_live = self.design.layers.layers.iter().any(|e| {
             matches!(&e.layer, ringdesign_core::Layer::Group(g) if g.recipe.is_some())
         });
-        if has_live {
+        // A graph-driven design is re-evaluated whole on the worker; its
+        // generators are nodes there, so nothing regenerates here.
+        if has_live && self.design.graph.is_none() {
             for note in ringdesign_core::pave::regenerate_live(&mut self.design) {
                 self.set_status(note);
             }
@@ -399,6 +419,7 @@ impl RingDesignerApp {
 
     /// Poll the worker, fire debounced rebuilds, and refresh the section slice.
     pub fn tick(&mut self, ctx: &egui::Context) {
+        self.sync_graph();
         if self.mcp.as_mut().is_some_and(|h| h.poll(&mut self.design)) {
             if self
                 .selected_layer
@@ -451,6 +472,23 @@ impl RingDesignerApp {
                     self.field = Some(done.field);
                     self.stones = done.stones;
                     self.hot_spot = done.hot_spot;
+                    if let Some(gd) = done.graph {
+                        if gd.ok {
+                            // The evaluated design, under whatever the graph
+                            // has become since the job was queued.
+                            let graph = self.design.graph.take();
+                            self.design = gd.design;
+                            self.design.graph = graph;
+                        }
+                        self.graph_errors = gd.errors.iter().map(ToString::to_string).collect();
+                        if let Some(ed) = &mut self.graph_ed {
+                            ed.set_values(&gd.values);
+                            ed.set_diagnostics(&gd.errors, &gd.notes);
+                        }
+                        if !gd.ok {
+                            self.status = format!("Graph: {}", self.graph_errors.join("; "));
+                        }
+                    }
                     self.refresh_sections();
                     ctx.request_repaint();
                 }
@@ -496,6 +534,7 @@ impl RingDesignerApp {
             design: self.design.clone(),
             lib: self.lib.clone(),
             params,
+            graph: self.design.graph.as_ref().and_then(|j| serde_json::from_value::<Graph>(j.clone()).ok()),
         };
         if self.worker.jobs.send(job).is_err() {
             self.in_flight = false;
@@ -706,6 +745,114 @@ impl RingDesignerApp {
     }
 }
 
+// --- The graph behind the design ------------------------------------------
+
+impl RingDesignerApp {
+    /// Whether the design is driven by a graph right now.
+    pub fn graph_driven(&self) -> bool {
+        self.design.graph.is_some()
+    }
+
+    /// Keep the editor in step with `design.graph`, whichever side moved:
+    /// history, MCP, a file, a template — anything that replaces the design
+    /// replaces the graph the editor shows.
+    pub fn sync_graph(&mut self) {
+        if self.design.graph == self.graph_json {
+            return;
+        }
+        self.graph_json = self.design.graph.clone();
+        let parsed = self.design.graph.as_ref().and_then(|j| serde_json::from_value::<Graph>(j.clone()).ok());
+        match parsed {
+            Some(g) => match &mut self.graph_ed {
+                Some(ed) => ed.set_graph(g, &self.graph_reg),
+                None => self.graph_ed = Some(Editor::new(g, &self.graph_reg)),
+            },
+            None => {
+                self.graph_ed = None;
+                self.selected_node = None;
+            }
+        }
+        if let (Some(ed), Some(sel)) = (&self.graph_ed, self.selected_node) {
+            if ed.node(sel).is_none() {
+                self.selected_node = None;
+            }
+        }
+    }
+
+    /// The editor moved the graph: write it into the design and rebuild.
+    pub fn graph_changed(&mut self) {
+        let Some(ed) = &self.graph_ed else { return };
+        let json = serde_json::to_value(ed.graph()).ok();
+        self.design.graph = json.clone();
+        self.graph_json = json;
+        self.mark_dirty();
+    }
+
+    /// Lift the design into a graph that evaluates back to it exactly, and
+    /// show it.
+    pub fn convert_to_graph(&mut self) {
+        match ringdesign_graph::lift::from_design(&self.design, &self.graph_reg, &self.lib) {
+            Ok(g) => {
+                self.design.graph = serde_json::to_value(&g).ok();
+                self.sync_graph();
+                self.show_graph_pane();
+                self.set_status("Converted to a graph — the panels follow it now");
+                self.mark_dirty();
+            }
+            Err(e) => self.set_status(format!("Could not convert: {e}")),
+        }
+    }
+
+    /// Open a starter or template graph as the design's graph.
+    pub fn open_graph(&mut self, g: Graph) {
+        self.design.graph = serde_json::to_value(&g).ok();
+        self.sync_graph();
+        self.show_graph_pane();
+        self.mark_dirty();
+    }
+
+    /// Drop the graph; the design stays exactly as last evaluated.
+    pub fn bake_graph(&mut self) {
+        if self.design.graph.take().is_some() {
+            self.graph_json = None;
+            self.graph_ed = None;
+            self.selected_node = None;
+            self.graph_errors.clear();
+            self.set_status("Baked: the graph is gone and the design is yours to edit");
+            self.mark_dirty();
+        }
+    }
+
+    /// Make a graph pane the active one, turning the active pane into one
+    /// if none shows the graph.
+    pub fn show_graph_pane(&mut self) {
+        if let Some(i) = self.panes.iter().position(|p| p.kind == PaneKind::Graph) {
+            self.active_pane = i;
+            return;
+        }
+        if let Some(p) = self.panes.get_mut(self.active_pane) {
+            p.kind = PaneKind::Graph;
+        }
+    }
+
+    pub fn arrange_graph(&mut self) {
+        let reg = self.graph_reg.clone();
+        if let Some(ed) = &mut self.graph_ed {
+            ed.arrange(&reg);
+        }
+        self.graph_changed();
+    }
+
+    pub fn delete_selected_node(&mut self) {
+        let Some(id) = self.selected_node.take() else { return };
+        if let Some(ed) = &mut self.graph_ed {
+            if ed.remove(id) {
+                self.graph_changed();
+            }
+        }
+    }
+}
+
 // --- Background build worker -----------------------------------------------
 
 struct Job {
@@ -713,6 +860,19 @@ struct Job {
     design: RingDesign,
     lib: Arc<AlphaLibrary>,
     params: BuildParams,
+    /// The design's graph, evaluated before the build when present.
+    graph: Option<Graph>,
+}
+
+/// What evaluating a job's graph produced.
+pub struct GraphDone {
+    pub design: RingDesign,
+    pub values: BTreeMap<GraphNodeId, BTreeMap<String, String>>,
+    pub notes: BTreeMap<GraphNodeId, Vec<String>>,
+    pub errors: Vec<GraphError>,
+    /// The design above is the evaluation's; false means the last good
+    /// design was built instead.
+    pub ok: bool,
 }
 
 struct Done {
@@ -724,6 +884,7 @@ struct Done {
     /// Slowest-freezing slice: `(theta, modulus mm)` off the Chvorinov scan.
     hot_spot: Option<(f64, f64)>,
     gems: Vec<f32>,
+    graph: Option<GraphDone>,
 }
 
 struct Worker {
@@ -738,10 +899,48 @@ impl Worker {
         std::thread::Builder::new()
             .name("ring-build".into())
             .spawn(move || {
+                let reg = Registry::builtin();
+                let mut evaluator = Evaluator::new();
                 while let Ok(mut job) = jobs_rx.recv() {
                     // Skip stale work: only the newest queued job matters.
                     while let Ok(newer) = jobs_rx.try_recv() {
                         job = newer;
+                    }
+                    // A graph-driven design is evaluated first; the library's
+                    // identity is its epoch, so a replaced library re-runs it.
+                    let mut graph_done = None;
+                    let mut field_from_graph = None;
+                    if let Some(g) = &job.graph {
+                        let epoch = Arc::as_ptr(&job.lib) as usize as u64;
+                        match evaluate_design(&mut evaluator, g, &reg, &job.lib, epoch) {
+                            Ok(out) => {
+                                let mut d = (*out.design).clone();
+                                d.graph = job.design.graph.clone();
+                                let values = out
+                                    .report
+                                    .values
+                                    .iter()
+                                    .map(|(id, outs)| (*id, outs.iter().map(|(k, v)| (k.clone(), v.summary())).collect()))
+                                    .collect();
+                                let notes = out
+                                    .report
+                                    .status
+                                    .iter()
+                                    .filter(|(_, s)| !s.errors.is_empty() || !s.warnings.is_empty())
+                                    .map(|(id, s)| {
+                                        let mut lines: Vec<String> = s.errors.iter().map(|(i, m)| if s.items > 1 { format!("item {i}: {m}") } else { m.clone() }).collect();
+                                        lines.extend(s.warnings.iter().cloned());
+                                        (*id, lines)
+                                    })
+                                    .collect();
+                                graph_done = Some(GraphDone { design: d.clone(), values, notes, errors: Vec::new(), ok: true });
+                                field_from_graph = Some(out.field);
+                                job.design = d;
+                            }
+                            Err(e) => {
+                                graph_done = Some(GraphDone { design: job.design.clone(), values: BTreeMap::new(), notes: BTreeMap::new(), errors: vec![e], ok: false });
+                            }
+                        }
                     }
                     let result = ringdesign_core::mesh::build(&job.design, &job.lib, job.params);
                     let cast = castability::analyze(
@@ -752,13 +951,10 @@ impl Worker {
                     // The verdict itself comes from the surface, at a fixed
                     // sampling so it cannot wobble with preview quality; any
                     // undercut arrives located and blamed.
-                    let field = castability::attributed_field_report(
-                        &job.design,
-                        &job.lib,
-                        &job.design.draft,
-                        192,
-                        128,
-                    );
+                    let field = match field_from_graph {
+                        Some(f) => f,
+                        None => castability::attributed_field_report(&job.design, &job.lib, &job.design.draft, 192, 128),
+                    };
                     let stones = ringdesign_core::stones::report(&job.design, field.parting_z_mm);
                     let hot_spot = castability::modulus_scan(&job.design, &job.lib, 64)
                         .into_iter()
@@ -773,6 +969,7 @@ impl Worker {
                             hot_spot,
                             stones,
                             gems,
+                            graph: graph_done,
                         })
                         .is_err()
                     {

--- a/crates/ringdesign-gui/src/dock.rs
+++ b/crates/ringdesign-gui/src/dock.rs
@@ -19,6 +19,7 @@ pub enum ToolKind {
     Layers,
     Report,
     Library,
+    Node,
 }
 
 impl ToolKind {
@@ -27,6 +28,7 @@ impl ToolKind {
         ToolKind::Layers,
         ToolKind::Report,
         ToolKind::Library,
+        ToolKind::Node,
     ];
 
     pub fn label(self) -> &'static str {
@@ -35,6 +37,7 @@ impl ToolKind {
             ToolKind::Layers => "Layers",
             ToolKind::Report => "Report",
             ToolKind::Library => "Tiles",
+            ToolKind::Node => "Node",
         }
     }
 
@@ -44,6 +47,7 @@ impl ToolKind {
             ToolKind::Layers => icon::STACK,
             ToolKind::Report => icon::CLIPBOARD_TEXT,
             ToolKind::Library => icon::GRID_FOUR,
+            ToolKind::Node => icon::SLIDERS_HORIZONTAL,
         }
     }
 }

--- a/crates/ringdesign-gui/src/history.rs
+++ b/crates/ringdesign-gui/src/history.rs
@@ -223,13 +223,20 @@ fn first_difference(
                     x.iter()
                         .filter(|(k, _)| !HEADLINE_KEYS.contains(&k.as_str())),
                 );
+            // A key on one side only is a change too (an optional field
+            // appearing or going), not a reason to give up on the name.
+            let null = Value::Null;
             for (k, va) in ordered {
-                let vb = y.get(k)?;
+                let vb = y.get(k).unwrap_or(&null);
                 if va != vb {
                     path.push(k.clone());
                     return first_difference(va, vb, path, depth + 1)
                         .or(Some((va.clone(), vb.clone())));
                 }
+            }
+            if let Some((k, vb)) = y.iter().find(|(k, _)| !x.contains_key(*k)) {
+                path.push(k.clone());
+                return Some((Value::Null, vb.clone()));
             }
             None
         }
@@ -256,6 +263,15 @@ fn first_difference(
 fn phrase(path: &[String], from: &Value, to: &Value) -> String {
     let section = path.first().map(String::as_str).unwrap_or("");
     let leaf = path.last().map(String::as_str).unwrap_or("");
+
+    // A graph is a document of its own; its nodes are not fields to name.
+    if section == "graph" {
+        return match (from.is_null(), to.is_null()) {
+            (true, false) => "Converted to graph".into(),
+            (false, true) => "Baked the graph".into(),
+            _ => "Graph edited".into(),
+        };
+    }
 
     // A layer count moving is an add or a remove, whatever field it surfaced on.
     if section == "layers" && from.is_u64() && to.is_u64() {
@@ -347,6 +363,18 @@ fn show(v: &Value, unit: &str) -> Option<String> {
 mod tests {
     use super::*;
     use ringdesign_core::field::{Layer, LayerEntry, MilgrainLayer};
+
+    #[test]
+    fn a_graph_is_named_as_a_document_not_as_fields() {
+        let a = design();
+        let mut b = a.clone();
+        b.graph = Some(serde_json::json!({"name": "g", "nodes": [{"id": 1, "kind": "number"}]}));
+        assert_eq!(describe(&a, &b).as_deref(), Some("Converted to graph"));
+        let mut c = b.clone();
+        c.graph = Some(serde_json::json!({"name": "g", "nodes": [{"id": 1, "kind": "int"}]}));
+        assert_eq!(describe(&b, &c).as_deref(), Some("Graph edited"));
+        assert_eq!(describe(&b, &a).as_deref(), Some("Baked the graph"));
+    }
 
     fn design() -> RingDesign {
         RingDesign::default()

--- a/crates/ringdesign-gui/src/pane.rs
+++ b/crates/ringdesign-gui/src/pane.rs
@@ -18,16 +18,18 @@ pub enum PaneKind {
     Solid,
     Unrolled,
     Section,
+    Graph,
 }
 
 impl PaneKind {
-    pub const ALL: &'static [PaneKind] = &[PaneKind::Solid, PaneKind::Unrolled, PaneKind::Section];
+    pub const ALL: &'static [PaneKind] = &[PaneKind::Solid, PaneKind::Unrolled, PaneKind::Section, PaneKind::Graph];
 
     pub fn label(self) -> &'static str {
         match self {
             PaneKind::Solid => "Ring",
             PaneKind::Unrolled => "Tile Layout",
             PaneKind::Section => "Cross Section",
+            PaneKind::Graph => "Graph",
         }
     }
 
@@ -36,6 +38,7 @@ impl PaneKind {
             PaneKind::Solid => icon::CIRCLE_NOTCH,
             PaneKind::Unrolled => icon::GRID_FOUR,
             PaneKind::Section => icon::CHART_LINE,
+            PaneKind::Graph => icon::GRAPH,
         }
     }
 }

--- a/crates/ringdesign-gui/src/panels/graph.rs
+++ b/crates/ringdesign-gui/src/panels/graph.rs
@@ -1,0 +1,78 @@
+//! The Graph pane: the node editor over the design's graph.
+
+use egui_phosphor::regular as icon;
+
+use crate::app::RingDesignerApp;
+use crate::theme;
+
+pub fn ui(app: &mut RingDesignerApp, ui: &mut egui::Ui, pane: usize) {
+    if app.graph_ed.is_none() {
+        empty_state(app, ui);
+        return;
+    }
+    egui::Panel::top(egui::Id::new(("graph_bar", pane)))
+        .frame(egui::Frame::NONE.fill(theme::PANEL).inner_margin(egui::Margin::symmetric(6, 3)))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                if ui.button(format!("{} Arrange", icon::ARROWS_OUT_LINE_HORIZONTAL)).on_hover_text("Lay the nodes out by depth").clicked() {
+                    app.arrange_graph();
+                }
+                if ui.button(format!("{} Bake", icon::FIRE)).on_hover_text("Drop the graph; keep the design as last evaluated").clicked() {
+                    app.bake_graph();
+                    return;
+                }
+                let nodes = app.graph_ed.as_ref().map(|e| e.graph().nodes.len()).unwrap_or(0);
+                ui.weak(format!("{nodes} nodes"));
+                if !app.graph_errors.is_empty() {
+                    ui.colored_label(theme::WARN, format!("{} {}", icon::WARNING, app.graph_errors.join("; ")));
+                }
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.weak("right-click: add node • drag pins to wire • click a node to inspect it");
+                });
+            });
+        });
+    let reg = app.graph_reg.clone();
+    // The editor leaves the app while it draws, as the dock's tree does, so
+    // the response can act on the app afterwards.
+    let Some(mut ed) = app.graph_ed.take() else { return };
+    let resp = egui::CentralPanel::default()
+        .frame(egui::Frame::NONE.fill(theme::VIEWPORT_BG))
+        .show(ui, |ui| ed.show(&reg, ui, &format!("graph-pane-{pane}")))
+        .inner;
+    app.graph_ed = Some(ed);
+    if resp.selected != app.selected_node {
+        app.selected_node = resp.selected;
+    }
+    if let Some(r) = resp.refused {
+        app.set_status(format!("Wire refused: {r}"));
+    }
+    if resp.changed {
+        app.graph_changed();
+    }
+}
+
+fn empty_state(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
+    ui.vertical_centered(|ui| {
+        ui.add_space(40.0);
+        ui.label(egui::RichText::new(format!("{} No graph behind this design yet", icon::GRAPH)).size(16.0).color(theme::TEXT_DIM));
+        ui.add_space(8.0);
+        ui.label(egui::RichText::new("Convert the design into nodes you can rewire, or start from a graph.").color(theme::TEXT_DIM));
+        ui.add_space(16.0);
+        if ui.button(format!("{} Convert this design to a graph", icon::ARROW_RIGHT)).clicked() {
+            app.convert_to_graph();
+        }
+        ui.add_space(6.0);
+        if ui.button(format!("{} Start from the simple graph", icon::PLUS)).clicked() {
+            app.open_graph(ringdesign_graph::templates::simple());
+        }
+        ui.add_space(6.0);
+        ui.menu_button(format!("{} Open a template graph", icon::FOLDER_OPEN), |ui| {
+            for (name, g) in ringdesign_graph::templates::all() {
+                if ui.button(name).clicked() {
+                    app.open_graph(g);
+                    ui.close();
+                }
+            }
+        });
+    });
+}

--- a/crates/ringdesign-gui/src/panels/mod.rs
+++ b/crates/ringdesign-gui/src/panels/mod.rs
@@ -1,7 +1,9 @@
 //! Window layout and the top-level chrome.
 
 pub mod design;
+pub mod graph;
 pub mod layers;
+pub mod node;
 pub mod library;
 pub mod report;
 pub mod section;
@@ -124,6 +126,7 @@ impl egui_tiles::Behavior<ToolKind> for ToolBehavior<'_> {
                 ToolKind::Layers => layers::ui(self.app, ui),
                 ToolKind::Report => report::ui(self.app, ui),
                 ToolKind::Library => library::ui(self.app, ui),
+                ToolKind::Node => node::ui(self.app, ui),
             });
         egui_tiles::UiResponse::None
     }
@@ -185,6 +188,7 @@ fn panes(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
                 PaneKind::Solid => viewport::ui(app, ui, i),
                 PaneKind::Unrolled => unrolled::ui(app, ui),
                 PaneKind::Section => section::ui(app, ui, i),
+                PaneKind::Graph => graph::ui(app, ui, i),
             });
 
         // Only worth marking which pane is active when there is a choice.
@@ -298,7 +302,13 @@ fn shortcuts(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
     // egui routes Delete to text editing itself, but a consumed key here would
     // otherwise still fire while typing in a field that ignored it.
     if delete && !ui.ctx().memory(|m| m.focused().is_some()) {
-        Command::DeleteLayer.run(app);
+        // The Delete key acts on what the active pane shows.
+        let graph_pane = app.panes.get(app.active_pane).is_some_and(|p| p.kind == PaneKind::Graph);
+        if graph_pane && app.selected_node.is_some() {
+            Command::DeleteNode.run(app);
+        } else {
+            Command::DeleteLayer.run(app);
+        }
     }
 
     command_palette(app, ui);
@@ -324,6 +334,11 @@ enum Command {
     DeleteLayer,
     Undo,
     Redo,
+    ConvertToGraph,
+    BakeGraph,
+    ShowGraphPane,
+    ArrangeGraph,
+    DeleteNode,
 }
 
 impl Command {
@@ -345,6 +360,11 @@ impl Command {
         Command::DeleteLayer,
         Command::Undo,
         Command::Redo,
+        Command::ConvertToGraph,
+        Command::BakeGraph,
+        Command::ShowGraphPane,
+        Command::ArrangeGraph,
+        Command::DeleteNode,
     ];
 
     fn label(self) -> &'static str {
@@ -366,6 +386,11 @@ impl Command {
             Command::DeleteLayer => "Delete selected layer  (Del)",
             Command::Undo => "Undo  (Ctrl+Z)",
             Command::Redo => "Redo  (Ctrl+Shift+Z)",
+            Command::ConvertToGraph => "Convert design to graph",
+            Command::BakeGraph => "Bake graph into the design",
+            Command::ShowGraphPane => "Show graph pane",
+            Command::ArrangeGraph => "Arrange graph nodes",
+            Command::DeleteNode => "Delete selected node  (Del)",
         }
     }
 
@@ -409,6 +434,11 @@ impl Command {
             }
             Command::Undo => app.undo(),
             Command::Redo => app.redo(),
+            Command::ConvertToGraph => app.convert_to_graph(),
+            Command::BakeGraph => app.bake_graph(),
+            Command::ShowGraphPane => app.show_graph_pane(),
+            Command::ArrangeGraph => app.arrange_graph(),
+            Command::DeleteNode => app.delete_selected_node(),
         }
     }
 }

--- a/crates/ringdesign-gui/src/panels/node.rs
+++ b/crates/ringdesign-gui/src/panels/node.rs
@@ -1,0 +1,138 @@
+//! The Node tool: the selected node's pins, values and diagnostics.
+
+use egui_phosphor::regular as icon;
+use ringdesign_graph::value::Literal;
+use ringdesign_graph_ui::widgets::{kind_color, pin_widget};
+
+use crate::app::RingDesignerApp;
+use crate::theme;
+
+pub fn ui(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
+    let Some(ed) = app.graph_ed.as_ref() else {
+        ui.weak("No graph. Open the Graph pane to convert the design or start one.");
+        return;
+    };
+    let Some(id) = app.selected_node else {
+        ui.weak("Click a node in the Graph pane to inspect it.");
+        return;
+    };
+    let Some(card) = ed.card(id).cloned() else {
+        ui.weak("The selected node is gone.");
+        return;
+    };
+    let Some(node) = ed.node(id).cloned() else { return };
+    let graph = ed.graph().clone();
+    let reg = app.graph_reg.clone();
+
+    ui.horizontal(|ui| {
+        ui.label(egui::RichText::new(&card.title).strong());
+        ui.weak(format!("{}  {}", card.kind, id));
+    });
+    if !card.doc.is_empty() {
+        ui.label(egui::RichText::new(&card.doc).small().color(theme::TEXT_DIM));
+    }
+    let mut label = card.label.clone().unwrap_or_default();
+    ui.horizontal(|ui| {
+        ui.label("Label");
+        if ui.add(egui::TextEdit::singleline(&mut label).desired_width(140.0)).lost_focus() {
+            if let Some(ed) = app.graph_ed.as_mut() {
+                if ed.set_label(id, Some(label.clone())) {
+                    app.graph_changed();
+                }
+            }
+        }
+    });
+    if !card.diag.is_empty() {
+        ui.separator();
+        for d in &card.diag {
+            ui.colored_label(theme::WARN, format!("{} {d}", icon::WARNING));
+        }
+    }
+    ui.separator();
+    ui.label(egui::RichText::new("Inputs").strong());
+    egui::Grid::new(("node_inputs", id)).num_columns(3).spacing([8.0, 4.0]).show(ui, |ui| {
+        for pin in &card.pins_in {
+            ui.label(egui::RichText::new(&pin.name).color(kind_color(pin.kind))).on_hover_text(format!("{}\n{}", pin.kind.label(), pin.doc));
+            match graph.wire_into(id, &pin.name) {
+                Some(w) => {
+                    ui.weak(format!("{} from {}.{}", icon::PLUGS_CONNECTED, w.from, w.out));
+                    ui.label("");
+                }
+                None => {
+                    let mut lit: Option<Literal> = node.inputs.get(&pin.name).cloned();
+                    let before = lit.clone();
+                    let spec = pin.clone();
+                    pin_widget(ui, &spec, &mut lit);
+                    if lit != before {
+                        if let Some(ed) = app.graph_ed.as_mut() {
+                            if ed.set_input(id, &pin.name, lit) {
+                                app.graph_changed();
+                            }
+                        }
+                    }
+                    let exposed = graph.exposed.iter().find(|e| e.node == id && e.input == pin.name).map(|e| e.name.clone());
+                    match exposed {
+                        Some(name) => {
+                            if ui.small_button(format!("{} {name}", icon::PUSH_PIN)).on_hover_text("Exposed on the graph's panel; click to withdraw").clicked() {
+                                if let Some(ed) = app.graph_ed.as_mut() {
+                                    ed.unexpose(&name);
+                                    app.graph_changed();
+                                }
+                            }
+                        }
+                        None => {
+                            if ui.small_button(icon::PUSH_PIN_SLASH).on_hover_text("Expose this input on the graph's panel").clicked() {
+                                if let Some(ed) = app.graph_ed.as_mut() {
+                                    let name = pretty(&pin.name);
+                                    if ed.expose(id, &pin.name, &name).is_ok() {
+                                        app.graph_changed();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            ui.end_row();
+        }
+    });
+    if !card.pins_out.is_empty() {
+        ui.separator();
+        ui.label(egui::RichText::new("Outputs").strong());
+        egui::Grid::new(("node_outputs", id)).num_columns(2).spacing([8.0, 4.0]).show(ui, |ui| {
+            for pin in &card.pins_out {
+                ui.label(egui::RichText::new(&pin.name).color(kind_color(pin.kind))).on_hover_text(format!("{}\n{}", pin.kind.label(), pin.doc));
+                match card.values.get(&pin.name) {
+                    Some(v) => ui.weak(v),
+                    None => ui.weak("—"),
+                };
+                ui.end_row();
+            }
+        });
+    }
+    if !node.params.is_null() {
+        ui.separator();
+        ui.collapsing("Params", |ui| {
+            let text = serde_json::to_string_pretty(&node.params).unwrap_or_default();
+            let shown: String = text.lines().take(40).collect::<Vec<_>>().join("\n");
+            ui.add(egui::Label::new(egui::RichText::new(shown).monospace().small()).wrap());
+        });
+    }
+    ui.separator();
+    ui.horizontal(|ui| {
+        if ui.button(format!("{} Delete node", icon::TRASH)).clicked() {
+            app.delete_selected_node();
+        }
+        let _ = &reg;
+    });
+}
+
+/// `width_mm` -> `Width`.
+fn pretty(key: &str) -> String {
+    let base = key.trim_end_matches("_mm").trim_end_matches("_deg").replace('_', " ");
+    let mut c = base.chars();
+    match c.next() {
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+        None => key.to_string(),
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -110,7 +110,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - [x] **M3.2 Editor core** (L, #40). Snarl payload `NodeCard`, `build_snarl`/`extract_graph` (truth
   = the graph), pin widgets by value kind, type-checked wiring, category palette, node menu,
   diagnostics on the node frame.
-- [ ] **M3.3 Desktop integration** (M, #41). `PaneKind::Graph` + a node-inspector dock tool; graph
+- [x] **M3.3 Desktop integration** (M, #41). `PaneKind::Graph` + a node-inspector dock tool; graph
   state on the app with a sync rule against `design.graph`; evaluation on the build worker;
   history labels; palette commands.
 - [ ] **M3.4 Simple ↔ graph bridge** (M, #42). Convert to graph, live banner with panels disabled


### PR DESCRIPTION
## Summary
- App state and one sync rule against `design.graph`; write-back through `graph_changed`; Convert / open / Bake / show pane / arrange / delete node.
- Worker: jobs carry the graph, evaluation first on a persistent `Evaluator`, the evaluated design is built and its field report reused; values/notes/errors return to the editor.
- `PaneKind::Graph` + `panels/graph.rs`; `ToolKind::Node` + `panels/node.rs`; five commands; Delete routed by the active pane; history labels (`first_difference` now sees one-sided keys).
- `Editor` gains `commit`, `set_input`, `set_label`, `expose`/`unexpose`, `arrange`, `card`, `node`.

## Verification
- `cargo test --workspace` green (GUI 31 tests).
- Not run interactively here — the pane and tool need a window.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)