### PR TITLE
M5.3 Editor polish: collapse into a cluster, fit, minimap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1613,7 +1613,14 @@ nodes in evaluation order, the lift's stack order) finds the producing
 node, the editor centres on it through snarl's `current_transform`, and
 the Node tool opens. Bake drops the graph and the design stays exactly as
 last evaluated. The Delete key acts on the active pane: a selected node
-in a Graph pane, otherwise the selected layer. History names a graph
+in a Graph pane, otherwise the selected layer. **Collapse** folds the
+view's selection (or a node with its upstream, from the node menu) into
+one cluster node: `Graph::collapse` keeps the folded nodes' ids inside,
+turns every boundary wire into an exposed input or output and rewires
+through the new node, and carries the parent's own exposures on folded
+nodes onto it — the graph evaluates the same before and after (pinned).
+Fit and the minimap read the view transform snarl hands to
+`current_transform` each frame. History names a graph
 change as a document — converted, edited, baked — which is why
 `first_difference` treats a key present on one side only as a change.
 

--- a/crates/ringdesign-graph-ui/src/editor.rs
+++ b/crates/ringdesign-graph-ui/src/editor.rs
@@ -175,12 +175,19 @@ pub struct Editor {
     style: SnarlStyle,
     /// A node to centre the view on at the next frame.
     pending_focus: Option<NodeId>,
+    /// Fit every node into the view at the next frame.
+    pending_fit: bool,
+    /// The view's transform as of the last frame, for the minimap.
+    transform: Option<egui::emath::TSTransform>,
+    /// The persistent id the snarl was last shown under, for selection.
+    snarl_id: Option<egui::Id>,
+    pub show_minimap: bool,
 }
 
 impl Editor {
     pub fn new(graph: Graph, reg: &Registry) -> Self {
         let (snarl, ids) = build_snarl(&graph, reg);
-        Self { graph, snarl, ids, revision: 0, selected: None, editable: true, style: SnarlStyle::new(), pending_focus: None }
+        Self { graph, snarl, ids, revision: 0, selected: None, editable: true, style: SnarlStyle::new(), pending_focus: None, pending_fit: false, transform: None, snarl_id: None, show_minimap: true }
     }
 
     pub fn graph(&self) -> &Graph {
@@ -242,9 +249,39 @@ impl Editor {
         }
     }
 
+    /// Fit the whole graph into the view at the next frame.
+    pub fn fit(&mut self) {
+        self.pending_fit = true;
+    }
+
+    /// The nodes the view has selected (rubber-band or click), as graph ids.
+    pub fn selected_nodes(&self, ctx: &egui::Context) -> Vec<NodeId> {
+        let Some(id) = self.snarl_id else { return Vec::new() };
+        egui_snarl::ui::get_selected_nodes(id, ctx).into_iter().filter_map(|sid| self.ids.to_graph.get(&sid).copied()).collect()
+    }
+
+    /// Fold nodes into a cluster node and rebuild the view.
+    pub fn collapse(&mut self, ids: &[NodeId], name: &str, reg: &Registry) -> Result<NodeId, GraphError> {
+        let mut g = self.graph.clone();
+        let cid = g.collapse(ids, name)?;
+        self.set_graph(g, reg);
+        self.selected = Some(cid);
+        Ok(cid)
+    }
+
+    /// Fold a node and everything feeding it into a cluster.
+    pub fn collapse_upstream(&mut self, id: NodeId, name: &str, reg: &Registry) -> Result<NodeId, GraphError> {
+        let mut ids = self.graph.upstream(id);
+        ids.push(id);
+        self.collapse(&ids, name, reg)
+    }
+
     /// Draw the editor and extract any change.
     pub fn show(&mut self, reg: &Registry, ui: &mut Ui, id_salt: &str) -> EditorResponse {
         let focus = self.pending_focus.take().and_then(|id| self.ids.to_snarl.get(&id).copied());
+        let viewport = ui.available_rect_before_wrap();
+        let fit = std::mem::take(&mut self.pending_fit).then_some(viewport);
+        self.snarl_id = Some(ui.make_persistent_id(id_salt));
         let mut viewer = Viewer {
             reg,
             editable: self.editable,
@@ -253,11 +290,26 @@ impl Editor {
             search: String::new(),
             ids: &self.ids,
             focus,
-            viewport_center: ui.available_rect_before_wrap().center(),
+            fit,
+            viewport_center: viewport.center(),
+            seen_transform: None,
+            collapse_request: None,
         };
         self.snarl.show(&mut viewer, &self.style, id_salt, ui);
         let clicked = viewer.clicked;
         let refused = viewer.refused.take();
+        let collapse_request = viewer.collapse_request.take();
+        self.transform = viewer.seen_transform.or(self.transform);
+        if self.show_minimap {
+            self.paint_minimap(ui, viewport);
+        }
+        if let Some(sid) = collapse_request {
+            if let Some(gid) = self.ids.to_graph.get(&sid).copied() {
+                let name = format!("Cluster {}", self.graph.nodes.iter().filter(|n| n.kind == "cluster").count() + 1);
+                let _ = self.collapse_upstream(gid, &name, reg);
+                return EditorResponse { changed: true, selected: self.selected, refused: None };
+            }
+        }
         let mut resp = EditorResponse { refused, ..Default::default() };
         if let Some(sid) = clicked {
             self.selected = self.ids.to_graph.get(&sid).copied();
@@ -400,7 +452,54 @@ struct Viewer<'a> {
     search: String,
     ids: &'a IdMap,
     focus: Option<SnarlId>,
+    fit: Option<egui::Rect>,
     viewport_center: egui::Pos2,
+    seen_transform: Option<egui::emath::TSTransform>,
+    collapse_request: Option<SnarlId>,
+}
+
+/// The footprint a node is assumed to take when fitting or mapping.
+const NODE_SIZE: egui::Vec2 = egui::vec2(220.0, 140.0);
+
+fn node_bounds(snarl: &Snarl<NodeCard>) -> Option<egui::Rect> {
+    let mut rect: Option<egui::Rect> = None;
+    for (_, pos, _) in snarl.nodes_pos_ids() {
+        let r = egui::Rect::from_min_size(pos, NODE_SIZE);
+        rect = Some(rect.map_or(r, |b| b.union(r)));
+    }
+    rect
+}
+
+impl Editor {
+    /// A small map of every node and the current view, in the corner.
+    fn paint_minimap(&self, ui: &Ui, viewport: egui::Rect) {
+        let Some(bounds) = node_bounds(&self.snarl) else { return };
+        if self.snarl.node_ids().count() < 2 {
+            return;
+        }
+        let map = egui::Rect::from_min_size(viewport.right_top() + egui::vec2(-172.0, 12.0), egui::vec2(160.0, 100.0));
+        let painter = ui.painter().with_clip_rect(viewport);
+        painter.rect_filled(map, 4.0, Color32::from_black_alpha(170));
+        painter.rect_stroke(map, 4.0, egui::Stroke::new(1.0, Color32::from_gray(90)), egui::StrokeKind::Inside);
+        let pad = bounds.expand(80.0);
+        let to_map = |p: egui::Pos2| -> egui::Pos2 {
+            let u = ((p.x - pad.min.x) / pad.width().max(1.0)).clamp(0.0, 1.0);
+            let v = ((p.y - pad.min.y) / pad.height().max(1.0)).clamp(0.0, 1.0);
+            map.min + egui::vec2(u * map.width(), v * map.height())
+        };
+        for (sid, pos, card) in self.snarl.nodes_pos_ids() {
+            let c = to_map(pos + NODE_SIZE * 0.5);
+            let selected = self.ids.to_graph.get(&sid).is_some_and(|g| self.selected == Some(*g));
+            let color = if !card.diag.is_empty() { Color32::from_rgb(220, 70, 70) } else if selected { Color32::from_rgb(255, 215, 120) } else { Color32::from_gray(200) };
+            painter.circle_filled(c, if selected { 3.5 } else { 2.5 }, color);
+        }
+        if let Some(t) = self.transform {
+            let inv = t.inverse();
+            let view = egui::Rect::from_min_max(inv * viewport.min, inv * viewport.max);
+            let r = egui::Rect::from_min_max(to_map(view.min), to_map(view.max));
+            painter.rect_stroke(r, 2.0, egui::Stroke::new(1.0, Color32::from_rgb(120, 190, 255)), egui::StrokeKind::Inside);
+        }
+    }
 }
 
 fn pin_info(pin: &PinSpec) -> PinInfo {
@@ -478,6 +577,14 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
     }
 
     fn current_transform(&mut self, to_global: &mut egui::emath::TSTransform, snarl: &mut Snarl<NodeCard>) {
+        if let Some(viewport) = self.fit.take() {
+            if let Some(bounds) = node_bounds(snarl) {
+                let pad = bounds.expand(40.0);
+                let scale = (viewport.width() / pad.width().max(1.0)).min(viewport.height() / pad.height().max(1.0)).clamp(0.15, 1.5);
+                to_global.scaling = scale;
+                to_global.translation = viewport.center().to_vec2() - pad.center().to_vec2() * scale;
+            }
+        }
         if let Some(sid) = self.focus.take() {
             if let Some(info) = snarl.get_node_info(sid) {
                 // The node's top-left, pushed a little so the header sits
@@ -487,6 +594,7 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
                 to_global.translation = self.viewport_center.to_vec2() - anchor.to_vec2() * scale;
             }
         }
+        self.seen_transform = Some(*to_global);
     }
 
     fn final_node_rect(&mut self, node: SnarlId, rect: egui::Rect, ui: &mut Ui, _snarl: &mut Snarl<NodeCard>) {
@@ -604,6 +712,10 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
             }
             ui.close();
         }
+        if ui.button("Collapse with upstream into a cluster").on_hover_text("This node and everything feeding it become one cluster node").clicked() {
+            self.collapse_request = Some(node);
+            ui.close();
+        }
     }
 }
 
@@ -643,7 +755,7 @@ mod tests {
 
         // Text -> Number is refused by the viewer; Number -> Number replaces.
         let (mut snarl, ids) = build_snarl(&g, &reg);
-        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids, focus: None, viewport_center: egui::Pos2::ZERO };
+        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids, focus: None, fit: None, viewport_center: egui::Pos2::ZERO, seen_transform: None, collapse_request: None };
         let text_out = OutPin { id: OutPinId { node: ids.to_snarl[&t], output: 0 }, remotes: vec![] };
         let add_b = InPin { id: InPinId { node: ids.to_snarl[&a], input: 1 }, remotes: vec![] };
         viewer.connect(&text_out, &add_b, &mut snarl);
@@ -701,6 +813,28 @@ mod tests {
         assert!(ed.pending_focus.is_none(), "one frame consumes the focus");
         ed.focus(NodeId(999));
         assert!(ed.pending_focus.is_none(), "an unknown node is ignored");
+
+        // Fit is consumed by a frame too, and leaves a transform the minimap reads.
+        ed.fit();
+        let mut harness = egui_kittest::Harness::new_ui(|ui| {
+            ed.show(&reg, ui, "focus-editor");
+        });
+        harness.set_size(egui::vec2(900.0, 600.0));
+        harness.run();
+        drop(harness);
+        assert!(!ed.pending_fit);
+        assert!(ed.transform.is_some());
+        assert!(ed.snarl_id.is_some());
+
+        // Collapsing a layer's entry with its upstream leaves the graph evaluable.
+        let g = ringdesign_graph::templates::graph("Braided band").unwrap();
+        let mut ed = Editor::new(g, &reg);
+        let entry = ed.graph().entry_nodes()[1];
+        let cid = ed.collapse_upstream(entry, "Milgrain cluster", &reg).unwrap();
+        assert!(ed.graph().validate(Some(&reg)).is_empty(), "{:?}", ed.graph().validate(Some(&reg)));
+        assert_eq!(ed.selected, Some(cid));
+        let out = ringdesign_graph::eval::evaluate_design(&mut ringdesign_graph::eval::Evaluator::new(), ed.graph(), &reg, &ringdesign_core::AlphaLibrary::builtin(), 0).unwrap();
+        assert_eq!(out.design.layers.layers.len(), 2, "both layers still arrive: {:?}", out.notes);
     }
 
     #[test]

--- a/crates/ringdesign-graph/src/graph.rs
+++ b/crates/ringdesign-graph/src/graph.rs
@@ -394,6 +394,105 @@ impl Graph {
         }
     }
 
+    /// Fold `ids` into one cluster node: the subset becomes a cluster graph
+    /// (ids kept), wires crossing its boundary become the cluster's exposed
+    /// inputs and outputs and are rewired through the new node, and any of
+    /// the parent's exposures on the folded nodes stay exposed through it.
+    /// Returns the cluster node's id.
+    pub fn collapse(&mut self, ids: &[NodeId], name: &str) -> Result<NodeId, GraphError> {
+        let set: BTreeSet<NodeId> = ids.iter().copied().collect();
+        if set.is_empty() {
+            return Err(GraphError::global("nothing to collapse"));
+        }
+        for id in &set {
+            if !self.contains(*id) {
+                return Err(GraphError::at(*id, "no such node"));
+            }
+        }
+        let mut inner = Graph::new(name, self.mode);
+        inner.next_id = self.next_id;
+        inner.nodes = self.nodes.iter().filter(|n| set.contains(&n.id)).cloned().collect();
+        inner.wires = self.wires.iter().filter(|w| set.contains(&w.from) && set.contains(&w.to)).cloned().collect();
+        fn fresh(base: &str, used: &mut BTreeSet<String>) -> String {
+            let mut n = base.to_string();
+            let mut k = 2;
+            while !used.insert(n.clone()) {
+                n = format!("{base} {k}");
+                k += 1;
+            }
+            n
+        }
+        let (mut used_in, mut used_out) = (BTreeSet::new(), BTreeSet::new());
+        let mut into: Vec<(Wire, String)> = Vec::new();
+        let mut out_of: Vec<(Wire, String)> = Vec::new();
+        let mut in_names: BTreeMap<(NodeId, String), String> = BTreeMap::new();
+        let mut out_names: BTreeMap<(NodeId, String), String> = BTreeMap::new();
+        for w in &self.wires {
+            if !set.contains(&w.from) && set.contains(&w.to) {
+                let key = (w.to, w.input.clone());
+                let pin = match in_names.get(&key) {
+                    Some(n) => n.clone(),
+                    None => {
+                        let n = fresh(&w.input, &mut used_in);
+                        inner.expose(w.to, &w.input, &n)?;
+                        in_names.insert(key, n.clone());
+                        n
+                    }
+                };
+                into.push((w.clone(), pin));
+            } else if set.contains(&w.from) && !set.contains(&w.to) {
+                let key = (w.from, w.out.clone());
+                let pin = match out_names.get(&key) {
+                    Some(n) => n.clone(),
+                    None => {
+                        let n = fresh(&w.out, &mut used_out);
+                        inner.expose_output(w.from, &w.out, &n)?;
+                        out_names.insert(key, n.clone());
+                        n
+                    }
+                };
+                out_of.push((w.clone(), pin));
+            }
+        }
+        // The parent's own exposures on folded nodes stay reachable.
+        let mut carried: Vec<(String, String)> = Vec::new();
+        for e in self.exposed.iter().filter(|e| set.contains(&e.node)) {
+            let key = (e.node, e.input.clone());
+            let pin = match in_names.get(&key) {
+                Some(n) => n.clone(),
+                None => {
+                    let n = fresh(&e.name, &mut used_in);
+                    inner.expose(e.node, &e.input, &n)?;
+                    in_names.insert(key, n.clone());
+                    n
+                }
+            };
+            carried.push((pin, e.name.clone()));
+        }
+        let centroid = {
+            let pts: Vec<[f32; 2]> = self.nodes.iter().filter(|n| set.contains(&n.id)).map(|n| n.pos).collect();
+            let k = pts.len().max(1) as f32;
+            [pts.iter().map(|p| p[0]).sum::<f32>() / k, pts.iter().map(|p| p[1]).sum::<f32>() / k]
+        };
+        for id in &set {
+            self.remove(*id)?;
+        }
+        let cid = crate::nodes::cluster::add_cluster(self, &inner)?;
+        if let Some(node) = self.node_mut(cid) {
+            node.pos = centroid;
+        }
+        for (w, pin) in into {
+            self.connect(w.from, w.out, cid, pin)?;
+        }
+        for (w, pin) in out_of {
+            self.connect(cid, pin, w.to, w.input)?;
+        }
+        for (pin, name) in carried {
+            self.expose(cid, pin, name)?;
+        }
+        Ok(cid)
+    }
+
     /// The `entry` nodes in evaluation order — the order the lift builds a
     /// stack in, so the k-th one is the node behind the k-th layer of a
     /// lifted design (a best effort on a hand-wired graph).
@@ -761,6 +860,48 @@ mod tests {
         g.remove(a).unwrap();
         assert!(g.exposed.is_empty());
         assert!(g.unexpose("W").is_none());
+    }
+
+    #[test]
+    fn a_collapse_keeps_the_graph_evaluating_the_same() {
+        use crate::eval::{Evaluator, Targets};
+        use crate::registry::Registry;
+        use crate::value::{Literal, Value};
+        use ringdesign_core::AlphaLibrary;
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::default();
+        let mut g = Graph::default();
+        let n = g.add("number").unwrap();
+        g.set_input(n, "value", Literal::Number(2.0)).unwrap();
+        let add = g.add("math.add").unwrap();
+        g.set_input(add, "b", Literal::Number(3.0)).unwrap();
+        let mul = g.add("math.mul").unwrap();
+        g.set_input(mul, "b", Literal::Number(4.0)).unwrap();
+        let neg = g.add("math.neg").unwrap();
+        g.connect(n, "out", add, "a").unwrap();
+        g.connect(add, "out", mul, "a").unwrap();
+        g.connect(mul, "out", neg, "x").unwrap();
+        g.expose(mul, "b", "Factor").unwrap();
+        let before = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert_eq!(before.value(neg, "out"), Some(&Value::Number(-20.0)));
+        let cid = g.collapse(&[add, mul], "Middle").unwrap();
+        assert_eq!(g.nodes.len(), 3, "number, the cluster, neg");
+        assert!(g.validate(Some(&reg)).is_empty(), "{:?}", g.validate(Some(&reg)));
+        let inner = crate::nodes::cluster::embedded(g.node(cid).unwrap()).unwrap();
+        assert_eq!(inner.nodes.len(), 2);
+        assert_eq!(inner.exposed.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(), vec!["a", "Factor"]);
+        assert_eq!(inner.outputs.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(), vec!["out"]);
+        assert_eq!(g.exposed.len(), 1, "the parent's exposure rides on the cluster");
+        assert_eq!((g.exposed[0].node, g.exposed[0].input.as_str(), g.exposed[0].name.as_str()), (cid, "Factor", "Factor"));
+        let after = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(!after.any_failed(), "{:?}", after.notes(&g));
+        assert_eq!(after.value(neg, "out"), Some(&Value::Number(-20.0)));
+        // The carried exposure still works through the cluster.
+        g.set_input(cid, "Factor", Literal::Number(10.0)).unwrap();
+        let again = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert_eq!(again.value(neg, "out"), Some(&Value::Number(-50.0)));
+        assert!(g.collapse(&[], "x").is_err());
+        assert!(g.collapse(&[NodeId(99)], "x").is_err());
     }
 
     #[test]

--- a/crates/ringdesign-gui/src/app.rs
+++ b/crates/ringdesign-gui/src/app.rs
@@ -860,6 +860,20 @@ impl RingDesignerApp {
         }
     }
 
+    /// Fold these nodes into a cluster node.
+    pub fn collapse_nodes(&mut self, ids: &[GraphNodeId]) {
+        let reg = self.graph_reg.clone();
+        let Some(ed) = &mut self.graph_ed else { return };
+        let name = format!("Cluster {}", ed.graph().nodes.iter().filter(|n| n.kind == "cluster").count() + 1);
+        match ed.collapse(ids, &name, &reg) {
+            Ok(cid) => {
+                self.selected_node = Some(cid);
+                self.graph_changed();
+            }
+            Err(e) => self.set_status(format!("Could not collapse: {e}")),
+        }
+    }
+
     pub fn delete_selected_node(&mut self) {
         let Some(id) = self.selected_node.take() else { return };
         if let Some(ed) = &mut self.graph_ed {

--- a/crates/ringdesign-gui/src/panels/graph.rs
+++ b/crates/ringdesign-gui/src/panels/graph.rs
@@ -17,6 +17,15 @@ pub fn ui(app: &mut RingDesignerApp, ui: &mut egui::Ui, pane: usize) {
                 if ui.button(format!("{} Arrange", icon::ARROWS_OUT_LINE_HORIZONTAL)).on_hover_text("Lay the nodes out by depth").clicked() {
                     app.arrange_graph();
                 }
+                if ui.button(format!("{} Fit", icon::ARROWS_IN)).on_hover_text("Fit the whole graph in view").clicked() {
+                    if let Some(ed) = app.graph_ed.as_mut() {
+                        ed.fit();
+                    }
+                }
+                let selection = app.graph_ed.as_ref().map(|ed| ed.selected_nodes(ui.ctx())).unwrap_or_default();
+                if ui.add_enabled(!selection.is_empty(), egui::Button::new(format!("{} Collapse {}", icon::PACKAGE, selection.len()))).on_hover_text("Fold the selected nodes into one cluster node").clicked() {
+                    app.collapse_nodes(&selection);
+                }
                 if ui.button(format!("{} Bake", icon::FIRE)).on_hover_text("Drop the graph; keep the design as last evaluated").clicked() {
                     app.bake_graph();
                     return;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -132,7 +132,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   lattice — never a relaxation), format, json, if.
 - [x] **M5.2 First hosted cluster** (M, #54). The signet construction as a user-dir cluster whose
   preset evaluates to the lofted head.
-- [ ] **M5.3 Editor polish** (M, #55). Live value badges, subgraph navigation and collapse, arrange,
+- [x] **M5.3 Editor polish** (M, #55). Live value badges, subgraph navigation and collapse, arrange,
   fit, minimap.
 
 ## M6 — Python: `ringdesign-py` (M) — epic #22


### PR DESCRIPTION
## Summary
- `Graph::collapse` (boundary wires → exposed pins, exposures carried, ids kept) with a test that the graph evaluates the same before and after.
- Editor: `fit`, `selected_nodes`, `collapse`/`collapse_upstream`, minimap from the captured view transform; toolbar Fit/Collapse; node menu "Collapse with upstream".

## Verification
- `cargo test --workspace` green (graph 64, graph-ui 6).
- wasm check passes.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)