### PR TITLE
M5.2 The signet as a hosted cluster with presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1549,6 +1549,15 @@ What the runtime settled while being built, each pinned by a test:
   `ring://graph` and `ring://graph/nodes` are the resources. The two tool
   routers combine with `+` in the handler; the Court band built by tools
   alone evaluates to the code template byte for byte (pinned).
+- **The first hosted cluster is the signet** (`graphs/clusters/signet.cluster.json`,
+  built by `templates::build_signet_cluster` from our own nodes — one
+  exposed Width fans out to the section, the face fit and the shank;
+  Rise, Shoulder, Rim, Loft, Cap, Taper, Outline, Name, Size are the
+  panel; design, head, shank and profile come out). Bundled presets
+  (`graphs/presets/*.preset.json`) set it, and the "Heart signet" preset
+  evaluates to the code template **byte for byte** (pinned). The file
+  layer lists user-dir clusters and presets first and the bundled ones
+  behind them, so a user file of the same name shadows a bundled one.
 - **The lift is exact by construction** (`lift.rs`, `Graph::from_design`):
   it wires the nodes a person would, evaluates them, diffs the result
   against the design field by field, and carries whatever the nodes cannot

--- a/crates/ringdesign-graph/src/file.rs
+++ b/crates/ringdesign-graph/src/file.rs
@@ -129,8 +129,15 @@ pub fn list_clusters_in(dir: &Path, reg: Option<&Registry>) -> Vec<Graph> {
     list_in(dir, CLUSTER_EXT, reg)
 }
 
+/// The user's clusters, then the bundled ones a user file does not shadow.
 pub fn list_clusters(reg: Option<&Registry>) -> Vec<Graph> {
-    list_clusters_in(&cluster_dir(), reg)
+    let mut out = list_clusters_in(&cluster_dir(), reg);
+    for c in crate::templates::bundled_clusters() {
+        if !out.iter().any(|u| u.name == c.name) {
+            out.push(c);
+        }
+    }
+    out
 }
 
 pub fn load_cluster_in(dir: &Path, name: &str, reg: Option<&Registry>) -> Option<Graph> {
@@ -142,7 +149,7 @@ pub fn load_cluster_in(dir: &Path, name: &str, reg: Option<&Registry>) -> Option
 }
 
 pub fn load_cluster(name: &str, reg: Option<&Registry>) -> Option<Graph> {
-    load_cluster_in(&cluster_dir(), name, reg)
+    load_cluster_in(&cluster_dir(), name, reg).or_else(|| crate::templates::bundled_clusters().into_iter().find(|c| c.name == name))
 }
 
 pub fn save_graph_in(dir: &Path, g: &Graph) -> anyhow::Result<PathBuf> {
@@ -227,8 +234,15 @@ pub fn list_presets_in(dir: &Path) -> Vec<Preset> {
     out
 }
 
+/// The user's presets, then the bundled ones a user file does not shadow.
 pub fn list_presets() -> Vec<Preset> {
-    list_presets_in(&preset_dir())
+    let mut out = list_presets_in(&preset_dir());
+    for p in crate::templates::bundled_presets() {
+        if !out.iter().any(|u| u.name == p.name) {
+            out.push(p);
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/ringdesign-graph/src/templates.rs
+++ b/crates/ringdesign-graph/src/templates.rs
@@ -44,6 +44,100 @@ bundled! {
 /// an empty stack and the output, with the design panel's knobs exposed.
 pub static SIMPLE: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../graphs/simple.graph.json"));
 
+/// Bundled clusters: graphs with exposed inputs and outputs, usable as
+/// one node. A user-dir cluster of the same name wins.
+pub static BUNDLED_CLUSTERS: &[(&str, &str)] = &[("Signet", include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../graphs/clusters/signet.cluster.json")))];
+
+/// Bundled presets for the bundled clusters.
+pub static BUNDLED_PRESETS: &[(&str, &str)] = &[
+    ("Heart signet", include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../graphs/presets/heart-signet.preset.json"))),
+    ("Cushion signet", include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../graphs/presets/cushion-signet.preset.json"))),
+];
+
+pub fn bundled_clusters() -> Vec<Graph> {
+    BUNDLED_CLUSTERS.iter().filter_map(|(_, json)| crate::file::load_graph_str(json, None).ok()).collect()
+}
+
+pub fn bundled_presets() -> Vec<crate::file::Preset> {
+    BUNDLED_PRESETS.iter().filter_map(|(_, json)| crate::file::load_preset_str(json).ok()).collect()
+}
+
+/// The signet construction as a cluster: one Width reaches the section,
+/// the face fit and the shank; the head's own knobs and the shank's taper
+/// are exposed; the design, head, shank and profile come out.
+pub fn build_signet_cluster() -> Graph {
+    signet_cluster().expect("the signet cluster wires")
+}
+
+/// The presets the bundled files come from.
+pub fn build_presets() -> Vec<crate::file::Preset> {
+    use crate::file::Preset;
+    let preset = |name: &str, width: f64, thickness: f64, outline: &str| Preset {
+        name: name.into(),
+        cluster: "Signet".into(),
+        values: [
+            ("Name".to_string(), Literal::Text(name.into())),
+            ("Width".to_string(), Literal::Number(width)),
+            ("Thickness".to_string(), Literal::Number(thickness)),
+            ("Outline".to_string(), Literal::Text(outline.into())),
+        ]
+        .into_iter()
+        .collect(),
+        doc: format!("A {outline} head on a {width} × {thickness} mm squared band, lofted."),
+    };
+    vec![preset("Heart signet", 15.5, 1.6, "Heart"), preset("Cushion signet", 14.5, 2.2, "Cushion")]
+}
+
+fn signet_cluster() -> Result<Graph, GraphError> {
+    use ringdesign_core::profile::SIGNET_TAPER;
+    let mut g = Graph::new("Signet", Mode::SandRing);
+    let width = g.add("number")?;
+    set(&mut g, width, &[("value", n(12.0))])?;
+    g.node_mut(width).expect("added").label = Some("Width".into());
+    let thickness = g.add("number")?;
+    set(&mut g, thickness, &[("value", n(1.8))])?;
+    g.node_mut(thickness).expect("added").label = Some("Thickness".into());
+    let outline = g.add("text")?;
+    set(&mut g, outline, &[("value", t("Oval"))])?;
+    g.node_mut(outline).expect("added").label = Some("Outline".into());
+    let name = g.add("text")?;
+    set(&mut g, name, &[("value", t("Signet"))])?;
+    g.node_mut(name).expect("added").label = Some("Name".into());
+    let p = g.add("band.profile")?;
+    set(&mut g, p, &[("style", t("Flat")), ("flatten_sides", b(true))])?;
+    g.connect(width, "out", p, "width_mm")?;
+    g.connect(thickness, "out", p, "thickness_mm")?;
+    let h = g.add("head")?;
+    g.connect(outline, "out", h, "outline")?;
+    g.connect(width, "out", h, "fit_to_width_mm")?;
+    let s = g.add("shank")?;
+    set(&mut g, s, &[("kind", t("Signet")), ("amount", n(SIGNET_TAPER))])?;
+    g.connect(h, "head", s, "head")?;
+    let d = g.add("design.new")?;
+    g.connect(name, "out", d, "name")?;
+    g.connect(p, "profile", d, "profile")?;
+    g.connect(s, "shank", d, "shank")?;
+    let out = g.add(OUTPUT_KIND)?;
+    g.connect(d, "design", out, OUTPUT_DESIGN_PIN)?;
+    g.expose(width, "value", "Width")?;
+    g.expose(thickness, "value", "Thickness")?;
+    g.expose(outline, "value", "Outline")?;
+    g.expose(name, "value", "Name")?;
+    g.expose(d, "size", "Size")?;
+    g.expose(h, "rise_mm", "Rise")?;
+    g.expose(h, "shoulder_deg", "Shoulder")?;
+    g.expose(h, "rim_round_mm", "Rim")?;
+    g.expose(h, "loft", "Loft")?;
+    g.expose(h, "table_dome_mm", "Cap")?;
+    g.expose(s, "amount", "Taper")?;
+    g.expose_output(d, "design", "design")?;
+    g.expose_output(h, "head", "head")?;
+    g.expose_output(s, "shank", "shank")?;
+    g.expose_output(p, "profile", "profile")?;
+    arrange(&mut g);
+    Ok(g)
+}
+
 /// Every bundled template graph, parsed.
 pub fn all() -> Vec<(&'static str, Graph)> {
     BUNDLED.iter().map(|t| (t.name, crate::file::load_graph_str(t.json, None).expect("bundled graph parses"))).collect()
@@ -383,6 +477,45 @@ mod tests {
         let mut s = build_simple();
         arrange(&mut s);
         std::fs::write(dir.join("simple.graph.json"), crate::file::graph_to_string(&s).unwrap()).unwrap();
+        std::fs::create_dir_all(dir.join("clusters")).unwrap();
+        std::fs::create_dir_all(dir.join("presets")).unwrap();
+        std::fs::write(dir.join("clusters/signet.cluster.json"), crate::file::graph_to_string(&build_signet_cluster()).unwrap()).unwrap();
+        for p in build_presets() {
+            std::fs::write(dir.join("presets").join(format!("{}.preset.json", crate::file::slug(&p.name))), crate::file::preset_to_string(&p).unwrap()).unwrap();
+        }
+    }
+
+    /// The signet cluster with a preset is the code template, byte for byte.
+    #[test]
+    fn the_signet_cluster_under_a_preset_is_the_template_byte_for_byte() {
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::builtin();
+        let clusters = bundled_clusters();
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0], build_signet_cluster(), "the committed cluster has drifted from its builder");
+        assert!(clusters[0].validate(Some(&reg)).is_empty(), "{:?}", clusters[0].validate(Some(&reg)));
+        let presets = bundled_presets();
+        assert_eq!(presets.len(), 2);
+        assert_eq!(presets, build_presets());
+        for preset in &presets {
+            let mut g = Graph::new("outer", Mode::SandRing);
+            let n = crate::nodes::cluster::add_cluster(&mut g, &clusters[0]).unwrap();
+            let unknown = preset.apply(g.node_mut(n).unwrap(), &reg);
+            assert!(unknown.is_empty(), "{unknown:?}");
+            let out = g.add(OUTPUT_KIND).unwrap();
+            g.connect(n, "design", out, OUTPUT_DESIGN_PIN).unwrap();
+            let res = evaluate_design(&mut Evaluator::new(), &g, &reg, &lib, 0).unwrap_or_else(|e| panic!("{}: {e}", preset.name));
+            assert!(res.notes.is_empty(), "{}: {:?}", preset.name, res.notes);
+            assert_ne!(res.field.verdict, Verdict::NotCastable, "{}", preset.name);
+            if let Some(t) = ringdesign_core::templates::all().iter().find(|t| t.name == preset.name) {
+                let got = serde_json::to_string(&*res.design).unwrap();
+                let want = serde_json::to_string(&t.design()).unwrap();
+                assert_eq!(got, want, "{}: the cluster's design differs from the code template", preset.name);
+            }
+        }
+        // The file layer sees bundled clusters and presets, user ones first.
+        assert!(crate::file::load_cluster("Signet", Some(&reg)).is_some());
+        assert!(crate::file::list_presets().iter().any(|p| p.name == "Heart signet"));
     }
 
     #[test]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -130,7 +130,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 
 - [x] **M5.1 List idiom nodes** (M, #53). Weave, entwine, cull, partition, gate, polar array (integer
   lattice — never a relaxation), format, json, if.
-- [ ] **M5.2 First hosted cluster** (M, #54). The signet construction as a user-dir cluster whose
+- [x] **M5.2 First hosted cluster** (M, #54). The signet construction as a user-dir cluster whose
   preset evaluates to the lofted head.
 - [ ] **M5.3 Editor polish** (M, #55). Live value badges, subgraph navigation and collapse, arrange,
   fit, minimap.

--- a/graphs/clusters/signet.cluster.json
+++ b/graphs/clusters/signet.cluster.json
@@ -1,0 +1,239 @@
+{
+  "format_version": 1,
+  "name": "Signet",
+  "mode": "SandRing",
+  "nodes": [
+    {
+      "id": 1,
+      "kind": "number",
+      "inputs": {
+        "value": 12.0
+      },
+      "pos": [
+        0.0,
+        0.0
+      ],
+      "label": "Width"
+    },
+    {
+      "id": 2,
+      "kind": "number",
+      "inputs": {
+        "value": 1.8
+      },
+      "pos": [
+        0.0,
+        150.0
+      ],
+      "label": "Thickness"
+    },
+    {
+      "id": 3,
+      "kind": "text",
+      "inputs": {
+        "value": "Oval"
+      },
+      "pos": [
+        0.0,
+        300.0
+      ],
+      "label": "Outline"
+    },
+    {
+      "id": 4,
+      "kind": "text",
+      "inputs": {
+        "value": "Signet"
+      },
+      "pos": [
+        0.0,
+        450.0
+      ],
+      "label": "Name"
+    },
+    {
+      "id": 5,
+      "kind": "band.profile",
+      "inputs": {
+        "flatten_sides": true,
+        "style": "Flat"
+      },
+      "pos": [
+        240.0,
+        0.0
+      ]
+    },
+    {
+      "id": 6,
+      "kind": "head",
+      "pos": [
+        240.0,
+        150.0
+      ]
+    },
+    {
+      "id": 7,
+      "kind": "shank",
+      "inputs": {
+        "amount": 0.85,
+        "kind": "Signet"
+      },
+      "pos": [
+        480.0,
+        0.0
+      ]
+    },
+    {
+      "id": 8,
+      "kind": "design.new",
+      "pos": [
+        720.0,
+        0.0
+      ]
+    },
+    {
+      "id": 9,
+      "kind": "sink.output",
+      "pos": [
+        960.0,
+        0.0
+      ]
+    }
+  ],
+  "wires": [
+    {
+      "from": 1,
+      "out": "out",
+      "to": 5,
+      "input": "width_mm"
+    },
+    {
+      "from": 2,
+      "out": "out",
+      "to": 5,
+      "input": "thickness_mm"
+    },
+    {
+      "from": 3,
+      "out": "out",
+      "to": 6,
+      "input": "outline"
+    },
+    {
+      "from": 1,
+      "out": "out",
+      "to": 6,
+      "input": "fit_to_width_mm"
+    },
+    {
+      "from": 6,
+      "out": "head",
+      "to": 7,
+      "input": "head"
+    },
+    {
+      "from": 4,
+      "out": "out",
+      "to": 8,
+      "input": "name"
+    },
+    {
+      "from": 5,
+      "out": "profile",
+      "to": 8,
+      "input": "profile"
+    },
+    {
+      "from": 7,
+      "out": "shank",
+      "to": 8,
+      "input": "shank"
+    },
+    {
+      "from": 8,
+      "out": "design",
+      "to": 9,
+      "input": "design"
+    }
+  ],
+  "exposed": [
+    {
+      "node": 1,
+      "input": "value",
+      "name": "Width"
+    },
+    {
+      "node": 2,
+      "input": "value",
+      "name": "Thickness"
+    },
+    {
+      "node": 3,
+      "input": "value",
+      "name": "Outline"
+    },
+    {
+      "node": 4,
+      "input": "value",
+      "name": "Name"
+    },
+    {
+      "node": 8,
+      "input": "size",
+      "name": "Size"
+    },
+    {
+      "node": 6,
+      "input": "rise_mm",
+      "name": "Rise"
+    },
+    {
+      "node": 6,
+      "input": "shoulder_deg",
+      "name": "Shoulder"
+    },
+    {
+      "node": 6,
+      "input": "rim_round_mm",
+      "name": "Rim"
+    },
+    {
+      "node": 6,
+      "input": "loft",
+      "name": "Loft"
+    },
+    {
+      "node": 6,
+      "input": "table_dome_mm",
+      "name": "Cap"
+    },
+    {
+      "node": 7,
+      "input": "amount",
+      "name": "Taper"
+    }
+  ],
+  "outputs": [
+    {
+      "node": 8,
+      "out": "design",
+      "name": "design"
+    },
+    {
+      "node": 6,
+      "out": "head",
+      "name": "head"
+    },
+    {
+      "node": 7,
+      "out": "shank",
+      "name": "shank"
+    },
+    {
+      "node": 5,
+      "out": "profile",
+      "name": "profile"
+    }
+  ],
+  "next_id": 10
+}

--- a/graphs/presets/cushion-signet.preset.json
+++ b/graphs/presets/cushion-signet.preset.json
@@ -1,0 +1,12 @@
+{
+  "format_version": 1,
+  "name": "Cushion signet",
+  "cluster": "Signet",
+  "values": {
+    "Name": "Cushion signet",
+    "Outline": "Cushion",
+    "Thickness": 2.2,
+    "Width": 14.5
+  },
+  "doc": "A Cushion head on a 14.5 × 2.2 mm squared band, lofted."
+}

--- a/graphs/presets/heart-signet.preset.json
+++ b/graphs/presets/heart-signet.preset.json
@@ -1,0 +1,12 @@
+{
+  "format_version": 1,
+  "name": "Heart signet",
+  "cluster": "Signet",
+  "values": {
+    "Name": "Heart signet",
+    "Outline": "Heart",
+    "Thickness": 1.6,
+    "Width": 15.5
+  },
+  "doc": "A Heart head on a 15.5 × 1.6 mm squared band, lofted."
+}


### PR DESCRIPTION
## Summary
- `templates::build_signet_cluster` + committed `graphs/clusters/signet.cluster.json`; two presets under `graphs/presets/`; bundled clusters/presets behind user-dir ones in `file.rs`.
- Test: the cluster under the "Heart signet" preset equals the code template byte-for-byte; both presets castable.

## Verification
- `cargo test --workspace` green; graph crate 63 tests.
- wasm check passes.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)