### PR TITLE
M7.2 Free-mode solid nodes, frames on the ring, mesh import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1586,6 +1586,23 @@ the Free-mode verdict — faces, not the field, because a solid has no
 chart. Everything here is lost-wax territory unless the field says
 otherwise; the SandRing verdict never reads a solid.
 
+The nodes (`ringdesign-graph/src/nodes/solid.rs`, behind
+`kernel-manifold`, all Free-mode only so a SandRing graph refuses them
+at validation): `solid.cylinder/sphere/box/extrude/revolve`,
+`solid.from_design` (the watertight sweep taken into the kernel),
+`solid.union/difference/intersect/union_all`, `translate/rotate/scale`,
+`frame.on_ring` (a frame on the band at an angle, `z` out of the metal,
+tilt and roll) with `solid.place`, `solid.tube`, `solid.setting`
+(marquise or round), `solid.leaf`, `solid.import` (the solid crate's OBJ
+and STL readers, welded; refused unless watertight) and `solid.mesh`,
+which is how a solid reaches `sink.mesh_verdict`, `sink.export` and
+`sink.render`. Pinned: a semi-mount — the Court band as a solid, a round
+setting placed by `frame.on_ring`, unioned — exports as STL and imports
+back within 0.1% of its volume; a revolved section matches π·(R²−r²)·h.
+The editor's palette lists the graph's own mode. The GUI and the CLI
+carry a `kernel` feature forwarding to it
+(`cargo run -p ringdesign-gui --features kernel`).
+
 ## Python: `crates/ringdesign-py`
 
 The core and the graph runtime as a Python module (`import ringdesign`),

--- a/crates/ringdesign-cli/Cargo.toml
+++ b/crates/ringdesign-cli/Cargo.toml
@@ -9,6 +9,10 @@ description = "The ringdesign command line: size runs, checks, and graph evaluat
 name = "ringdesign"
 path = "src/main.rs"
 
+[features]
+default = []
+kernel = ["ringdesign-graph/kernel-manifold", "ringdesign-script/kernel"]
+
 [dependencies]
 ringdesign-core.workspace = true
 ringdesign-graph.workspace = true

--- a/crates/ringdesign-graph-ui/src/editor.rs
+++ b/crates/ringdesign-graph-ui/src/editor.rs
@@ -294,6 +294,7 @@ impl Editor {
             viewport_center: viewport.center(),
             seen_transform: None,
             collapse_request: None,
+            mode: self.graph.mode,
         };
         self.snarl.show(&mut viewer, &self.style, id_salt, ui);
         let clicked = viewer.clicked;
@@ -456,6 +457,7 @@ struct Viewer<'a> {
     viewport_center: egui::Pos2,
     seen_transform: Option<egui::emath::TSTransform>,
     collapse_request: Option<SnarlId>,
+    mode: ringdesign_graph::graph::Mode,
 }
 
 /// The footprint a node is assumed to take when fitting or mapping.
@@ -650,8 +652,7 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
         ui.set_min_width(220.0);
         ui.label(RichText::new("Add node").small().weak());
         ui.add(egui::TextEdit::singleline(&mut self.search).hint_text("search…"));
-        let mode = ringdesign_graph::graph::Mode::SandRing;
-        let specs = self.reg.list(mode);
+        let specs = self.reg.list(self.mode);
         let needle = self.search.trim().to_lowercase();
         if !needle.is_empty() {
             egui::ScrollArea::vertical().max_height(260.0).show(ui, |ui| {
@@ -755,7 +756,7 @@ mod tests {
 
         // Text -> Number is refused by the viewer; Number -> Number replaces.
         let (mut snarl, ids) = build_snarl(&g, &reg);
-        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids, focus: None, fit: None, viewport_center: egui::Pos2::ZERO, seen_transform: None, collapse_request: None };
+        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids, focus: None, fit: None, viewport_center: egui::Pos2::ZERO, seen_transform: None, collapse_request: None, mode: Mode::SandRing };
         let text_out = OutPin { id: OutPinId { node: ids.to_snarl[&t], output: 0 }, remotes: vec![] };
         let add_b = InPin { id: InPinId { node: ids.to_snarl[&a], input: 1 }, remotes: vec![] };
         viewer.connect(&text_out, &add_b, &mut snarl);

--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -19,6 +19,8 @@ pub mod list;
 pub mod math;
 pub mod shank;
 pub mod sink;
+#[cfg(feature = "kernel-manifold")]
+pub mod solid;
 pub mod source;
 pub mod structs;
 pub mod text;
@@ -39,6 +41,8 @@ pub fn register_all(reg: &mut Registry) {
     sink::register(reg);
     cluster::register(reg);
     idiom::register(reg);
+    #[cfg(feature = "kernel-manifold")]
+    solid::register(reg);
 }
 
 #[cfg(test)]

--- a/crates/ringdesign-graph/src/nodes/solid.rs
+++ b/crates/ringdesign-graph/src/nodes/solid.rs
@@ -1,0 +1,472 @@
+//! Free-mode solids: the Manifold kernel as nodes. Every node here runs in
+//! Free mode only; a SandRing graph refuses them at validation, because a
+//! solid has no chart and the field cannot judge it.
+
+use std::sync::Arc;
+
+use ringdesign_core::mesh::BuildParams;
+use ringdesign_solid::kernel::{self, Frame, Solid, V3, v3};
+use serde::{Deserialize, Serialize};
+
+use crate::graph::Node;
+use crate::registry::{Category, EvalCtx, Inputs, NodeError, NodeSpec, Outputs, PinSpec, Registry, Widget};
+use crate::value::{SolidHandle, Value, ValueKind};
+
+/// A Manifold behind the graph's solid handle.
+pub struct ManifoldSolid(pub Solid);
+
+impl SolidHandle for ManifoldSolid {
+    fn describe(&self) -> String {
+        format!("solid {} tris, {:.2} mm³", self.0.num_tri(), self.0.volume())
+    }
+
+    fn to_mesh(&self) -> Option<ringdesign_core::Mesh> {
+        Some(kernel::to_mesh(&self.0))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn wrap(s: Solid) -> Value {
+    Value::Solid(Arc::new(ManifoldSolid(s)))
+}
+
+fn solid_of(i: &Inputs, pin: &str) -> Result<Solid, NodeError> {
+    match i.get(pin) {
+        Value::Solid(h) => h.as_any().downcast_ref::<ManifoldSolid>().map(|m| m.0.clone()).ok_or_else(|| NodeError::input(pin, "a solid from another kernel")),
+        Value::Mesh(m) => kernel::from_mesh(m).map_err(|e| NodeError::input(pin, e.to_string())),
+        other => Err(NodeError::input(pin, format!("expected a solid, got {}", other.summary()))),
+    }
+}
+
+fn segments(i: &Inputs) -> Result<i32, NodeError> {
+    let s = i.int("segments")?;
+    if !(3..=512).contains(&s) {
+        return Err(NodeError::input("segments", format!("{s} is not between 3 and 512")));
+    }
+    Ok(s as i32)
+}
+
+fn positive(i: &Inputs, pin: &str) -> Result<f64, NodeError> {
+    let v = i.number(pin)?;
+    if !(v > 0.0) || !v.is_finite() {
+        return Err(NodeError::input(pin, format!("{v} is not positive")));
+    }
+    Ok(v)
+}
+
+fn points2(i: &Inputs, pin: &str) -> Result<Vec<[f64; 2]>, NodeError> {
+    match i.get(pin) {
+        Value::Path(p) => Ok((**p).clone()),
+        other => Err(NodeError::input(pin, format!("expected a path, got {}", other.summary()))),
+    }
+}
+
+fn points3(i: &Inputs, pin: &str) -> Result<Vec<V3>, NodeError> {
+    let json = i.get(pin).to_json_any().ok_or_else(|| NodeError::input(pin, "expected a list of [x, y, z]"))?;
+    let pts: Vec<[f64; 3]> = serde_json::from_value(json).map_err(|e| NodeError::input(pin, format!("expected a list of [x, y, z]: {e}")))?;
+    Ok(pts.into_iter().map(|p| v3(p[0], p[1], p[2])).collect())
+}
+
+/// A frame as the graph carries it: JSON.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct FrameJson {
+    origin: [f64; 3],
+    x: [f64; 3],
+    y: [f64; 3],
+    z: [f64; 3],
+}
+
+impl FrameJson {
+    fn of(f: &Frame) -> Self {
+        let a = |v: V3| [v.x, v.y, v.z];
+        Self { origin: a(f.origin), x: a(f.x), y: a(f.y), z: a(f.z) }
+    }
+    fn frame(&self) -> Frame {
+        let v = |a: [f64; 3]| v3(a[0], a[1], a[2]);
+        Frame { origin: v(self.origin), x: v(self.x), y: v(self.y), z: v(self.z) }
+    }
+}
+
+fn frame_of(i: &Inputs, pin: &str) -> Result<Frame, NodeError> {
+    let json = i.get(pin).to_json_any().ok_or_else(|| NodeError::input(pin, "expected a frame"))?;
+    let f: FrameJson = serde_json::from_value(json).map_err(|e| NodeError::input(pin, format!("not a frame: {e}")))?;
+    Ok(f.frame())
+}
+
+fn cylinder(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let h = positive(i, "height")?;
+    let r = positive(i, "radius")?;
+    let rt = i.get("radius_top").as_number().unwrap_or(r).max(0.0);
+    let s = ringdesign_solid::kernel::manifold3d::Manifold::cylinder(h, r, rt, segments(i)?, i.bool("center")?);
+    Ok(Outputs::one("solid", wrap(s)))
+}
+
+fn sphere(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(kernel::sphere(positive(i, "radius")?, segments(i)?))))
+}
+
+fn box_(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(kernel::cube(positive(i, "x")?, positive(i, "y")?, positive(i, "z")?, i.bool("center")?))))
+}
+
+fn extrude(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let pts = points2(i, "points")?;
+    if pts.len() < 3 {
+        return Err(NodeError::input("points", "a section needs at least three points"));
+    }
+    let cs = ringdesign_solid::kernel::manifold3d::CrossSection::from_simple_polygon(&pts);
+    Ok(Outputs::one("solid", wrap(cs.extrude(positive(i, "height")?))))
+}
+
+fn revolve(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let pts = points2(i, "points")?;
+    if pts.len() < 3 {
+        return Err(NodeError::input("points", "a section needs at least three points"));
+    }
+    if pts.iter().any(|p| p[0] < 0.0) {
+        return Err(NodeError::input("points", "a revolved section lies at x ≥ 0 (x is the radius)"));
+    }
+    let cs = ringdesign_solid::kernel::manifold3d::CrossSection::from_simple_polygon(&pts);
+    let deg = i.number("degrees")?.clamp(1.0, 360.0);
+    Ok(Outputs::one("solid", wrap(ringdesign_solid::kernel::manifold3d::Manifold::revolve(&cs, segments(i)?, deg))))
+}
+
+fn from_design(ctx: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let d = match i.get("design") {
+        Value::Design(d) => d.clone(),
+        other => return Err(NodeError::input("design", format!("expected a design, got {}", other.summary()))),
+    };
+    let preset = i.text("preset")?;
+    let (_, t, p) = BuildParams::PRESETS.iter().find(|(n, _, _)| n.eq_ignore_ascii_case(preset)).ok_or_else(|| NodeError::input("preset", format!("{preset:?} is not a build preset")))?;
+    let mut params = d.build;
+    params.theta_steps = *t;
+    params.profile_steps = *p;
+    params.refine = None;
+    let mut lib = (*ctx.lib).clone();
+    d.unpack_embedded(&mut lib);
+    d.bake_all(&mut lib);
+    let out = ringdesign_core::mesh::build(&d, &lib, params);
+    let s = kernel::from_mesh(&out.mesh).map_err(|e| NodeError::new(format!("the sweep did not take as a solid: {e}")))?;
+    Ok(Outputs::one("solid", wrap(s)))
+}
+
+fn union(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(solid_of(i, "a")?.union(&solid_of(i, "b")?))))
+}
+
+fn difference(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(solid_of(i, "a")?.difference(&solid_of(i, "b")?))))
+}
+
+fn intersect(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(solid_of(i, "a")?.intersection(&solid_of(i, "b")?))))
+}
+
+fn union_all(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let mut solids = Vec::new();
+    for (k, v) in i.list("solids").iter().enumerate() {
+        match v {
+            Value::Solid(h) => solids.push(h.as_any().downcast_ref::<ManifoldSolid>().map(|m| m.0.clone()).ok_or_else(|| NodeError::input("solids", format!("item {k} is from another kernel")))?),
+            other => return Err(NodeError::input("solids", format!("item {k} is {}, not a solid", other.summary()))),
+        }
+    }
+    Ok(Outputs::one("solid", wrap(kernel::union_all(&solids))))
+}
+
+fn translate(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(solid_of(i, "solid")?.translate(i.number("x")?, i.number("y")?, i.number("z")?))))
+}
+
+fn rotate(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(solid_of(i, "solid")?.rotate(i.number("x_deg")?, i.number("y_deg")?, i.number("z_deg")?))))
+}
+
+fn scale(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(solid_of(i, "solid")?.scale(positive(i, "x")?, positive(i, "y")?, positive(i, "z")?))))
+}
+
+fn frame_on_ring(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let radius = match i.get("design") {
+        Value::Design(d) => d.inner_radius_mm() + d.profile.thickness_mm,
+        Value::Null => i.get("radius_mm").as_number().ok_or_else(|| NodeError::input("radius_mm", "a design or a radius is needed"))?,
+        other => return Err(NodeError::input("design", format!("expected a design, got {}", other.summary()))),
+    };
+    let f = Frame::on_ring(radius, i.number("theta_deg")?, i.number("axial_mm")?, i.number("extra_mm")?).tilted(i.number("tilt_deg")?).rolled(i.number("roll_deg")?);
+    let json = serde_json::to_value(FrameJson::of(&f)).map_err(|e| NodeError::new(e.to_string()))?;
+    Ok(Outputs::one("frame", json).with("origin", serde_json::json!([f.origin.x, f.origin.y, f.origin.z])))
+}
+
+fn place(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let f = frame_of(i, "frame")?;
+    Ok(Outputs::one("solid", wrap(f.place(&solid_of(i, "solid")?))))
+}
+
+fn tube(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let pts = points3(i, "points")?;
+    if pts.len() < 2 {
+        return Err(NodeError::input("points", "a tube needs at least two points"));
+    }
+    Ok(Outputs::one("solid", wrap(kernel::tube(&pts, positive(i, "radius")?, segments(i)?))))
+}
+
+fn setting(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let seat_h = positive(i, "seat_h")?;
+    let parts = match i.text("kind")? {
+        "marquise" => kernel::marquise_setting(positive(i, "length")?, positive(i, "width")?, seat_h, i.bool("cross_brace")?),
+        "round" => kernel::round_setting(positive(i, "width")?, seat_h),
+        other => return Err(NodeError::input("kind", format!("{other:?} is not marquise or round"))),
+    };
+    Ok(Outputs::one("solid", wrap(parts.resolve())))
+}
+
+fn leaf(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    Ok(Outputs::one("solid", wrap(kernel::leaf(positive(i, "length")?, positive(i, "width")?, positive(i, "thickness")?))))
+}
+
+fn import(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let path = i.text("path")?.trim().to_string();
+    let lower = path.to_lowercase();
+    let mesh = if lower.ends_with(".obj") {
+        ringdesign_solid::io::read_obj(&path)
+    } else if lower.ends_with(".stl") {
+        ringdesign_solid::io::read_stl(&path)
+    } else {
+        return Err(NodeError::input("path", "an .obj or .stl file"));
+    }
+    .map_err(|e| NodeError::input("path", format!("{path}: {e:#}")))?;
+    let s = kernel::from_mesh(&mesh).map_err(|e| NodeError::input("path", format!("{path}: {e}")))?;
+    Ok(Outputs::one("solid", wrap(s)))
+}
+
+fn mesh(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+    let s = solid_of(i, "solid")?;
+    let m = kernel::to_mesh(&s);
+    let v = m.validate();
+    Ok(Outputs::one("triangles", v.triangle_count as i64)
+        .with("watertight", v.watertight)
+        .with("volume_mm3", s.volume())
+        .with("surface_area_mm2", s.surface_area())
+        .with("mesh", Value::Mesh(Arc::new(m))))
+}
+
+pub fn register(reg: &mut Registry) {
+    let seg = || PinSpec::item("segments", ValueKind::Int).default(48i64).doc("Facets round a circle, 3..512.");
+    let specs = [
+        NodeSpec::new("solid.cylinder", "Cylinder", Category::Solid).free_only()
+            .doc("A cylinder (or a cone, with a different top radius) along Z.")
+            .input(PinSpec::item("height", ValueKind::Number).default(2.0).widget(Widget::Mm { min: 0.01, max: 100.0 }).doc("Height, mm."))
+            .input(PinSpec::item("radius", ValueKind::Number).default(1.0).widget(Widget::Mm { min: 0.01, max: 100.0 }).doc("Bottom radius, mm."))
+            .input(PinSpec::item("radius_top", ValueKind::Number).optional().doc("Top radius, mm; the bottom's if unset."))
+            .input(seg())
+            .input(PinSpec::item("center", ValueKind::Bool).default(false).doc("Centre on the origin instead of standing on z = 0."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .eval(cylinder),
+        NodeSpec::new("solid.sphere", "Sphere", Category::Solid).free_only()
+            .doc("A sphere at the origin.")
+            .input(PinSpec::item("radius", ValueKind::Number).default(1.0).widget(Widget::Mm { min: 0.01, max: 100.0 }).doc("Radius, mm."))
+            .input(seg())
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .eval(sphere),
+        NodeSpec::new("solid.box", "Box", Category::Solid).free_only()
+            .doc("A box from the origin, or centred.")
+            .input(PinSpec::item("x", ValueKind::Number).default(2.0).doc("Size along x, mm."))
+            .input(PinSpec::item("y", ValueKind::Number).default(2.0).doc("Size along y, mm."))
+            .input(PinSpec::item("z", ValueKind::Number).default(2.0).doc("Size along z, mm."))
+            .input(PinSpec::item("center", ValueKind::Bool).default(false).doc("Centre on the origin."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .eval(box_),
+        NodeSpec::new("solid.extrude", "Extrude", Category::Solid).free_only()
+            .doc("A closed polygon in the XY plane extruded along Z.")
+            .input(PinSpec::item("points", ValueKind::Path).doc("The polygon, [x, y] pairs."))
+            .input(PinSpec::item("height", ValueKind::Number).default(1.0).doc("Height, mm."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .eval(extrude),
+        NodeSpec::new("solid.revolve", "Revolve", Category::Solid).free_only()
+            .doc("A closed polygon at x ≥ 0 revolved about the Y axis — a ring section turned into a ring.")
+            .input(PinSpec::item("points", ValueKind::Path).doc("The section, [radius, height] pairs."))
+            .input(seg())
+            .input(PinSpec::item("degrees", ValueKind::Number).default(360.0).doc("How far round, degrees."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .eval(revolve),
+        NodeSpec::new("solid.from_design", "Design as solid", Category::Solid).free_only()
+            .doc("The design's watertight sweep taken into the kernel, so settings and vines can be added to a band the field already judged.")
+            .input(PinSpec::item("design", ValueKind::Design).doc("The design."))
+            .input(PinSpec::select("preset", BuildParams::PRESETS.iter().map(|p| p.0.to_string()).collect()).default("Preview").doc("Sweep resolution."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The band as a solid."))
+            .eval(from_design),
+        NodeSpec::new("solid.union", "Union", Category::Solid).free_only()
+            .doc("a ∪ b.")
+            .input(PinSpec::item("a", ValueKind::Solid).doc("First.")).input(PinSpec::item("b", ValueKind::Solid).doc("Second."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The union.")).eval(union),
+        NodeSpec::new("solid.difference", "Difference", Category::Solid).free_only()
+            .doc("a minus b.")
+            .input(PinSpec::item("a", ValueKind::Solid).doc("Kept.")).input(PinSpec::item("b", ValueKind::Solid).doc("Cut away."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The difference.")).eval(difference),
+        NodeSpec::new("solid.intersect", "Intersect", Category::Solid).free_only()
+            .doc("a ∩ b.")
+            .input(PinSpec::item("a", ValueKind::Solid).doc("First.")).input(PinSpec::item("b", ValueKind::Solid).doc("Second."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The intersection.")).eval(intersect),
+        NodeSpec::new("solid.union_all", "Union all", Category::Solid).free_only()
+            .doc("Every solid in a list, unioned at once.")
+            .input(PinSpec::list("solids", ValueKind::Solid).doc("The solids."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The union.")).eval(union_all),
+        NodeSpec::new("solid.translate", "Translate", Category::Solid).free_only()
+            .doc("Move a solid.")
+            .input(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .input(PinSpec::item("x", ValueKind::Number).default(0.0).doc("mm")).input(PinSpec::item("y", ValueKind::Number).default(0.0).doc("mm")).input(PinSpec::item("z", ValueKind::Number).default(0.0).doc("mm"))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The moved solid.")).eval(translate),
+        NodeSpec::new("solid.rotate", "Rotate", Category::Solid).free_only()
+            .doc("Rotate a solid about the axes, degrees, X then Y then Z.")
+            .input(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .input(PinSpec::item("x_deg", ValueKind::Number).default(0.0).doc("About X.")).input(PinSpec::item("y_deg", ValueKind::Number).default(0.0).doc("About Y.")).input(PinSpec::item("z_deg", ValueKind::Number).default(0.0).doc("About Z."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The rotated solid.")).eval(rotate),
+        NodeSpec::new("solid.scale", "Scale", Category::Solid).free_only()
+            .doc("Scale a solid per axis.")
+            .input(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .input(PinSpec::item("x", ValueKind::Number).default(1.0).doc("Factor.")).input(PinSpec::item("y", ValueKind::Number).default(1.0).doc("Factor.")).input(PinSpec::item("z", ValueKind::Number).default(1.0).doc("Factor."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The scaled solid.")).eval(scale),
+        NodeSpec::new("frame.on_ring", "Frame on ring", Category::Solid).free_only()
+            .doc("A frame on the band at an angle (90° is the top): z points out of the metal, x along the ring; lifted along the finger, pushed outward, tilted about x and rolled about z.")
+            .input(PinSpec::item("design", ValueKind::Design).optional().doc("The design whose crest radius the frame sits at."))
+            .input(PinSpec::item("radius_mm", ValueKind::Number).optional().doc("A radius instead of a design."))
+            .input(PinSpec::item("theta_deg", ValueKind::Number).default(90.0).widget(Widget::Angle).doc("Where round the ring."))
+            .input(PinSpec::item("axial_mm", ValueKind::Number).default(0.0).doc("Along the finger axis, mm."))
+            .input(PinSpec::item("extra_mm", ValueKind::Number).default(0.0).doc("Outward from the crest, mm."))
+            .input(PinSpec::item("tilt_deg", ValueKind::Number).default(0.0).doc("Tilt about the frame's x."))
+            .input(PinSpec::item("roll_deg", ValueKind::Number).default(0.0).doc("Roll about the frame's z."))
+            .output(PinSpec::item("frame", ValueKind::Json).doc("The frame."))
+            .output(PinSpec::item("origin", ValueKind::Json).doc("Its origin, [x, y, z]."))
+            .eval(frame_on_ring),
+        NodeSpec::new("solid.place", "Place", Category::Solid).free_only()
+            .doc("A solid moved into a frame: its origin to the frame's origin, its axes to the frame's.")
+            .input(PinSpec::item("solid", ValueKind::Solid).doc("The solid, built at the origin with z up."))
+            .input(PinSpec::item("frame", ValueKind::Json).doc("The frame, from frame.on_ring."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The placed solid.")).eval(place),
+        NodeSpec::new("solid.tube", "Tube", Category::Solid).free_only()
+            .doc("A round wire along a polyline of [x, y, z] points: spheres at the knots, cylinders between.")
+            .input(PinSpec::item("points", ValueKind::Json).doc("The path, a list of [x, y, z]."))
+            .input(PinSpec::item("radius", ValueKind::Number).default(0.4).doc("Wire radius, mm."))
+            .input(seg())
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The wire.")).eval(tube),
+        NodeSpec::new("solid.setting", "Setting", Category::Solid).free_only()
+            .doc("A four-prong setting, marquise or round, standing on z = 0 with the girdle rail at the seat height.")
+            .input(PinSpec::select("kind", vec!["round".into(), "marquise".into()]).default("round").doc("Round or marquise."))
+            .input(PinSpec::item("length", ValueKind::Number).default(6.0).doc("Stone length, mm (marquise)."))
+            .input(PinSpec::item("width", ValueKind::Number).default(4.0).doc("Stone width (or round diameter), mm."))
+            .input(PinSpec::item("seat_h", ValueKind::Number).default(2.0).doc("Seat height over the base, mm."))
+            .input(PinSpec::item("cross_brace", ValueKind::Bool).default(false).doc("Cross bars under a marquise."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The setting.")).eval(setting),
+        NodeSpec::new("solid.leaf", "Leaf", Category::Solid).free_only()
+            .doc("A domed leaf with a midrib and veins cut in, lying on the XY plane.")
+            .input(PinSpec::item("length", ValueKind::Number).default(6.0).doc("mm")).input(PinSpec::item("width", ValueKind::Number).default(3.0).doc("mm")).input(PinSpec::item("thickness", ValueKind::Number).default(0.8).doc("mm"))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The leaf.")).eval(leaf),
+        NodeSpec::new("solid.import", "Import mesh", Category::Solid).free_only()
+            .doc("An OBJ or STL file as a solid; it must be watertight.")
+            .input(PinSpec::item("path", ValueKind::Text).default("").widget(Widget::TextLine).doc("The file."))
+            .output(PinSpec::item("solid", ValueKind::Solid).doc("The solid.")).eval(import),
+        NodeSpec::new("solid.mesh", "Solid as mesh", Category::Solid).free_only()
+            .doc("A solid's surface as a mesh, for sink.mesh_verdict, sink.export and sink.render.")
+            .input(PinSpec::item("solid", ValueKind::Solid).doc("The solid."))
+            .output(PinSpec::item("mesh", ValueKind::Mesh).doc("The mesh."))
+            .output(PinSpec::item("triangles", ValueKind::Int).doc("Triangle count."))
+            .output(PinSpec::item("watertight", ValueKind::Bool).doc("Always, for a solid."))
+            .output(PinSpec::item("volume_mm3", ValueKind::Number).doc("Volume, mm³."))
+            .output(PinSpec::item("surface_area_mm2", ValueKind::Number).doc("Area, mm²."))
+            .eval(mesh),
+    ];
+    for s in specs {
+        reg.register(s).expect("unique");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::eval::{Evaluator, Targets};
+    use crate::graph::{Graph, Mode};
+    use crate::registry::Registry;
+    use crate::value::{Literal, Value};
+    use ringdesign_core::AlphaLibrary;
+
+    #[test]
+    fn a_semi_mount_builds_in_free_mode_and_sandring_refuses_the_nodes() {
+        let reg = Registry::builtin();
+        let lib = AlphaLibrary::builtin();
+        let mut g = Graph::new("semi-mount", Mode::Free);
+        let d = g.add("design.new").unwrap();
+        let band = g.add("solid.from_design").unwrap();
+        g.connect(d, "design", band, "design").unwrap();
+        g.set_input(band, "preset", Literal::Text("Draft".into())).unwrap();
+        let frame = g.add("frame.on_ring").unwrap();
+        g.connect(d, "design", frame, "design").unwrap();
+        g.set_input(frame, "extra_mm", Literal::Number(-0.4)).unwrap();
+        let setting = g.add("solid.setting").unwrap();
+        g.set_input(setting, "width", Literal::Number(4.0)).unwrap();
+        let placed = g.add("solid.place").unwrap();
+        g.connect(setting, "solid", placed, "solid").unwrap();
+        g.connect(frame, "frame", placed, "frame").unwrap();
+        let union = g.add("solid.union").unwrap();
+        g.connect(band, "solid", union, "a").unwrap();
+        g.connect(placed, "solid", union, "b").unwrap();
+        let mesh = g.add("solid.mesh").unwrap();
+        g.connect(union, "solid", mesh, "solid").unwrap();
+        let verdict = g.add("sink.mesh_verdict").unwrap();
+        g.connect(mesh, "mesh", verdict, "mesh").unwrap();
+        g.connect(d, "design", verdict, "design").unwrap();
+        let dir = std::env::temp_dir().join(format!("ringdesign-free-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let stl = dir.join("semi-mount.stl");
+        let export = g.add("sink.export").unwrap();
+        g.connect(mesh, "mesh", export, "mesh").unwrap();
+        g.set_input(export, "path", Literal::Text(stl.display().to_string())).unwrap();
+        assert!(g.validate(Some(&reg)).is_empty(), "{:?}", g.validate(Some(&reg)));
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::Everything);
+        assert!(!r.any_failed(), "{:?}", r.notes(&g));
+        assert_eq!(r.value(mesh, "watertight"), Some(&Value::Bool(true)));
+        let band_vol = match r.value(band, "solid") { Some(Value::Solid(s)) => s.describe(), other => panic!("{other:?}") };
+        assert!(band_vol.contains("mm³"));
+        let v = r.value(mesh, "volume_mm3").unwrap().as_number().unwrap();
+        assert!(v > 50.0, "{v}");
+        assert!(matches!(r.value(verdict, "verdict"), Some(Value::Text(_))), "{:?}", r.status[&verdict]);
+        assert!(std::fs::metadata(&stl).unwrap().len() > 84, "the semi-mount exported");
+
+        // The exported file comes back in as a solid of the same volume.
+        let imp = g.add("solid.import").unwrap();
+        g.set_input(imp, "path", Literal::Text(stl.display().to_string())).unwrap();
+        let m2 = g.add("solid.mesh").unwrap();
+        g.connect(imp, "solid", m2, "solid").unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(!r.status[&imp].failed(), "{:?}", r.status[&imp].errors);
+        let v2 = r.value(m2, "volume_mm3").unwrap().as_number().unwrap();
+        assert!((v2 - v).abs() < 1e-3 * v, "{v2} vs {v}");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // The same graph in SandRing mode is refused at validation.
+        g.mode = Mode::SandRing;
+        let errs = g.validate(Some(&reg));
+        assert!(errs.iter().any(|e| e.message.contains("does not run in SandRing")), "{errs:?}");
+
+        // Primitives, booleans and a revolve agree with the kernel.
+        let mut g = Graph::new("prims", Mode::Free);
+        let a = g.add("solid.cylinder").unwrap();
+        g.set_input(a, "height", Literal::Number(2.0)).unwrap();
+        let b = g.add("solid.sphere").unwrap();
+        let diff = g.add("solid.difference").unwrap();
+        g.connect(a, "solid", diff, "a").unwrap();
+        g.connect(b, "solid", diff, "b").unwrap();
+        let rv = g.add("solid.revolve").unwrap();
+        g.set_input(rv, "points", Literal::Json(serde_json::json!([[8.0, -1.0], [10.0, -1.0], [10.0, 1.0], [8.0, 1.0]]))).unwrap();
+        let rm = g.add("solid.mesh").unwrap();
+        g.connect(rv, "solid", rm, "solid").unwrap();
+        let bad = g.add("solid.revolve").unwrap();
+        g.set_input(bad, "points", Literal::Json(serde_json::json!([[-1.0, 0.0], [1.0, 0.0], [0.0, 1.0]]))).unwrap();
+        let r = Evaluator::new().evaluate(&g, &reg, &lib, 0, Targets::AllPure);
+        assert!(matches!(r.value(diff, "solid"), Some(Value::Solid(_))));
+        let ring_vol = r.value(rm, "volume_mm3").unwrap().as_number().unwrap();
+        let expect = std::f64::consts::PI * (100.0 - 64.0) * 2.0;
+        assert!((ring_vol - expect).abs() < 0.02 * expect, "{ring_vol} vs {expect}");
+        assert!(r.status[&bad].errors[0].1.contains("x ≥ 0"));
+    }
+}

--- a/crates/ringdesign-graph/src/value.rs
+++ b/crates/ringdesign-graph/src/value.rs
@@ -35,6 +35,8 @@ pub trait SolidHandle: Send + Sync {
     fn describe(&self) -> String;
     /// The solid's surface as a core mesh, if the kernel can produce one.
     fn to_mesh(&self) -> Option<Mesh>;
+    /// For the kernel crate to get its own type back.
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 /// An alpha as source data: what the design file carries and the library

--- a/crates/ringdesign-gui/Cargo.toml
+++ b/crates/ringdesign-gui/Cargo.toml
@@ -8,6 +8,11 @@ license.workspace = true
 name = "ringdesigner"
 path = "src/main.rs"
 
+[features]
+default = []
+## Free mode's solid kernel (Manifold, C++ via cmake on first build).
+kernel = ["ringdesign-graph/kernel-manifold", "ringdesign-script/kernel"]
+
 [dependencies]
 ringdesign-core.workspace = true
 ringdesign-mcp.workspace = true

--- a/crates/ringdesign-script/Cargo.toml
+++ b/crates/ringdesign-script/Cargo.toml
@@ -5,6 +5,10 @@ version.workspace = true
 license.workspace = true
 description = "Sandboxed rhai for ringdesign-graph: expression pins and script nodes"
 
+[features]
+default = []
+kernel = ["ringdesign-graph/kernel-manifold"]
+
 [dependencies]
 ringdesign-core = { path = "../ringdesign-core", default-features = false }
 ringdesign-graph = { path = "../ringdesign-graph", default-features = false }

--- a/crates/ringdesign-solid/src/io.rs
+++ b/crates/ringdesign-solid/src/io.rs
@@ -1,0 +1,172 @@
+//! Mesh readers: OBJ and STL (binary or ASCII) into the core's mesh. The
+//! core writes these formats; Free mode also has to take them in.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use ringdesign_core::mesh::{Mesh, Vec3};
+
+use crate::mesh_from;
+
+/// Read an OBJ: `v` and `f` lines, polygons fanned into triangles,
+/// negative indices resolved, texture and normal indices ignored.
+pub fn read_obj(path: impl AsRef<Path>) -> anyhow::Result<Mesh> {
+    let text = std::fs::read_to_string(path)?;
+    parse_obj(&text)
+}
+
+pub fn parse_obj(text: &str) -> anyhow::Result<Mesh> {
+    let mut vertices: Vec<Vec3> = Vec::new();
+    let mut faces: Vec<[u32; 3]> = Vec::new();
+    for (ln, line) in text.lines().enumerate() {
+        let mut it = line.split_whitespace();
+        match it.next() {
+            Some("v") => {
+                let xyz: Vec<f32> = it.take(3).map(|t| t.parse::<f32>()).collect::<Result<_, _>>().map_err(|e| anyhow::anyhow!("line {}: {e}", ln + 1))?;
+                if xyz.len() != 3 {
+                    anyhow::bail!("line {}: a vertex needs three coordinates", ln + 1);
+                }
+                vertices.push(Vec3(xyz[0], xyz[1], xyz[2]));
+            }
+            Some("f") => {
+                let idx: Vec<u32> = it
+                    .map(|t| {
+                        let first = t.split('/').next().unwrap_or("");
+                        let i: i64 = first.parse().map_err(|_| anyhow::anyhow!("line {}: bad index {t:?}", ln + 1))?;
+                        let n = vertices.len() as i64;
+                        let resolved = if i < 0 { n + i } else { i - 1 };
+                        if resolved < 0 || resolved >= n {
+                            anyhow::bail!("line {}: index {i} is outside the {n} vertices read so far", ln + 1);
+                        }
+                        Ok(resolved as u32)
+                    })
+                    .collect::<anyhow::Result<_>>()?;
+                if idx.len() < 3 {
+                    anyhow::bail!("line {}: a face needs three vertices", ln + 1);
+                }
+                for k in 1..idx.len() - 1 {
+                    faces.push([idx[0], idx[k], idx[k + 1]]);
+                }
+            }
+            _ => {}
+        }
+    }
+    if faces.is_empty() {
+        anyhow::bail!("no faces");
+    }
+    Ok(mesh_from(vertices, faces))
+}
+
+/// Read an STL, binary or ASCII, welding identical vertices so the result
+/// can be a manifold.
+pub fn read_stl(path: impl AsRef<Path>) -> anyhow::Result<Mesh> {
+    let bytes = std::fs::read(path)?;
+    parse_stl(&bytes)
+}
+
+pub fn parse_stl(bytes: &[u8]) -> anyhow::Result<Mesh> {
+    let looks_ascii = bytes.len() >= 5 && bytes.starts_with(b"solid") && !is_binary_sized(bytes);
+    let tris: Vec<[[f32; 3]; 3]> = if looks_ascii { parse_stl_ascii(std::str::from_utf8(bytes)?)? } else { parse_stl_binary(bytes)? };
+    weld(&tris)
+}
+
+fn is_binary_sized(bytes: &[u8]) -> bool {
+    if bytes.len() < 84 {
+        return false;
+    }
+    let n = u32::from_le_bytes([bytes[80], bytes[81], bytes[82], bytes[83]]) as usize;
+    bytes.len() == 84 + n * 50
+}
+
+fn parse_stl_binary(bytes: &[u8]) -> anyhow::Result<Vec<[[f32; 3]; 3]>> {
+    if bytes.len() < 84 {
+        anyhow::bail!("too short for a binary STL");
+    }
+    let n = u32::from_le_bytes([bytes[80], bytes[81], bytes[82], bytes[83]]) as usize;
+    if bytes.len() < 84 + n * 50 {
+        anyhow::bail!("binary STL truncated: {n} triangles announced");
+    }
+    let f = |at: usize| f32::from_le_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]]);
+    Ok((0..n)
+        .map(|k| {
+            let base = 84 + k * 50 + 12;
+            [[f(base), f(base + 4), f(base + 8)], [f(base + 12), f(base + 16), f(base + 20)], [f(base + 24), f(base + 28), f(base + 32)]]
+        })
+        .collect())
+}
+
+fn parse_stl_ascii(text: &str) -> anyhow::Result<Vec<[[f32; 3]; 3]>> {
+    let mut tris = Vec::new();
+    let mut cur: Vec<[f32; 3]> = Vec::new();
+    for line in text.lines() {
+        let mut it = line.split_whitespace();
+        if it.next() == Some("vertex") {
+            let xyz: Vec<f32> = it.take(3).map(|t| t.parse::<f32>()).collect::<Result<_, _>>()?;
+            if xyz.len() == 3 {
+                cur.push([xyz[0], xyz[1], xyz[2]]);
+                if cur.len() == 3 {
+                    tris.push([cur[0], cur[1], cur[2]]);
+                    cur.clear();
+                }
+            }
+        }
+    }
+    if tris.is_empty() {
+        anyhow::bail!("no triangles");
+    }
+    Ok(tris)
+}
+
+fn weld(tris: &[[[f32; 3]; 3]]) -> anyhow::Result<Mesh> {
+    let mut index: HashMap<[u32; 3], u32> = HashMap::new();
+    let mut vertices: Vec<Vec3> = Vec::new();
+    let mut faces: Vec<[u32; 3]> = Vec::with_capacity(tris.len());
+    for t in tris {
+        let mut f = [0u32; 3];
+        for (k, p) in t.iter().enumerate() {
+            let key = [p[0].to_bits(), p[1].to_bits(), p[2].to_bits()];
+            let i = *index.entry(key).or_insert_with(|| {
+                vertices.push(Vec3(p[0], p[1], p[2]));
+                (vertices.len() - 1) as u32
+            });
+            f[k] = i;
+        }
+        if f[0] != f[1] && f[1] != f[2] && f[0] != f[2] {
+            faces.push(f);
+        }
+    }
+    if faces.is_empty() {
+        anyhow::bail!("no triangles");
+    }
+    Ok(mesh_from(vertices, faces))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn obj_and_stl_read_back_what_the_core_writes() {
+        let mut d = ringdesign_core::RingDesign::default();
+        d.profile.width_mm = 4.0;
+        let lib = ringdesign_core::AlphaLibrary::default();
+        let out = ringdesign_core::mesh::build(&d, &lib, ringdesign_core::mesh::BuildParams { theta_steps: 48, profile_steps: 24, ..Default::default() });
+        let dir = std::env::temp_dir().join(format!("ringdesign-solid-io-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let obj = dir.join("r.obj");
+        let stl = dir.join("r.stl");
+        ringdesign_core::stl::write_obj(&obj, &out.mesh, "r").unwrap();
+        ringdesign_core::stl::write_stl(&stl, &out.mesh, "r").unwrap();
+        let a = read_obj(&obj).unwrap();
+        let b = read_stl(&stl).unwrap();
+        assert_eq!(a.faces.len(), out.mesh.faces.len());
+        assert_eq!(b.faces.len(), out.mesh.faces.len());
+        assert!(a.validate().watertight && b.validate().watertight, "{:?} {:?}", a.validate(), b.validate());
+        assert!((a.volume_mm3() - out.mesh.volume_mm3()).abs() < 1e-2 * out.mesh.volume_mm3());
+        assert!((b.volume_mm3() - out.mesh.volume_mm3()).abs() < 1e-2 * out.mesh.volume_mm3());
+        let ascii = "solid t\nfacet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\nendsolid t\n";
+        assert_eq!(parse_stl(ascii.as_bytes()).unwrap().faces.len(), 1);
+        assert!(parse_obj("v 0 0 0\nv 1 0 0\nf 1 2 9\n").is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/ringdesign-solid/src/kernel.rs
+++ b/crates/ringdesign-solid/src/kernel.rs
@@ -245,27 +245,7 @@ pub fn to_mesh(solid: &Solid) -> Mesh {
     }
     let vertices: Vec<Vec3> = props.chunks_exact(n_props).map(|p| Vec3(p[0], p[1], p[2])).collect();
     let faces: Vec<[u32; 3]> = tris.chunks_exact(3).map(|t| [t[0], t[1], t[2]]).collect();
-    let mut acc = vec![[0.0f32; 3]; vertices.len()];
-    for f in &faces {
-        let [a, b, c] = [vertices[f[0] as usize], vertices[f[1] as usize], vertices[f[2] as usize]];
-        let u = [b.0 - a.0, b.1 - a.1, b.2 - a.2];
-        let v = [c.0 - a.0, c.1 - a.1, c.2 - a.2];
-        let n = [u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0]];
-        for i in f {
-            let s = &mut acc[*i as usize];
-            s[0] += n[0];
-            s[1] += n[1];
-            s[2] += n[2];
-        }
-    }
-    let normals = acc
-        .into_iter()
-        .map(|n| {
-            let l = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
-            if l > 1e-12 { Vec3(n[0] / l, n[1] / l, n[2] / l) } else { Vec3(0.0, 0.0, 1.0) }
-        })
-        .collect();
-    Mesh { vertices, normals, faces }
+    crate::mesh_from(vertices, faces)
 }
 
 /// The core's mesh as a Manifold, or why Manifold would not take it.

--- a/crates/ringdesign-solid/src/lib.rs
+++ b/crates/ringdesign-solid/src/lib.rs
@@ -8,6 +8,38 @@
 
 #[cfg(feature = "manifold")]
 pub mod kernel;
+pub mod io;
+
+use ringdesign_core::mesh::{Mesh, Vec3};
+
+/// Area-weighted vertex normals for a face list.
+pub fn vertex_normals(vertices: &[Vec3], faces: &[[u32; 3]]) -> Vec<Vec3> {
+    let mut acc = vec![[0.0f32; 3]; vertices.len()];
+    for f in faces {
+        let [a, b, c] = [vertices[f[0] as usize], vertices[f[1] as usize], vertices[f[2] as usize]];
+        let u = [b.0 - a.0, b.1 - a.1, b.2 - a.2];
+        let v = [c.0 - a.0, c.1 - a.1, c.2 - a.2];
+        let n = [u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0]];
+        for i in f {
+            let s = &mut acc[*i as usize];
+            s[0] += n[0];
+            s[1] += n[1];
+            s[2] += n[2];
+        }
+    }
+    acc.into_iter()
+        .map(|n| {
+            let l = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+            if l > 1e-12 { Vec3(n[0] / l, n[1] / l, n[2] / l) } else { Vec3(0.0, 0.0, 1.0) }
+        })
+        .collect()
+}
+
+/// A mesh from vertices and faces, normals computed.
+pub fn mesh_from(vertices: Vec<Vec3>, faces: Vec<[u32; 3]>) -> Mesh {
+    let normals = vertex_normals(&vertices, &faces);
+    Mesh { vertices, normals, faces }
+}
 
 /// Whether this build carries the Manifold kernel.
 pub const fn kernel_available() -> bool {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -148,7 +148,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 
 - [x] **M7.1 Kernel crate** (L, #65). Manifold behind `kernel-manifold` (off by default; the default
   build has no C++); `Solid`, frames, tubes, `Parts{add,cut}`, mesh conversion + validation.
-- [ ] **M7.2 Free-mode nodes** (L, #66). Primitives, extrude/revolve, from-design, booleans, frames on
+- [x] **M7.2 Free-mode nodes** (L, #66). Primitives, extrude/revolve, from-design, booleans, frames on
   the ring, tubes, mesh import, the mesh verifier, mesh export.
 - [ ] **M7.3 mandrel merge** (M, #67). The vine semi-mount as a cluster; carat calibration
   reconciled; its MCP retired in favour of `graph_*`.


### PR DESCRIPTION
## Summary
- `nodes/solid.rs` (behind `kernel-manifold`, Free-mode only): primitives, from_design, booleans, transforms, `frame.on_ring` + `solid.place`, tube, settings, leaf, import, `solid.mesh`.
- `ringdesign-solid::io`: OBJ/STL readers with welding; `vertex_normals`/`mesh_from` shared.
- `SolidHandle::as_any`; the palette follows the graph's mode; `kernel` features on GUI/CLI/script.

## Verification
- `cargo test --workspace` green (pure Rust); `cargo test -p ringdesign-graph --features kernel-manifold solid` → semi-mount export/import, revolve volume, SandRing refusal; `cargo test -p ringdesign-solid` → readers.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)