### PR TITLE
M3.4 Simple ↔ graph bridge: banner, Bake, Edit in graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1550,6 +1550,35 @@ created on demand, so everything the app writes lands in one predictable tree.
 Recent, missing files disabled rather than hidden); File > New from template
 lists `templates::all()` with blurbs as hover text.
 
+### The graph pane, the node tool, and the bridge
+
+A design with `graph` set is **driven**: `app.sync_graph` rebuilds the
+`ringdesign_graph_ui::Editor` whenever `design.graph` differs from what the
+editor last saw (history, MCP, a file, Convert, Bake), and
+`app.graph_changed` writes the editor's graph back and marks dirty. The
+build worker evaluates the graph before it builds (a persistent
+`Evaluator`; the library's `Arc` identity is its epoch), builds the
+evaluated design, reuses the evaluation's field report, and returns
+per-node values and notes; `tick` splices the evaluated design in *under
+whatever the graph has become since*, so an edit made during a build is
+never clobbered. `mark_dirty` skips `regenerate_live` on a driven design —
+its generators are nodes on the worker.
+
+`PaneKind::Graph` is the editor (arrange, bake, the empty state offering
+Convert / the simple graph / the template graphs); `ToolKind::Node` is
+the inspector (pins with widgets or the wire feeding them, expose and
+withdraw, output values, params, diagnostics). While driven, the Design,
+Layers and Tiles tools show a banner and their bodies are disabled —
+the graph is where edits go — and the Layers banner lists the stack's
+entries as **Edit in graph** buttons: `Graph::entry_nodes` (the `entry`
+nodes in evaluation order, the lift's stack order) finds the producing
+node, the editor centres on it through snarl's `current_transform`, and
+the Node tool opens. Bake drops the graph and the design stays exactly as
+last evaluated. The Delete key acts on the active pane: a selected node
+in a Graph pane, otherwise the selected layer. History names a graph
+change as a document — converted, edited, baked — which is why
+`first_difference` treats a key present on one side only as a change.
+
 ### Paint-on-band: pressure is millimetres, the ceiling is the draft
 
 `paint.rs` (core) is the brush both apps share: `bite()` resolves a press

--- a/crates/ringdesign-graph-ui/src/editor.rs
+++ b/crates/ringdesign-graph-ui/src/editor.rs
@@ -173,12 +173,14 @@ pub struct Editor {
     pub selected: Option<NodeId>,
     pub editable: bool,
     style: SnarlStyle,
+    /// A node to centre the view on at the next frame.
+    pending_focus: Option<NodeId>,
 }
 
 impl Editor {
     pub fn new(graph: Graph, reg: &Registry) -> Self {
         let (snarl, ids) = build_snarl(&graph, reg);
-        Self { graph, snarl, ids, revision: 0, selected: None, editable: true, style: SnarlStyle::new() }
+        Self { graph, snarl, ids, revision: 0, selected: None, editable: true, style: SnarlStyle::new(), pending_focus: None }
     }
 
     pub fn graph(&self) -> &Graph {
@@ -232,9 +234,27 @@ impl Editor {
         }
     }
 
+    /// Centre the view on a node at the next frame, and select it.
+    pub fn focus(&mut self, id: NodeId) {
+        if self.graph.contains(id) {
+            self.pending_focus = Some(id);
+            self.selected = Some(id);
+        }
+    }
+
     /// Draw the editor and extract any change.
     pub fn show(&mut self, reg: &Registry, ui: &mut Ui, id_salt: &str) -> EditorResponse {
-        let mut viewer = Viewer { reg, editable: self.editable, clicked: None, refused: None, search: String::new(), ids: &self.ids };
+        let focus = self.pending_focus.take().and_then(|id| self.ids.to_snarl.get(&id).copied());
+        let mut viewer = Viewer {
+            reg,
+            editable: self.editable,
+            clicked: None,
+            refused: None,
+            search: String::new(),
+            ids: &self.ids,
+            focus,
+            viewport_center: ui.available_rect_before_wrap().center(),
+        };
         self.snarl.show(&mut viewer, &self.style, id_salt, ui);
         let clicked = viewer.clicked;
         let refused = viewer.refused.take();
@@ -379,6 +399,8 @@ struct Viewer<'a> {
     refused: Option<String>,
     search: String,
     ids: &'a IdMap,
+    focus: Option<SnarlId>,
+    viewport_center: egui::Pos2,
 }
 
 fn pin_info(pin: &PinSpec) -> PinInfo {
@@ -452,6 +474,18 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
     fn show_on_hover_popup(&mut self, node: SnarlId, _inputs: &[InPin], _outputs: &[OutPin], ui: &mut Ui, snarl: &mut Snarl<NodeCard>) {
         for d in &snarl[node].diag {
             ui.colored_label(Color32::from_rgb(220, 90, 90), d);
+        }
+    }
+
+    fn current_transform(&mut self, to_global: &mut egui::emath::TSTransform, snarl: &mut Snarl<NodeCard>) {
+        if let Some(sid) = self.focus.take() {
+            if let Some(info) = snarl.get_node_info(sid) {
+                // The node's top-left, pushed a little so the header sits
+                // near the centre rather than the corner.
+                let anchor = info.pos + egui::vec2(110.0, 40.0);
+                let scale = to_global.scaling.max(0.1);
+                to_global.translation = self.viewport_center.to_vec2() - anchor.to_vec2() * scale;
+            }
         }
     }
 
@@ -609,7 +643,7 @@ mod tests {
 
         // Text -> Number is refused by the viewer; Number -> Number replaces.
         let (mut snarl, ids) = build_snarl(&g, &reg);
-        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids };
+        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids, focus: None, viewport_center: egui::Pos2::ZERO };
         let text_out = OutPin { id: OutPinId { node: ids.to_snarl[&t], output: 0 }, remotes: vec![] };
         let add_b = InPin { id: InPinId { node: ids.to_snarl[&a], input: 1 }, remotes: vec![] };
         viewer.connect(&text_out, &add_b, &mut snarl);
@@ -645,6 +679,28 @@ mod tests {
         assert!(ed.remove(p));
         let extracted = extract_graph(ed.snarl(), ed.graph());
         assert!(extracted.nodes.is_empty() && extracted.exposed.is_empty());
+    }
+
+    #[test]
+    fn focus_selects_and_is_consumed_by_a_frame() {
+        let reg = Registry::builtin();
+        let g = ringdesign_graph::templates::graph("Braided band").unwrap();
+        let entries = g.entry_nodes();
+        assert_eq!(entries.len(), 2, "two layers, two entry nodes, in stack order");
+        assert!(g.node(entries[0]).unwrap().inputs.get("name") == Some(&Literal::Text("Braid".into())));
+        let mut ed = Editor::new(g, &reg);
+        ed.focus(entries[1]);
+        assert_eq!(ed.selected, Some(entries[1]));
+        assert!(ed.pending_focus.is_some());
+        let mut harness = egui_kittest::Harness::new_ui(|ui| {
+            ed.show(&reg, ui, "focus-editor");
+        });
+        harness.set_size(egui::vec2(900.0, 600.0));
+        harness.run();
+        drop(harness);
+        assert!(ed.pending_focus.is_none(), "one frame consumes the focus");
+        ed.focus(NodeId(999));
+        assert!(ed.pending_focus.is_none(), "an unknown node is ignored");
     }
 
     #[test]

--- a/crates/ringdesign-graph/src/graph.rs
+++ b/crates/ringdesign-graph/src/graph.rs
@@ -394,6 +394,16 @@ impl Graph {
         }
     }
 
+    /// The `entry` nodes in evaluation order — the order the lift builds a
+    /// stack in, so the k-th one is the node behind the k-th layer of a
+    /// lifted design (a best effort on a hand-wired graph).
+    pub fn entry_nodes(&self) -> Vec<NodeId> {
+        match self.topo() {
+            Ok(order) => order.into_iter().filter(|id| self.node(*id).is_some_and(|n| n.kind == "entry")).collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     /// Every node this one depends on, nearest first.
     pub fn upstream(&self, id: NodeId) -> Vec<NodeId> {
         let mut seen = BTreeSet::new();

--- a/crates/ringdesign-gui/src/app.rs
+++ b/crates/ringdesign-gui/src/app.rs
@@ -843,6 +843,23 @@ impl RingDesignerApp {
         self.graph_changed();
     }
 
+    /// Jump to the node that produced the k-th layer of the stack.
+    pub fn edit_in_graph(&mut self, layer: usize) {
+        let Some(ed) = &mut self.graph_ed else { return };
+        let entries = ed.graph().entry_nodes();
+        match entries.get(layer).copied() {
+            Some(id) => {
+                ed.focus(id);
+                self.selected_node = Some(id);
+                self.show_graph_pane();
+                if !self.dock.is_open(crate::dock::ToolKind::Node) {
+                    self.dock.open_on(crate::dock::ToolKind::Node, crate::dock::Side::Right);
+                }
+            }
+            None => self.set_status("No entry node for that layer; the graph builds its stack another way"),
+        }
+    }
+
     pub fn delete_selected_node(&mut self) {
         let Some(id) = self.selected_node.take() else { return };
         if let Some(ed) = &mut self.graph_ed {

--- a/crates/ringdesign-gui/src/panels/mod.rs
+++ b/crates/ringdesign-gui/src/panels/mod.rs
@@ -121,12 +121,20 @@ impl egui_tiles::Behavior<ToolKind> for ToolBehavior<'_> {
         egui::ScrollArea::vertical()
             .id_salt(("tool", tool.label()))
             .auto_shrink([false, false])
-            .show(ui, |ui| match tool {
-                ToolKind::Design => design::ui(self.app, ui),
-                ToolKind::Layers => layers::ui(self.app, ui),
-                ToolKind::Report => report::ui(self.app, ui),
-                ToolKind::Library => library::ui(self.app, ui),
-                ToolKind::Node => node::ui(self.app, ui),
+            .show(ui, |ui| {
+                // While a graph drives the design these panels only show;
+                // the graph is where edits go.
+                let driven = self.app.graph_driven() && matches!(tool, ToolKind::Design | ToolKind::Layers | ToolKind::Library);
+                if driven {
+                    driven_banner(self.app, ui, tool);
+                }
+                ui.add_enabled_ui(!driven, |ui| match tool {
+                    ToolKind::Design => design::ui(self.app, ui),
+                    ToolKind::Layers => layers::ui(self.app, ui),
+                    ToolKind::Report => report::ui(self.app, ui),
+                    ToolKind::Library => library::ui(self.app, ui),
+                    ToolKind::Node => node::ui(self.app, ui),
+                });
             });
         egui_tiles::UiResponse::None
     }
@@ -339,6 +347,39 @@ enum Command {
     ShowGraphPane,
     ArrangeGraph,
     DeleteNode,
+}
+
+/// The strip over a panel whose design is driven by a graph.
+fn driven_banner(app: &mut RingDesignerApp, ui: &mut egui::Ui, tool: ToolKind) {
+    egui::Frame::NONE
+        .fill(theme::PANEL)
+        .stroke(egui::Stroke::new(1.0, theme::ACCENT_DIM))
+        .inner_margin(egui::Margin::symmetric(8, 6))
+        .corner_radius(4.0)
+        .show(ui, |ui| {
+            ui.horizontal_wrapped(|ui| {
+                ui.colored_label(theme::ACCENT, format!("{} Driven by the graph", icon::GRAPH));
+                ui.weak("— edit the graph, or bake it to edit here.");
+                if ui.small_button(format!("{} Edit graph", icon::GRAPH)).clicked() {
+                    app.show_graph_pane();
+                }
+                if ui.small_button(format!("{} Bake", icon::FIRE)).on_hover_text("Drop the graph; keep the design as last evaluated").clicked() {
+                    app.bake_graph();
+                }
+            });
+            if tool == ToolKind::Layers && !app.design.layers.layers.is_empty() {
+                ui.horizontal_wrapped(|ui| {
+                    ui.weak("Edit in graph:");
+                    let names: Vec<String> = app.design.layers.layers.iter().map(|e| e.name.clone()).collect();
+                    for (k, name) in names.iter().enumerate() {
+                        if ui.small_button(name).on_hover_text("Find the node that produced this layer").clicked() {
+                            app.edit_in_graph(k);
+                        }
+                    }
+                });
+            }
+        });
+    ui.add_space(4.0);
 }
 
 impl Command {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,7 +113,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - [x] **M3.3 Desktop integration** (M, #41). `PaneKind::Graph` + a node-inspector dock tool; graph
   state on the app with a sync rule against `design.graph`; evaluation on the build worker;
   history labels; palette commands.
-- [ ] **M3.4 Simple ↔ graph bridge** (M, #42). Convert to graph, live banner with panels disabled
+- [x] **M3.4 Simple ↔ graph bridge** (M, #42). Convert to graph, live banner with panels disabled
   while driven, Bake, "Edit in graph".
 
 ## M4 — Scripting, MCP and CLI (L) — epic #20


### PR DESCRIPTION
## Summary
- Driven banner over Design/Layers/Tiles with bodies disabled; Edit in graph per stack entry (`Graph::entry_nodes`), `Editor::focus` via `current_transform`, Node tool opened.
- CLAUDE.md: the graph pane, the node tool and the bridge.

## Verification
- `cargo test --workspace` green (graph-ui 6 tests incl. focus consumed by a frame).

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)