### PR TITLE
M4.1 ringdesign-script: sandboxed rhai, expression pins, script nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1520,6 +1520,20 @@ What the runtime settled while being built, each pinned by a test:
   the golden test holds each file to its builder and each evaluation to the
   code template **byte for byte**. Regenerate with
   `RD_WRITE_TEMPLATE_GRAPHS=1 cargo test -p ringdesign-graph write_template_graphs`.
+- **Scripts compute and nothing else** (`crates/ringdesign-script`): one
+  sandboxed rhai engine per process — operation, call-depth, expression-
+  depth, array, map and string caps, `eval` disabled, no module resolver —
+  and `loop {}` halts with "Too many operations" (pinned). The graph crate
+  defines the `ExprEvaluator` hook and `Literal::Expr` (`{"expr": …}` in a
+  file, the one tagged literal shape); the script crate implements it.
+  An expression pin runs per item with the node's other inputs in scope
+  plus `i`/`n`; a `script` node declares its pins in header comments
+  (`// in: a: Number = 1.0, b: List<Number>` / `// out: h: Number`), reads
+  inputs as variables and leaves outputs as variables, and header errors
+  name their line. A literal left on a pin the header no longer names
+  stays a pin, so the graph still validates and the node reports the
+  header itself. `ringdesign_script::registry()` is the builtin library
+  plus the script node; the GUI and its worker use it.
 - **The lift is exact by construction** (`lift.rs`, `Graph::from_design`):
   it wires the nodes a person would, evaluates them, diffs the result
   against the design field by field, and carries whatever the nodes cannot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -479,6 +480,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1205,6 +1226,17 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -2000,6 +2032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2407,9 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2792,6 +2836,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rhai"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
+dependencies = [
+ "ahash",
+ "bitflags 2.13.1",
+ "no-std-compat",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd3a7535e50bf36857e7be7bec276d334e8c2dfa469c2201226fd01638ea5ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ringdesign-configurator"
 version = "0.1.0"
 dependencies = [
@@ -2865,6 +2939,7 @@ dependencies = [
  "ringdesign-graph",
  "ringdesign-graph-ui",
  "ringdesign-mcp",
+ "ringdesign-script",
  "serde",
  "serde_json",
  "tokio",
@@ -2901,6 +2976,17 @@ dependencies = [
  "ringdesign-mcp",
  "rmcp",
  "tokio",
+]
+
+[[package]]
+name = "ringdesign-script"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "rhai",
+ "ringdesign-core",
+ "ringdesign-graph",
+ "serde_json",
 ]
 
 [[package]]
@@ -3247,6 +3333,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "serde",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "smithay-client-toolkit"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,6 +3427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "sse-stream"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,6 +3559,15 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/ringdesign-configurator",
     "crates/ringdesign-graph",
     "crates/ringdesign-graph-ui",
+    "crates/ringdesign-script",
 ]
 # Vendored forks are reached through [patch.crates-io], not built as members.
 exclude = ["patches/egui-snarl", "patches/egui-scale"]
@@ -22,6 +23,8 @@ ringdesign-core = { path = "crates/ringdesign-core" }
 ringdesign-mcp = { path = "crates/ringdesign-mcp" }
 ringdesign-graph = { path = "crates/ringdesign-graph" }
 ringdesign-graph-ui = { path = "crates/ringdesign-graph-ui" }
+ringdesign-script = { path = "crates/ringdesign-script" }
+rhai = { version = "1.25", features = ["sync", "serde"] }
 
 nalgebra = "0.35"
 serde = { version = "1.0.229", features = ["derive"] }

--- a/crates/ringdesign-graph-ui/src/widgets.rs
+++ b/crates/ringdesign-graph-ui/src/widgets.rs
@@ -8,6 +8,15 @@ use ringdesign_graph::value::{Literal, ValueKind};
 /// the literal changed.
 pub fn pin_widget(ui: &mut Ui, pin: &PinSpec, literal: &mut Option<Literal>) -> bool {
     let effective = literal.clone().or_else(|| pin.default.clone());
+    if let Some(Literal::Expr(e)) = &effective {
+        let mut code = e.expr.clone();
+        ui.label(egui::RichText::new("=").monospace().strong());
+        if ui.add_sized([140.0, 18.0], egui::TextEdit::singleline(&mut code).font(egui::TextStyle::Monospace)).changed() {
+            *literal = Some(Literal::expr(code));
+            return true;
+        }
+        return false;
+    }
     if let Some(Literal::List(items)) = &effective {
         ui.weak(format!("list ×{}", items.len()));
         return false;

--- a/crates/ringdesign-graph/src/eval.rs
+++ b/crates/ringdesign-graph/src/eval.rs
@@ -23,8 +23,8 @@ use ringdesign_core::{AlphaLibrary, RingDesign};
 
 use crate::MAX_LIST_ITEMS;
 use crate::graph::{Access, Graph, GraphError, NodeId};
-use crate::registry::{EvalCtx, Inputs, NodeSpec, Registry};
-use crate::value::{Value, ValueKind};
+use crate::registry::{EvalCtx, Inputs, NodeSpec, PinSpec, Registry};
+use crate::value::{Literal, Value, ValueKind};
 
 /// The kind of the node whose `design` input is what a SandRing graph is
 /// for. Registered by the sink library; named here so the evaluator can
@@ -37,6 +37,21 @@ pub const MAX_RECORDED_ERRORS: usize = 16;
 /// Sampling the field verdict reads at: the GUI worker's numbers.
 pub const FIELD_THETA_STEPS: usize = 192;
 pub const FIELD_PROFILE_STEPS: usize = 128;
+
+/// What an expression on a pin sees: the node's other inputs by name,
+/// and where in the implicit list it is.
+#[derive(Clone, Debug, Default)]
+pub struct ExprScope {
+    pub siblings: BTreeMap<String, Value>,
+    pub item: usize,
+    pub items: usize,
+}
+
+/// Runs `{"expr": …}` pins. The graph crate only defines the hook; the
+/// script crate implements it, so the runtime stays free of any language.
+pub trait ExprEvaluator: Send + Sync {
+    fn eval_expr(&self, code: &str, scope: &ExprScope) -> Result<Value, String>;
+}
 
 /// Which nodes an evaluation runs.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -139,11 +154,17 @@ pub struct Evaluator {
     cache: HashMap<NodeId, CacheEntry>,
     /// How deep in clusters this evaluator runs; the root is 0.
     pub depth: usize,
+    /// Runs expression pins; without one they fail with a clear line.
+    pub exprs: Option<Arc<dyn ExprEvaluator>>,
 }
 
 impl Evaluator {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_exprs(exprs: Arc<dyn ExprEvaluator>) -> Self {
+        Self { exprs: Some(exprs), ..Self::default() }
     }
 
     /// Forget every cached output.
@@ -243,7 +264,7 @@ impl Evaluator {
                     }
                 }
             }
-            let (outputs, status) = run_node(g, reg, spec, node, &report.values, lib, lib_epoch, run_side_effects, self.depth, injected);
+            let (outputs, status) = run_node(g, reg, spec, node, &report.values, lib, lib_epoch, run_side_effects, self.depth, injected, self.exprs.as_ref());
             report.values.insert(id, outputs.clone());
             report.status.insert(id, status.clone());
             if !spec.side_effect {
@@ -309,10 +330,13 @@ fn run_node(
     run_side_effects: bool,
     depth: usize,
     injected: &BTreeMap<(NodeId, String), Value>,
+    exprs: Option<&Arc<dyn ExprEvaluator>>,
 ) -> (BTreeMap<String, Value>, NodeStatus) {
     let start = tick();
     let mut status = NodeStatus::default();
     let (in_pins, out_pins) = spec.pins_for(node, reg);
+    // Expression pins run per item once the other inputs are in scope.
+    let mut expr_pins: Vec<(PinSpec, String)> = Vec::new();
     let record = |status: &mut NodeStatus, item: usize, msg: String| {
         status.error_count += 1;
         if status.errors.len() < MAX_RECORDED_ERRORS {
@@ -322,6 +346,12 @@ fn run_node(
 
     let mut resolved: BTreeMap<String, Resolved> = BTreeMap::new();
     for pin in &in_pins {
+        if injected.get(&(node.id, pin.name.clone())).is_none() && g.wire_into(node.id, &pin.name).is_none() {
+            if let Some(code) = node.inputs.get(&pin.name).and_then(Literal::as_expr) {
+                expr_pins.push((pin.clone(), code.to_string()));
+                continue;
+            }
+        }
         let raw: Value = match injected.get(&(node.id, pin.name.clone())) {
             Some(v) => v.clone(),
             None => match g.wire_into(node.id, &pin.name) {
@@ -378,6 +408,7 @@ fn run_node(
     ctx.run_side_effects = run_side_effects;
     ctx.depth = depth;
     ctx.lib_epoch = lib_epoch;
+    ctx.exprs = exprs.cloned();
     ctx.items = n;
     for t in 0..n {
         ctx.item = t;
@@ -395,6 +426,28 @@ fn run_node(
                 Access::List => Value::List(r.items.clone()),
             };
             inputs.values.insert(name.clone(), v);
+        }
+        let mut expr_failed = false;
+        for (pin, code) in &expr_pins {
+            let result = match exprs {
+                Some(ev) => ev.eval_expr(code, &ExprScope { siblings: inputs.values.clone(), item: t, items: n }),
+                None => Err("no expression engine is attached to this evaluation".to_string()),
+            };
+            match result.and_then(|v| pin.kind.coerce(v).map_err(|e| e.to_string())) {
+                Ok(v) => {
+                    inputs.values.insert(pin.name.clone(), v);
+                }
+                Err(e) => {
+                    record(&mut status, t, format!("{}: expression: {e}", pin.name));
+                    expr_failed = true;
+                }
+            }
+        }
+        if expr_failed {
+            for p in &out_pins {
+                columns.get_mut(&p.name).expect("declared").push(Value::Null);
+            }
+            continue;
         }
         match (spec.eval)(&mut ctx, node, &inputs) {
             Ok(outs) => {

--- a/crates/ringdesign-graph/src/graph.rs
+++ b/crates/ringdesign-graph/src/graph.rs
@@ -495,7 +495,8 @@ impl Graph {
                                     let from = lit.kind();
                                     let ok = pin.kind.accepts(from)
                                         || (from == ValueKind::List && pin.access == Access::List)
-                                        || from == ValueKind::List;
+                                        || from == ValueKind::List
+                                        || lit.as_expr().is_some();
                                     if !ok {
                                         errs.push(GraphError::at(n.id, format!("input {name:?} takes {}, not {}", pin.kind.label(), from.label())));
                                     }

--- a/crates/ringdesign-graph/src/nodes/cluster.rs
+++ b/crates/ringdesign-graph/src/nodes/cluster.rs
@@ -93,6 +93,7 @@ fn run(ctx: &mut EvalCtx<'_>, node: &Node, i: &Inputs) -> Result<Outputs, NodeEr
     }
     let mut ev = Evaluator::new();
     ev.depth = ctx.depth + 1;
+    ev.exprs = ctx.exprs.clone();
     let report = ev.evaluate_injected(&inner, ctx.reg, ctx.lib, ctx.lib_epoch, Targets::Nodes(targets), &injected);
     if let Some(e) = report.errors.first() {
         return Err(NodeError::new(format!("inside {:?}: {e}", inner.name)));

--- a/crates/ringdesign-graph/src/registry.rs
+++ b/crates/ringdesign-graph/src/registry.rs
@@ -166,6 +166,8 @@ pub struct EvalCtx<'a> {
     pub depth: usize,
     /// The alpha library's epoch, for nested evaluations.
     pub lib_epoch: u64,
+    /// The expression engine, handed down to nested evaluations.
+    pub exprs: Option<Arc<dyn crate::eval::ExprEvaluator>>,
     /// Whether sinks that write files or spawn work may do so this run.
     pub run_side_effects: bool,
     /// Which item of an implicit list this run is, and how many there are.
@@ -177,7 +179,7 @@ pub struct EvalCtx<'a> {
 
 impl<'a> EvalCtx<'a> {
     pub fn new(lib: &'a AlphaLibrary, reg: &'a Registry, mode: Mode) -> Self {
-        Self { lib, reg, mode, depth: 0, lib_epoch: 0, run_side_effects: false, item: 0, items: 1, warnings: Vec::new() }
+        Self { lib, reg, mode, depth: 0, lib_epoch: 0, exprs: None, run_side_effects: false, item: 0, items: 1, warnings: Vec::new() }
     }
 
     pub fn warn(&mut self, message: impl Into<String>) {

--- a/crates/ringdesign-graph/src/value.rs
+++ b/crates/ringdesign-graph/src/value.rs
@@ -615,9 +615,17 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
     }
 }
 
+/// An expression on a pin, evaluated per item with the node's other
+/// inputs in scope: `{"expr": "width_mm / 3"}` in a file.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExprLit {
+    pub expr: String,
+}
+
 /// What an unwired pin holds in a graph file: the literal subset of
 /// [`Value`]. Untagged, so a file reads `6.0`, `12`, `"Oval"`, `true`,
-/// `[1, 2, 3]` or an object as what they look like.
+/// `[1, 2, 3]` or an object as what they look like; an expression is the
+/// one tagged shape, `{"expr": …}`, tried before a plain object.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Literal {
@@ -627,6 +635,7 @@ pub enum Literal {
     Number(f64),
     Text(String),
     List(Vec<Literal>),
+    Expr(ExprLit),
     Json(serde_json::Value),
 }
 
@@ -654,7 +663,21 @@ impl Literal {
             Literal::Number(_) => ValueKind::Number,
             Literal::Text(_) => ValueKind::Text,
             Literal::List(_) => ValueKind::List,
+            // An expression's kind is known only once it runs.
+            Literal::Expr(_) => ValueKind::Any,
             Literal::Json(_) => ValueKind::Json,
+        }
+    }
+
+    /// An expression literal.
+    pub fn expr(code: impl Into<String>) -> Self {
+        Literal::Expr(ExprLit { expr: code.into() })
+    }
+
+    pub fn as_expr(&self) -> Option<&str> {
+        match self {
+            Literal::Expr(e) => Some(&e.expr),
+            _ => None,
         }
     }
 }
@@ -668,6 +691,9 @@ impl From<Literal> for Value {
             Literal::Number(x) => Value::Number(x),
             Literal::Text(s) => Value::Text(s),
             Literal::List(items) => Value::List(items.into_iter().map(Value::from).collect()),
+            // Unevaluated, an expression is nothing; the evaluator runs it
+            // before it ever gets here.
+            Literal::Expr(_) => Value::Null,
             Literal::Json(j) => Value::Json(Arc::new(j)),
         }
     }
@@ -760,6 +786,7 @@ mod tests {
             ("\"Oval\"", Literal::Text("Oval".into())),
             ("[1,2.5,\"x\"]", Literal::List(vec![Literal::Int(1), Literal::Number(2.5), Literal::Text("x".into())])),
             ("{\"a\":1}", Literal::Json(serde_json::json!({"a": 1}))),
+            ("{\"expr\":\"w / 2\"}", Literal::expr("w / 2")),
         ];
         for (text, want) in cases {
             let got: Literal = serde_json::from_str(text).unwrap();
@@ -767,6 +794,9 @@ mod tests {
             let back = serde_json::to_string(&got).unwrap();
             let again: Literal = serde_json::from_str(&back).unwrap();
             assert_eq!(again, want, "{text} via {back}");
+            if got.as_expr().is_some() {
+                continue;
+            }
             let v = Value::from(got.clone());
             assert_eq!(Literal::of(&v), Some(want), "{text} through Value");
         }

--- a/crates/ringdesign-gui/Cargo.toml
+++ b/crates/ringdesign-gui/Cargo.toml
@@ -19,6 +19,7 @@ egui-phosphor.workspace = true
 egui_tiles.workspace = true
 ringdesign-graph = { path = "../ringdesign-graph" }
 ringdesign-graph-ui = { path = "../ringdesign-graph-ui" }
+ringdesign-script = { path = "../ringdesign-script" }
 rfd.workspace = true
 nalgebra.workspace = true
 serde.workspace = true

--- a/crates/ringdesign-gui/src/app.rs
+++ b/crates/ringdesign-gui/src/app.rs
@@ -313,7 +313,7 @@ impl RingDesignerApp {
             status: "Ready".into(),
             auto_rebuild: true,
             history: History::new(&design_for_history),
-            graph_reg: Arc::new(Registry::builtin()),
+            graph_reg: Arc::new(ringdesign_script::registry()),
             graph_ed: None,
             graph_json: None,
             graph_errors: Vec::new(),
@@ -916,8 +916,8 @@ impl Worker {
         std::thread::Builder::new()
             .name("ring-build".into())
             .spawn(move || {
-                let reg = Registry::builtin();
-                let mut evaluator = Evaluator::new();
+                let reg = ringdesign_script::registry();
+                let mut evaluator = Evaluator::with_exprs(ringdesign_script::engine());
                 while let Ok(mut job) = jobs_rx.recv() {
                     // Skip stale work: only the newest queued job matters.
                     while let Ok(newer) = jobs_rx.try_recv() {

--- a/crates/ringdesign-script/Cargo.toml
+++ b/crates/ringdesign-script/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ringdesign-script"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+description = "Sandboxed rhai for ringdesign-graph: expression pins and script nodes"
+
+[dependencies]
+ringdesign-core = { path = "../ringdesign-core", default-features = false }
+ringdesign-graph = { path = "../ringdesign-graph", default-features = false }
+rhai.workspace = true
+serde_json.workspace = true
+log.workspace = true

--- a/crates/ringdesign-script/src/lib.rs
+++ b/crates/ringdesign-script/src/lib.rs
@@ -1,0 +1,309 @@
+//! Sandboxed rhai for the graph: expression pins and script nodes.
+//!
+//! One [`ScriptEngine`] per process, built with every cap rhai offers —
+//! operations, call depth, expression depth, array, map and string sizes —
+//! `eval` disabled and no module resolver, so a script can compute and
+//! nothing else. Values cross as plain rhai types (numbers, bools, strings,
+//! arrays); a design is a registered handle with the chart's numbers as
+//! functions on it; every other handle passes through opaque.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use rhai::{AST, Array, Dynamic, Engine, Scope};
+use ringdesign_core::RingDesign;
+use ringdesign_core::field::SIDE_FACE_MIN_DRAFT_DEG;
+use ringdesign_graph::MAX_LIST_ITEMS;
+use ringdesign_graph::eval::{ExprEvaluator, ExprScope};
+use ringdesign_graph::registry::Registry;
+use ringdesign_graph::value::Value;
+
+pub mod node;
+
+/// Operations a single evaluation may spend before it is stopped.
+pub const MAX_OPERATIONS: u64 = 200_000;
+pub const MAX_CALL_LEVELS: usize = 32;
+pub const MAX_STRING_BYTES: usize = 64 * 1024;
+
+/// The sandbox.
+pub struct ScriptEngine {
+    engine: Engine,
+    asts: Mutex<HashMap<u64, Arc<AST>>>,
+}
+
+impl Default for ScriptEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A design handle inside a script.
+#[derive(Clone)]
+pub struct DesignRef(pub Arc<RingDesign>);
+
+/// Any other handle, carried through untouched.
+#[derive(Clone)]
+pub struct Opaque(pub Value);
+
+impl ScriptEngine {
+    pub fn new() -> Self {
+        let mut engine = Engine::new();
+        engine
+            .set_max_operations(MAX_OPERATIONS)
+            .set_max_call_levels(MAX_CALL_LEVELS)
+            .set_max_expr_depths(64, 32)
+            .set_max_array_size(MAX_LIST_ITEMS)
+            .set_max_map_size(1024)
+            .set_max_string_size(MAX_STRING_BYTES)
+            .set_module_resolver(rhai::module_resolvers::DummyModuleResolver);
+        engine.disable_symbol("eval");
+        engine.register_type_with_name::<DesignRef>("Design");
+        engine.register_type_with_name::<Opaque>("Handle");
+        api::register(&mut engine);
+        Self { engine, asts: Mutex::new(HashMap::new()) }
+    }
+
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    /// Compile once per distinct source.
+    pub fn compile(&self, code: &str) -> Result<Arc<AST>, String> {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::hash::DefaultHasher::new();
+        code.hash(&mut h);
+        let key = h.finish();
+        if let Some(ast) = self.asts.lock().ok().and_then(|m| m.get(&key).cloned()) {
+            return Ok(ast);
+        }
+        let ast = Arc::new(self.engine.compile(code).map_err(|e| e.to_string())?);
+        if let Ok(mut m) = self.asts.lock() {
+            if m.len() > 256 {
+                m.clear();
+            }
+            m.insert(key, ast.clone());
+        }
+        Ok(ast)
+    }
+
+    /// Run `code` with `scope` and return what it evaluates to.
+    pub fn eval(&self, code: &str, scope: &mut Scope<'static>) -> Result<Dynamic, String> {
+        let ast = self.compile(code)?;
+        self.engine.eval_ast_with_scope::<Dynamic>(scope, &ast).map_err(|e| e.to_string())
+    }
+}
+
+/// A graph value as a script value.
+pub fn to_dynamic(v: &Value) -> Dynamic {
+    match v {
+        Value::Null => Dynamic::UNIT,
+        Value::Number(x) => Dynamic::from_float(*x),
+        Value::Int(i) => Dynamic::from_int(*i),
+        Value::Bool(b) => Dynamic::from_bool(*b),
+        Value::Text(s) | Value::AlphaRef(s) => Dynamic::from(s.clone()),
+        Value::List(items) => Dynamic::from_array(items.iter().map(to_dynamic).collect()),
+        Value::Json(j) => rhai::serde::to_dynamic(&**j).unwrap_or(Dynamic::UNIT),
+        Value::Path(p) => Dynamic::from_array(p.iter().map(|q| Dynamic::from_array(vec![Dynamic::from_float(q[0]), Dynamic::from_float(q[1])])).collect()),
+        Value::Design(d) => Dynamic::from(DesignRef(d.clone())),
+        other => Dynamic::from(Opaque(other.clone())),
+    }
+}
+
+/// A script value as a graph value.
+pub fn from_dynamic(d: Dynamic) -> Value {
+    if d.is_unit() {
+        return Value::Null;
+    }
+    if d.is_int() {
+        return Value::Int(d.as_int().unwrap_or(0));
+    }
+    if d.is_float() {
+        return Value::Number(d.as_float().unwrap_or(f64::NAN));
+    }
+    if d.is_bool() {
+        return Value::Bool(d.as_bool().unwrap_or(false));
+    }
+    if d.is_string() {
+        return Value::Text(d.into_string().unwrap_or_default());
+    }
+    if d.is_array() {
+        let items: Array = d.into_array().unwrap_or_default();
+        return Value::List(items.into_iter().map(from_dynamic).collect());
+    }
+    if d.is::<DesignRef>() {
+        return Value::Design(d.cast::<DesignRef>().0);
+    }
+    if d.is::<Opaque>() {
+        return d.cast::<Opaque>().0;
+    }
+    if d.is_map() {
+        return match rhai::serde::from_dynamic::<serde_json::Value>(&d) {
+            Ok(j) => Value::Json(Arc::new(j)),
+            Err(_) => Value::Null,
+        };
+    }
+    Value::Text(d.to_string())
+}
+
+impl ExprEvaluator for ScriptEngine {
+    fn eval_expr(&self, code: &str, scope: &ExprScope) -> Result<Value, String> {
+        let mut s = Scope::new();
+        for (k, v) in &scope.siblings {
+            s.push_dynamic(k.clone(), to_dynamic(v));
+        }
+        s.push("i", scope.item as i64);
+        s.push("n", scope.items as i64);
+        self.eval(code, &mut s).map(from_dynamic)
+    }
+}
+
+/// The process-wide sandbox.
+pub fn engine() -> Arc<ScriptEngine> {
+    static ENGINE: OnceLock<Arc<ScriptEngine>> = OnceLock::new();
+    ENGINE.get_or_init(|| Arc::new(ScriptEngine::new())).clone()
+}
+
+/// The builtin node library plus the script node.
+pub fn registry() -> Registry {
+    let mut reg = Registry::builtin();
+    node::register(&mut reg, engine());
+    reg
+}
+
+/// The small API scripts see: interpolation, series, list folds, and the
+/// chart's numbers off a design.
+mod api {
+    use super::*;
+
+    pub fn register(engine: &mut Engine) {
+        engine.register_fn("lerp", |a: f64, b: f64, t: f64| a + (b - a) * t);
+        engine.register_fn("remap", |x: f64, a: f64, b: f64, c: f64, d: f64| if (b - a).abs() < 1e-300 { c } else { c + (d - c) * (x - a) / (b - a) });
+        engine.register_fn("clamp", |x: f64, lo: f64, hi: f64| x.clamp(lo.min(hi), hi.max(lo)));
+        engine.register_fn("deg", |x: f64| x.to_degrees());
+        engine.register_fn("rad", |x: f64| x.to_radians());
+        engine.register_fn("series", |start: f64, step: f64, count: i64| -> Array {
+            let n = count.clamp(0, MAX_LIST_ITEMS as i64) as usize;
+            (0..n).map(|k| Dynamic::from_float(start + step * k as f64)).collect()
+        });
+        engine.register_fn("linspace", |a: f64, b: f64, count: i64| -> Array {
+            let n = count.clamp(0, MAX_LIST_ITEMS as i64) as usize;
+            match n {
+                0 => Vec::new(),
+                1 => vec![Dynamic::from_float(a)],
+                n => (0..n).map(|k| Dynamic::from_float(a + (b - a) * k as f64 / (n - 1) as f64)).collect(),
+            }
+        });
+        engine.register_fn("sum", |a: Array| a.iter().filter_map(num).sum::<f64>());
+        engine.register_fn("mean", |a: Array| {
+            let xs: Vec<f64> = a.iter().filter_map(num).collect();
+            if xs.is_empty() { 0.0 } else { xs.iter().sum::<f64>() / xs.len() as f64 }
+        });
+        engine.register_fn("minmax", |a: Array| -> Array {
+            let xs: Vec<f64> = a.iter().filter_map(num).collect();
+            let lo = xs.iter().copied().fold(f64::INFINITY, f64::min);
+            let hi = xs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            if xs.is_empty() { Vec::new() } else { vec![Dynamic::from_float(lo), Dynamic::from_float(hi)] }
+        });
+        engine.register_fn("circumference", |d: DesignRef| d.0.field_context().circumference_mm);
+        engine.register_fn("inner_diameter", |d: DesignRef| d.0.size.inner_diameter_mm());
+        engine.register_fn("band_v_len", |d: DesignRef| d.0.field_context().band_v_len_mm);
+        engine.register_fn("crest_v", |d: DesignRef| d.0.field_context().crest_v_mm);
+        engine.register_fn("width", |d: DesignRef| d.0.profile.width_mm);
+        engine.register_fn("thickness", |d: DesignRef| d.0.profile.thickness_mm);
+        engine.register_fn("size", |d: DesignRef| d.0.size.0);
+        engine.register_fn("name", |d: DesignRef| d.0.name.clone());
+        engine.register_fn("side_faces", |d: DesignRef| -> Array {
+            let ctx = d.0.field_context();
+            let Some(faces) = ctx.side_faces(SIDE_FACE_MIN_DRAFT_DEG) else { return Vec::new() };
+            [faces.low, faces.high]
+                .into_iter()
+                .flatten()
+                .map(|(lo, hi)| Dynamic::from_array(vec![Dynamic::from_float(lo), Dynamic::from_float(hi)]))
+                .collect()
+        });
+    }
+
+    fn num(d: &Dynamic) -> Option<f64> {
+        if d.is_float() { d.as_float().ok() } else if d.is_int() { d.as_int().ok().map(|i| i as f64) } else { None }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ringdesign_core::ProfileStyle;
+
+    #[test]
+    fn the_sandbox_stops_a_runaway_script_and_refuses_eval() {
+        let e = ScriptEngine::new();
+        let mut s = Scope::new();
+        let err = e.eval("loop {}", &mut s).unwrap_err();
+        assert!(err.contains("Too many operations"), "{err}");
+        let err = e.eval("eval(\"1 + 1\")", &mut s).unwrap_err();
+        assert!(!err.is_empty());
+        let err = e.eval("import \"fs\" as f; f::read(\"/etc/passwd\")", &mut s).unwrap_err();
+        assert!(!err.is_empty());
+        let err = e.eval("let a = []; loop { a.push(1); }", &mut s).unwrap_err();
+        assert!(err.contains("Size of array") || err.contains("Too many"), "{err}");
+    }
+
+    #[test]
+    fn values_cross_both_ways_and_the_api_reads_the_chart() {
+        let e = ScriptEngine::new();
+        let mut s = Scope::new();
+        assert_eq!(from_dynamic(e.eval("lerp(0.0, 10.0, 0.25)", &mut s).unwrap()), Value::Number(2.5));
+        assert_eq!(from_dynamic(e.eval("series(0.0, 30.0, 4)", &mut s).unwrap()), Value::from(vec![0.0, 30.0, 60.0, 90.0]));
+        assert_eq!(from_dynamic(e.eval("mean([1, 2, 3, 4])", &mut s).unwrap()), Value::Number(2.5));
+        assert_eq!(from_dynamic(e.eval("minmax([3.0, 1.0, 2.0])", &mut s).unwrap()), Value::from(vec![1.0, 3.0]));
+        assert_eq!(from_dynamic(e.eval("clamp(5.0, 0.0, 1.0)", &mut s).unwrap()), Value::Number(1.0));
+        assert_eq!(from_dynamic(e.eval("\"a\" + \"b\"", &mut s).unwrap()), Value::Text("ab".into()));
+        assert_eq!(from_dynamic(e.eval("()", &mut s).unwrap()), Value::Null);
+        assert_eq!(from_dynamic(e.eval("#{a: 1}", &mut s).unwrap()), Value::Json(Arc::new(serde_json::json!({"a": 1}))));
+
+        // A dome has no side face; a squared band has two.
+        let dome = RingDesign::default();
+        let mut squared = RingDesign::default();
+        squared.profile.apply_style(ProfileStyle::Flat);
+        squared.profile.flatten_sides();
+        let mut s = Scope::new();
+        s.push_dynamic("dome", to_dynamic(&Value::from(dome)));
+        s.push_dynamic("sq", to_dynamic(&Value::from(squared)));
+        assert_eq!(from_dynamic(e.eval("side_faces(dome)", &mut s).unwrap()), Value::List(vec![]));
+        match from_dynamic(e.eval("side_faces(sq)", &mut s).unwrap()) {
+            Value::List(spans) => assert_eq!(spans.len(), 2, "{spans:?}"),
+            other => panic!("{other:?}"),
+        }
+        let w = from_dynamic(e.eval("width(sq) * 0.5", &mut s).unwrap());
+        assert_eq!(w, Value::Number(3.0));
+        assert!(matches!(from_dynamic(e.eval("sq", &mut s).unwrap()), Value::Design(_)), "a handle comes back as itself");
+    }
+
+    #[test]
+    fn an_expression_pin_sees_its_siblings_and_the_item_index() {
+        use ringdesign_graph::eval::{Evaluator, Targets};
+        use ringdesign_graph::graph::Graph;
+        use ringdesign_graph::value::Literal;
+        use ringdesign_core::AlphaLibrary;
+        let reg = registry();
+        let mut g = Graph::default();
+        let p = g.add("band.profile").unwrap();
+        g.set_input(p, "width_mm", Literal::List(vec![Literal::Number(6.0), Literal::Number(9.0)])).unwrap();
+        g.set_input(p, "thickness_mm", Literal::expr("width_mm / 3.0 + i * 0.1")).unwrap();
+        assert!(g.validate(Some(&reg)).is_empty(), "{:?}", g.validate(Some(&reg)));
+        let r = Evaluator::with_exprs(engine()).evaluate(&g, &reg, &AlphaLibrary::default(), 0, Targets::AllPure);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        match r.value(p, "profile") {
+            Some(Value::List(items)) => {
+                let t: Vec<f64> = items.iter().map(|v| if let Value::Profile(bp) = v { bp.thickness_mm } else { f64::NAN }).collect();
+                assert!((t[0] - 2.0).abs() < 1e-9 && (t[1] - 3.1).abs() < 1e-9, "{t:?}");
+            }
+            other => panic!("{other:?}"),
+        }
+        // Without an engine the pin fails in words; a bad expression names itself.
+        let r = Evaluator::new().evaluate(&g, &reg, &AlphaLibrary::default(), 0, Targets::AllPure);
+        assert!(r.status[&p].errors[0].1.contains("no expression engine"), "{:?}", r.status[&p].errors);
+        g.set_input(p, "thickness_mm", Literal::expr("width_mm /")).unwrap();
+        let r = Evaluator::with_exprs(engine()).evaluate(&g, &reg, &AlphaLibrary::default(), 0, Targets::AllPure);
+        assert!(r.status[&p].errors[0].1.starts_with("thickness_mm: expression:"), "{:?}", r.status[&p].errors);
+    }
+}

--- a/crates/ringdesign-script/src/node.rs
+++ b/crates/ringdesign-script/src/node.rs
@@ -1,0 +1,216 @@
+//! The script node: pins declared in header comments, a body that reads
+//! its inputs as variables and leaves its outputs as variables.
+//!
+//! ```text
+//! // in: a: Number = 1.0, b: List<Number>
+//! // out: h: Number, names: List<Text>
+//! let h = a * 2.0;
+//! let names = b.map(|x| `n${x}`);
+//! ```
+
+use std::sync::Arc;
+
+use rhai::Scope;
+use ringdesign_graph::graph::{Access, Node};
+use ringdesign_graph::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use ringdesign_graph::value::{Literal, ValueKind};
+
+use crate::{ScriptEngine, from_dynamic, to_dynamic};
+
+pub const SCRIPT_KIND: &str = "script";
+
+/// The default body a new script node carries.
+pub const DEFAULT_SOURCE: &str = "// in: a: Number = 1.0, b: Number = 2.0\n// out: sum: Number\nlet sum = a + b;\n";
+
+/// A parsed header line.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Header {
+    pub inputs: Vec<PinSpec>,
+    pub outputs: Vec<PinSpec>,
+}
+
+fn kind_of(name: &str) -> Option<(ValueKind, Access)> {
+    let name = name.trim();
+    if let Some(inner) = name.strip_prefix("List<").and_then(|s| s.strip_suffix('>')) {
+        return kind_of(inner).map(|(k, _)| (k, Access::List));
+    }
+    let k = match name {
+        "Number" | "number" | "float" => ValueKind::Number,
+        "Int" | "int" | "integer" => ValueKind::Int,
+        "Bool" | "bool" | "boolean" => ValueKind::Bool,
+        "Text" | "text" | "string" => ValueKind::Text,
+        "Any" | "any" => ValueKind::Any,
+        "Design" => ValueKind::Design,
+        "Profile" => ValueKind::Profile,
+        "Shank" => ValueKind::Shank,
+        "Head" => ValueKind::Head,
+        "Gem" => ValueKind::Gem,
+        "Window" => ValueKind::Window,
+        "Layer" => ValueKind::Layer,
+        "Entry" => ValueKind::Entry,
+        "Stack" => ValueKind::Stack,
+        "Alpha" | "AlphaRef" => ValueKind::AlphaRef,
+        "Mesh" => ValueKind::Mesh,
+        "Field" => ValueKind::Field,
+        "Path" => ValueKind::Path,
+        "Json" | "json" => ValueKind::Json,
+        "List" | "list" => ValueKind::List,
+        _ => return None,
+    };
+    Some((k, Access::Item))
+}
+
+/// Parse the `// in:` and `// out:` lines at the top of a script.
+pub fn parse_header(source: &str) -> Result<Header, String> {
+    let mut h = Header { inputs: Vec::new(), outputs: Vec::new() };
+    for (ln, line) in source.lines().enumerate() {
+        let t = line.trim();
+        let (is_in, rest) = if let Some(r) = t.strip_prefix("// in:") {
+            (true, r)
+        } else if let Some(r) = t.strip_prefix("// out:") {
+            (false, r)
+        } else if t.starts_with("//") || t.is_empty() {
+            continue;
+        } else {
+            break;
+        };
+        for decl in rest.split(',').map(str::trim).filter(|d| !d.is_empty()) {
+            let (name_ty, default) = match decl.split_once('=') {
+                Some((a, b)) => (a.trim(), Some(b.trim())),
+                None => (decl, None),
+            };
+            let (name, ty) = name_ty.split_once(':').map(|(a, b)| (a.trim(), b.trim())).unwrap_or((name_ty.trim(), "Any"));
+            if name.is_empty() || !name.chars().all(|c| c.is_alphanumeric() || c == '_') || name.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                return Err(format!("line {}: {name:?} is not a pin name", ln + 1));
+            }
+            let (kind, access) = kind_of(ty).ok_or_else(|| format!("line {}: {ty:?} is not a pin type", ln + 1))?;
+            let mut pin = if access == Access::List { PinSpec::list(name, kind) } else { PinSpec::item(name, kind) };
+            pin.doc = format!("Script {} {}", if is_in { "input" } else { "output" }, name);
+            if let Some(d) = default {
+                let lit: Literal = serde_json::from_str(d).map_err(|e| format!("line {}: default {d:?}: {e}", ln + 1))?;
+                pin.default = Some(lit);
+            } else if is_in {
+                pin = pin.optional();
+            }
+            if is_in { h.inputs.push(pin) } else { h.outputs.push(pin) }
+        }
+    }
+    Ok(h)
+}
+
+fn source_of(node: &Node) -> &str {
+    node.params.get("source").and_then(|v| v.as_str()).unwrap_or(DEFAULT_SOURCE)
+}
+
+fn pins(_: &NodeSpec, node: &Node, _: &Registry) -> (Vec<PinSpec>, Vec<PinSpec>) {
+    let (mut inputs, outputs) = match parse_header(source_of(node)) {
+        Ok(h) => (h.inputs, h.outputs),
+        Err(_) => (Vec::new(), Vec::new()),
+    };
+    // A literal left on a pin the header no longer names stays a pin, so
+    // the graph still validates and the node reports the header itself.
+    for k in node.inputs.keys() {
+        if !inputs.iter().any(|p| &p.name == k) {
+            inputs.push(PinSpec::item(k.clone(), ValueKind::Any).doc("Not in the header").optional());
+        }
+    }
+    (inputs, outputs)
+}
+
+fn run(engine: &ScriptEngine, ctx: &mut EvalCtx<'_>, node: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let source = source_of(node);
+    let header = parse_header(source).map_err(|e| NodeError::new(format!("header: {e}")))?;
+    let mut scope = Scope::new();
+    for pin in &header.inputs {
+        scope.push_dynamic(pin.name.clone(), to_dynamic(i.get(&pin.name)));
+    }
+    scope.push("i", ctx.item as i64);
+    scope.push("n", ctx.items as i64);
+    let _ = engine.eval(source, &mut scope).map_err(NodeError::new)?;
+    let mut out = Outputs::default();
+    for pin in &header.outputs {
+        let v = scope.get_value::<rhai::Dynamic>(&pin.name).map(from_dynamic).ok_or_else(|| NodeError::new(format!("the script never set `{}`", pin.name)))?;
+        let v = pin.kind.coerce(v).map_err(|e| NodeError::new(format!("{}: {e}", pin.name)))?;
+        out.values.insert(pin.name.clone(), v);
+    }
+    Ok(out)
+}
+
+/// Params for a new script node with `source`.
+pub fn params_for(source: &str) -> serde_json::Value {
+    serde_json::json!({ "source": source })
+}
+
+pub fn register(reg: &mut Registry, engine: Arc<ScriptEngine>) {
+    let spec = NodeSpec::new(SCRIPT_KIND, "Script", Category::Util)
+        .doc("A rhai script with pins declared in its header: `// in: a: Number = 1.0, b: List<Number>` and `// out: h: Number`. Inputs arrive as variables, outputs are read back from variables; `i` and `n` say which item this is.")
+        .input(PinSpec::item("source", ValueKind::Text).widget(Widget::TextArea).doc("Unused pin: the source lives in params").optional())
+        .resolve(pins)
+        .eval(move |ctx, node, i| run(&engine, ctx, node, i));
+    // The source is a param, not a pin: drop the placeholder input so the
+    // header alone decides the pins.
+    let spec = NodeSpec { inputs: Vec::new(), ..spec };
+    reg.register(spec).expect("unique");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ringdesign_core::AlphaLibrary;
+    use ringdesign_graph::eval::{Evaluator, Targets};
+    use ringdesign_graph::graph::Graph;
+    use ringdesign_graph::value::Value;
+
+    #[test]
+    fn headers_declare_pins_and_name_their_errors_by_line() {
+        let h = parse_header("// in: a: Number = 1.0, b: List<Number>\n// out: h: Number, names: List<Text>\nlet h = a;").unwrap();
+        assert_eq!(h.inputs.len(), 2);
+        assert_eq!((h.inputs[0].kind, h.inputs[0].access, h.inputs[0].default.clone()), (ValueKind::Number, Access::Item, Some(Literal::Number(1.0))));
+        assert_eq!((h.inputs[1].kind, h.inputs[1].access), (ValueKind::Number, Access::List));
+        assert!(h.inputs[1].optional);
+        assert_eq!(h.outputs.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(), vec!["h", "names"]);
+        let err = parse_header("// in: a: Number\n// out: 1bad: Number").unwrap_err();
+        assert!(err.starts_with("line 2:"), "{err}");
+        let err = parse_header("// in: a: Quaternion").unwrap_err();
+        assert!(err.contains("line 1") && err.contains("Quaternion"), "{err}");
+        let err = parse_header("// in: a: Number = nope").unwrap_err();
+        assert!(err.contains("line 1") && err.contains("default"), "{err}");
+    }
+
+    #[test]
+    fn a_script_node_maps_over_a_list_and_reports_its_failures() {
+        let reg = crate::registry();
+        let lib = AlphaLibrary::default();
+        let mut g = Graph::default();
+        let s = g.add(SCRIPT_KIND).unwrap();
+        g.node_mut(s).unwrap().params = params_for("// in: a: Number = 1.0, k: Int = 3\n// out: h: Number, tag: Text\nlet h = a * k;\nlet tag = `item ${i} of ${n}`;\n");
+        g.set_input(s, "a", Literal::List((1..=5).map(|x| Literal::Number(x as f64)).collect())).unwrap();
+        assert!(g.validate(Some(&reg)).is_empty(), "{:?}", g.validate(Some(&reg)));
+        let r = Evaluator::with_exprs(crate::engine()).evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        assert_eq!(r.value(s, "h"), Some(&Value::from(vec![3.0, 6.0, 9.0, 12.0, 15.0])), "five in, five out");
+        match r.value(s, "tag") {
+            Some(Value::List(t)) => assert_eq!(t[4], Value::Text("item 4 of 5".into())),
+            other => panic!("{other:?}"),
+        }
+        // A list pin sees the whole list once.
+        let l = g.add(SCRIPT_KIND).unwrap();
+        g.node_mut(l).unwrap().params = params_for("// in: xs: List<Number>\n// out: total: Number\nlet total = sum(xs);\n");
+        g.connect(s, "h", l, "xs").unwrap();
+        let r = Evaluator::with_exprs(crate::engine()).evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert_eq!(r.value(l, "total"), Some(&Value::Number(45.0)));
+        // A script that forgets its output, a runaway, and a bad header all say so.
+        g.node_mut(s).unwrap().params = params_for("// out: h: Number\nlet q = 1;\n");
+        let r = Evaluator::with_exprs(crate::engine()).evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(r.status[&s].errors[0].1.contains("never set `h`"), "{:?}", r.status[&s].errors);
+        g.node_mut(s).unwrap().params = params_for("// out: h: Number\nloop {}\n");
+        let r = Evaluator::with_exprs(crate::engine()).evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(r.status[&s].errors[0].1.contains("Too many operations"), "{:?}", r.status[&s].errors);
+        // A header that fails to parse declares no outputs, so the wire below
+        // would dangle; the node still reports the header on its own.
+        g.disconnect(l, "xs");
+        g.node_mut(s).unwrap().params = params_for("// in: a: Nope\nlet h = 1;\n");
+        let r = Evaluator::with_exprs(crate::engine()).evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(r.status[&s].errors[0].1.starts_with("header: line 1"), "{:?}", r.status[&s].errors);
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -118,12 +118,12 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 
 ## M4 — Scripting, MCP and CLI (L) — epic #20
 
-- [ ] **M4.1 `ringdesign-script` (rhai)** (L). Sandboxed engine with size/operation caps,
+- [x] **M4.1 `ringdesign-script` (rhai)** (L, #47). Sandboxed engine with size/operation caps,
   `Value ⇄ Dynamic`, a small math/list/domain API, Expr pins evaluated per item, Script nodes with
   declared pins, diagnostics in the editor.
-- [ ] **M4.2 MCP `graph_*` tools** (M). New/load/save/describe/list nodes/add/remove/connect/
+- [ ] **M4.2 MCP `graph_*` tools** (M, #48). New/load/save/describe/list nodes/add/remove/connect/
   set/expose/clusters/presets/evaluate/from_design, plus graph resources.
-- [ ] **M4.3 CLI crate** (S). `ringdesign graph eval|check|describe`; the binary moves to its own
+- [ ] **M4.3 CLI crate** (S, #49). `ringdesign graph eval|check|describe`; the binary moves to its own
   crate.
 
 ## M5 — Idioms, clusters, polish (M) — epic #21


### PR DESCRIPTION
## Summary
- New crate `ringdesign-script`: sandboxed `ScriptEngine` (all rhai caps, no eval, no modules), `Value ⇄ Dynamic`, math/list/domain API, `ExprEvaluator` impl, `script` node with header-declared pins.
- Graph crate: `Literal::Expr`, `ExprEvaluator` hook, per-item expression pins with siblings in scope; clusters inherit the engine.
- Editor shows expression pins; GUI/worker use the script-aware registry.

## Verification
- `cargo test --workspace` green; script crate 5 tests (runaway halts, eval/import refused, API and handles, expression pins with siblings, script node over a 5-list with header/line errors).
- graph crate wasm check passes.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)