### PR TITLE
M4.3 ringdesign-cli: the binary in its own crate, with graph eval/check/describe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -981,12 +981,18 @@ pins both directions. On top of that:
   `metal::pattern_scale` = `1/(1−s)`; the export menu's "Shrink for" combo
   and the CLI's `--shrink` scale the mesh and *rename* the file as a pattern
   so an oversize file can never be mistaken for nominal.
-- **The size-run CLI** (`src/bin/ringdesign.rs`): `ringdesign export
+- **The size-run CLI** (`crates/ringdesign-cli`): `ringdesign export
   ring.json --sizes 5:9:0.5 --formats stl,3mf --shrink sterling` builds each
   size, field-checks it, writes the files and a manifest CSV (verdict,
   thinnest wall, volume per size) — one flask, one command; the manifest is
   also the export-regression diff. `ringdesign check` prints the field
-  verdict and the stones findings for one design.
+  verdict and the stones findings for one design. `ringdesign graph
+  eval|check|describe <graph.json>` evaluates a graph file the way the
+  app does (same registry, script engine attached): `--set Name=value`
+  sets an exposed parameter, `--preset` a saved preset's values,
+  `--out` writes the evaluated design with its graph embedded, and
+  `--run-sinks` runs the side-effect sinks afterwards. The binary lives in
+  its own crate because the core cannot depend on the graph.
 
 ### The profile library is user-extensible
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringdesign-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ringdesign-core",
+ "ringdesign-graph",
+ "ringdesign-script",
+ "serde_json",
+]
+
+[[package]]
 name = "ringdesign-configurator"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/ringdesign-graph",
     "crates/ringdesign-graph-ui",
     "crates/ringdesign-script",
+    "crates/ringdesign-cli",
 ]
 # Vendored forks are reached through [patch.crates-io], not built as members.
 exclude = ["patches/egui-snarl", "patches/egui-scale"]

--- a/crates/ringdesign-cli/Cargo.toml
+++ b/crates/ringdesign-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ringdesign-cli"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+description = "The ringdesign command line: size runs, checks, and graph evaluation"
+
+[[bin]]
+name = "ringdesign"
+path = "src/main.rs"
+
+[dependencies]
+ringdesign-core.workspace = true
+ringdesign-graph.workspace = true
+ringdesign-script.workspace = true
+anyhow.workspace = true
+serde_json.workspace = true

--- a/crates/ringdesign-cli/src/main.rs
+++ b/crates/ringdesign-cli/src/main.rs
@@ -9,7 +9,12 @@
 //! ```text
 //! ringdesign export ring.json --sizes 5:9:0.5 --formats stl,3mf --shrink sterling
 //! ringdesign check ring.json
+//! ringdesign graph eval court.graph.json --set Width=6 --out court.ring.json
 //! ```
+//!
+//! The graph commands evaluate a `.graph.json` the way the app does — the
+//! same registry, the script engine attached — so a graph is a design
+//! file that can be parameterized from the shell.
 
 use std::path::{Path, PathBuf};
 
@@ -17,7 +22,11 @@ use ringdesign_core::alpha::AlphaLibrary;
 use ringdesign_core::castability::analyze_field;
 use ringdesign_core::mesh::build;
 use ringdesign_core::sizing::RingSize;
-use ringdesign_core::{library, metal, stl, stones, threemf, RingDesign};
+use ringdesign_core::{RingDesign, library, metal, stl, stones, threemf};
+use ringdesign_graph::eval::{Evaluator, Targets, evaluate_design};
+use ringdesign_graph::file;
+use ringdesign_graph::graph::Graph;
+use ringdesign_graph::value::Literal;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -32,6 +41,9 @@ fn main() {
 const USAGE: &str = "usage:
   ringdesign export <design.json> [options]
   ringdesign check  <design.json>
+  ringdesign graph eval     <graph.json> [--set Name=value]* [--preset name] [--out design.ring.json] [--run-sinks]
+  ringdesign graph check    <graph.json> [--set Name=value]*
+  ringdesign graph describe <graph.json>
 
 options:
   --sizes 5:9:0.5 | 6,7,8   sizes to run (default: the design's own)
@@ -42,6 +54,9 @@ options:
   --steps 1024x320          sweep resolution (default: the design's build)";
 
 fn run(args: &[String]) -> anyhow::Result<()> {
+    if args.first().map(String::as_str) == Some("graph") {
+        return graph::run(&args[1..]);
+    }
     let (cmd, design_path) = match args {
         [c, p, ..] => (c.as_str(), p.as_str()),
         _ => anyhow::bail!("expected a command and a design file"),
@@ -116,7 +131,7 @@ fn export(
                 formats = value()?.split(',').map(|s| s.trim().to_lowercase()).collect();
                 for f in &formats {
                     if !matches!(f.as_str(), "stl" | "obj" | "3mf" | "glb" | "ply") {
-                        anyhow::bail!("unknown format {f:?} (stl, obj, 3mf)");
+                        anyhow::bail!("unknown format {f:?} (stl, obj, 3mf, glb, ply)");
                     }
                 }
             }
@@ -273,5 +288,136 @@ mod tests {
     fn slugs_are_filename_safe() {
         assert_eq!(slug("My Heart / Signet!"), "my-heart-signet");
         assert_eq!(slug("***"), "ring");
+    }
+}
+
+/// `ringdesign graph …`: a graph file evaluated like the app does it.
+mod graph {
+    use super::*;
+
+    pub fn run(args: &[String]) -> anyhow::Result<()> {
+        let (sub, path) = match args {
+            [s, p, ..] => (s.as_str(), p.as_str()),
+            _ => anyhow::bail!("expected `graph eval|check|describe <graph.json>`"),
+        };
+        let reg = ringdesign_script::registry();
+        let mut g = file::load_graph(path, Some(&reg)).map_err(|e| anyhow::anyhow!("{path}: {e:#}"))?;
+        let mut out: Option<PathBuf> = None;
+        let mut run_sinks = false;
+        let mut rest = args[2..].iter();
+        while let Some(flag) = rest.next() {
+            match flag.as_str() {
+                "--set" => {
+                    let kv = rest.next().ok_or_else(|| anyhow::anyhow!("--set needs Name=value"))?;
+                    let (name, value) = kv.split_once('=').ok_or_else(|| anyhow::anyhow!("--set {kv:?}: expected Name=value"))?;
+                    set_exposed(&mut g, name.trim(), value.trim())?;
+                }
+                "--preset" => {
+                    let name = rest.next().ok_or_else(|| anyhow::anyhow!("--preset needs a name"))?;
+                    let preset = file::list_presets().into_iter().find(|p| &p.name == name).ok_or_else(|| anyhow::anyhow!("no preset {name:?} in {}", file::preset_dir().display()))?;
+                    for (k, v) in &preset.values {
+                        set_exposed_literal(&mut g, k, v.clone())?;
+                    }
+                }
+                "--out" => out = Some(PathBuf::from(rest.next().ok_or_else(|| anyhow::anyhow!("--out needs a path"))?)),
+                "--run-sinks" => run_sinks = true,
+                other => anyhow::bail!("unknown option {other:?}"),
+            }
+        }
+        let errors = g.validate(Some(&reg));
+        match sub {
+            "describe" => {
+                println!("{} ({:?}, {} nodes, {} wires)", g.name, g.mode, g.nodes.len(), g.wires.len());
+                for n in &g.nodes {
+                    let (ins, outs) = reg.node_pins(n).unwrap_or_default();
+                    let lits: Vec<String> = n.inputs.iter().map(|(k, v)| format!("{k}={}", serde_json::to_string(v).unwrap_or_default())).collect();
+                    println!(
+                        "  {:>4}  {:<24} {:<18} in: {}  out: {}{}",
+                        n.id,
+                        n.kind,
+                        n.label.clone().unwrap_or_default(),
+                        ins.iter().map(|p| p.name.as_str()).collect::<Vec<_>>().join(","),
+                        outs.iter().map(|p| p.name.as_str()).collect::<Vec<_>>().join(","),
+                        if lits.is_empty() { String::new() } else { format!("  [{}]", lits.join(" ")) }
+                    );
+                }
+                for w in &g.wires {
+                    println!("  {}.{} -> {}.{}", w.from, w.out, w.to, w.input);
+                }
+                for e in &g.exposed {
+                    println!("  exposed {} = {}.{}", e.name, e.node, e.input);
+                }
+                for e in &errors {
+                    println!("  error: {e}");
+                }
+                Ok(())
+            }
+            "eval" | "check" => {
+                if !errors.is_empty() {
+                    for e in &errors {
+                        eprintln!("error: {e}");
+                    }
+                    anyhow::bail!("the graph does not validate");
+                }
+                let mut lib = AlphaLibrary::builtin();
+                if let Err(e) = lib.load_dir(library::user_alpha_dir()) {
+                    eprintln!("note: user alphas not loaded: {e}");
+                }
+                let mut ev = Evaluator::with_exprs(ringdesign_script::engine());
+                let result = evaluate_design(&mut ev, &g, &reg, &lib, 0).map_err(|e| anyhow::anyhow!("{e}"))?;
+                for n in &result.notes {
+                    eprintln!("note: {n}");
+                }
+                let f = &result.field;
+                println!(
+                    "{}: {}: {:.4}% undercut, worst {:+.1} deg, thinnest wall {:.2} mm",
+                    result.design.name,
+                    f.verdict.label(),
+                    f.undercut_fraction() * 100.0,
+                    f.worst_draft_deg,
+                    f.thinnest_wall_mm
+                );
+                for n in &f.notes {
+                    println!("  {n}");
+                }
+                if sub == "check" {
+                    return Ok(());
+                }
+                if run_sinks {
+                    let report = ev.evaluate(&g, &reg, &lib, 0, Targets::Everything);
+                    for line in report.notes(&g) {
+                        eprintln!("sink: {line}");
+                    }
+                    println!("ran {} nodes with side effects", report.ran().len());
+                }
+                if let Some(path) = out {
+                    let mut d = (*result.design).clone();
+                    d.graph = Some(serde_json::to_value(&g)?);
+                    let mut baked = lib.clone();
+                    d.bake_all(&mut baked);
+                    library::save_design_embedded(&path, &d, &baked)?;
+                    println!("wrote {}", path.display());
+                }
+                Ok(())
+            }
+            other => anyhow::bail!("unknown graph command {other:?} (eval, check, describe)"),
+        }
+    }
+
+    /// `--set Name=value`: the value parses as a literal (JSON), else as text.
+    fn set_exposed(g: &mut Graph, name: &str, value: &str) -> anyhow::Result<()> {
+        let lit: Literal = serde_json::from_str(value).unwrap_or_else(|_| Literal::Text(value.to_string()));
+        set_exposed_literal(g, name, lit)
+    }
+
+    fn set_exposed_literal(g: &mut Graph, name: &str, lit: Literal) -> anyhow::Result<()> {
+        let e = g
+            .exposed
+            .iter()
+            .find(|e| e.name == name)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("{name:?} is not an exposed parameter; the graph exposes {:?}", g.exposed.iter().map(|e| e.name.as_str()).collect::<Vec<_>>()))?;
+        g.set_input(e.node, e.input, lit).map_err(|er| anyhow::anyhow!("{er}"))?;
+        Ok(())
     }
 }

--- a/crates/ringdesign-cli/tests/cli.rs
+++ b/crates/ringdesign-cli/tests/cli.rs
@@ -1,0 +1,40 @@
+//! The binary end to end: a template graph evaluated to a design file,
+//! then checked as a design.
+
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ringdesign"))
+}
+
+#[test]
+fn graph_eval_writes_a_design_that_check_reads_with_the_same_verdict() {
+    let dir = std::env::temp_dir().join(format!("ringdesign-cli-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let graph = dir.join("court.graph.json");
+    std::fs::write(&graph, ringdesign_graph::templates::BUNDLED.iter().find(|t| t.name == "Court band").unwrap().json).unwrap();
+    let out = dir.join("court.ring.json");
+
+    let o = bin().args(["graph", "describe", graph.to_str().unwrap()]).output().unwrap();
+    assert!(o.status.success(), "{}", String::from_utf8_lossy(&o.stderr));
+    let text = String::from_utf8_lossy(&o.stdout);
+    assert!(text.contains("band.profile") && text.contains("exposed Width"), "{text}");
+
+    let o = bin().args(["graph", "eval", graph.to_str().unwrap(), "--set", "Width=6", "--out", out.to_str().unwrap()]).output().unwrap();
+    assert!(o.status.success(), "{}", String::from_utf8_lossy(&o.stderr));
+    let text = String::from_utf8_lossy(&o.stdout);
+    assert!(text.starts_with("Court band: Castable"), "{text}");
+    let design = ringdesign_core::library::load_design(&out).unwrap();
+    assert_eq!(design.profile.width_mm, 6.0, "--set reached the exposed pin");
+    assert!(design.graph.is_some(), "the design carries its graph");
+
+    let o = bin().args(["check", out.to_str().unwrap()]).output().unwrap();
+    assert!(o.status.success(), "{}", String::from_utf8_lossy(&o.stderr));
+    let text = String::from_utf8_lossy(&o.stdout);
+    assert!(text.contains("Castable"), "{text}");
+
+    let o = bin().args(["graph", "eval", graph.to_str().unwrap(), "--set", "Nope=1"]).output().unwrap();
+    assert!(!o.status.success());
+    assert!(String::from_utf8_lossy(&o.stderr).contains("not an exposed parameter"));
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,7 +123,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   declared pins, diagnostics in the editor.
 - [x] **M4.2 MCP `graph_*` tools** (M, #48). New/load/save/describe/list nodes/add/remove/connect/
   set/expose/clusters/presets/evaluate/from_design, plus graph resources.
-- [ ] **M4.3 CLI crate** (S, #49). `ringdesign graph eval|check|describe`; the binary moves to its own
+- [x] **M4.3 CLI crate** (S, #49). `ringdesign graph eval|check|describe`; the binary moves to its own
   crate.
 
 ## M5 — Idioms, clusters, polish (M) — epic #21


### PR DESCRIPTION
## Summary
- `crates/ringdesign-cli` owns the `ringdesign` binary (moved from core's `src/bin`); `--formats` error text fixed.
- `ringdesign graph eval|check|describe` with `--set`, `--preset`, `--out`, `--run-sinks`.
- CLAUDE.md CLI bullet updated.

## Verification
- `cargo test --workspace` green; the CLI integration test drives the built binary end to end.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)