### PR TITLE
M8.3: build-a-ring in the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ assets/
 # Harvest tooling and its venv: useful to keep near the code, never tracked.
 /tools/harvest/
 /tools/venv/
+/crates/ringdesign-configurator/dist/
+/.claude/launch.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1757,10 +1757,38 @@ can never fail quietly again.
 off, every fan-out runs serial through the same call sites (per-site `cfg`
 splits, no trait shims). `BuildClock` guards the one other wasm landmine —
 `Instant::now` panics in a browser. Both core and the configurator pass
-`cargo check --no-default-features --target wasm32-unknown-unknown`; what a
-live web build still needs is the configurator's `WebRunner` entry + trunk
-packaging and its `std::thread` workers made synchronous or moved to a web
-worker (a serial preview build is ~40 ms, so synchronous is viable).
+`cargo check --no-default-features --target wasm32-unknown-unknown`.
+
+**The configurator runs in the browser.** `trunk serve` in
+`crates/ringdesign-configurator` (its `index.html` carries
+`data-cargo-no-default-features`, so core runs serial; `Trunk.toml` builds
+release on port 8787) starts `build-a-ring` through an eframe `WebRunner`
+on the `#build_a_ring` canvas, glow on WebGL2. Three things had to change,
+none of them in `compose`:
+
+- **There is no thread in a browser**, so the job body is a `Worker` whose
+  `run` is the same function on both targets: natively `Engine::new` wraps
+  it in the `compose-build` thread, on wasm `Engine::pump` runs the pending
+  jobs on the UI thread from `poll`, with the same coalescing (the newest
+  job wins, a design change is never dropped for a camera frame). A
+  preview build is ~40 ms serial, which the frame absorbs. The style
+  cards (`Thumbs`) render one base per frame and ask for another frame
+  while any remain, instead of a one-shot thread.
+- **An order is bytes before it is files.** `order_files` builds the six
+  documents in memory — `library::design_json`, `gltf::to_glb`,
+  `render::png_bytes`, `render::turntable_gif_bytes` — and
+  `deliver_order` writes the folder natively or hands the browser one
+  `order-<slug>.zip` through `threemf::zip_store` (the 3MF writer's
+  store-only zip, now public with `threemf::Entry`) and a Blob download
+  link (`web.rs`). The file writers in core are the byte writers plus a
+  `std::fs::write`, pinned equal by a test.
+- The workspace egui's `rayon` feature stays on: rayon-core 1.13 falls
+  back to the calling thread where it cannot spawn, so the browser build
+  needs no feature surgery. `prices.json` is simply absent on the web, and
+  the metal step says so.
+
+`.claude/launch.json` (ignored) carries a `build-a-ring-web` entry for the
+in-app browser preview.
 
 ## Running the tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,10 +2985,14 @@ dependencies = [
  "eframe",
  "egui",
  "env_logger",
+ "js-sys",
  "log",
  "ringdesign-core",
  "serde",
  "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/ringdesign-configurator/Cargo.toml
+++ b/crates/ringdesign-configurator/Cargo.toml
@@ -22,3 +22,19 @@ serde_json.workspace = true
 log.workspace = true
 env_logger.workspace = true
 anyhow.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = [
+    "Blob",
+    "BlobPropertyBag",
+    "Url",
+    "Window",
+    "Document",
+    "Element",
+    "HtmlElement",
+    "HtmlAnchorElement",
+    "HtmlCanvasElement",
+] }

--- a/crates/ringdesign-configurator/Trunk.toml
+++ b/crates/ringdesign-configurator/Trunk.toml
@@ -1,0 +1,8 @@
+[build]
+target = "index.html"
+dist = "dist"
+release = true
+
+[serve]
+port = 8787
+open = false

--- a/crates/ringdesign-configurator/index.html
+++ b/crates/ringdesign-configurator/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Build a Ring</title>
+  <link data-trunk rel="rust" data-bin="build-a-ring" data-cargo-no-default-features data-type="main">
+  <style>
+    html, body { margin: 0; height: 100%; background: #121214; overflow: hidden; }
+    canvas { width: 100%; height: 100%; display: block; outline: none; }
+  </style>
+</head>
+<body>
+  <canvas id="build_a_ring"></canvas>
+</body>
+</html>

--- a/crates/ringdesign-configurator/src/main.rs
+++ b/crates/ringdesign-configurator/src/main.rs
@@ -4,9 +4,17 @@
 //! software rasterizer, so this binary carries no GL plumbing and the same
 //! crate could later target a browser. Choices live in [`compose::Config`],
 //! small serializable data; the finished order lands as a folder holding the
-//! design file, the order JSON, the casting sheet, a GLB and a turntable.
+//! design file, the order JSON, the casting sheet, a GLB and a turntable — or,
+//! in the browser, as one zip download of the same files.
+//!
+//! Web build: `trunk serve` in this crate's directory (`index.html` carries
+//! the `--no-default-features` flag, so core runs serial). There is no
+//! thread in a browser, so the build worker and the thumbnail renders run on
+//! the UI thread, pumped from `poll` — a preview build is ~40 ms serial.
 
 mod compose;
+#[cfg(target_arch = "wasm32")]
+mod web;
 
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
@@ -31,12 +39,22 @@ const VIEW_PX: usize = 640;
 
 #[cfg(target_arch = "wasm32")]
 fn main() {
-    // The crate compiles for wasm32 with `--no-default-features` (core runs
-    // serial), which keeps the browser door open. What a live web build
-    // still needs: an eframe `WebRunner` entry with its canvas + trunk
-    // packaging, and `spawn_worker`/`spawn_thumbs` replaced — std::thread
-    // does not run in a browser, so builds either go synchronous (a preview
-    // build is ~40 ms serial) or into a web worker.
+    use wasm_bindgen::JsCast as _;
+    eframe::WebLogger::init(log::LevelFilter::Info).ok();
+    wasm_bindgen_futures::spawn_local(async {
+        let document = web_sys::window().and_then(|w| w.document()).expect("no document");
+        let canvas = document
+            .get_element_by_id("build_a_ring")
+            .expect("no canvas #build_a_ring")
+            .dyn_into::<web_sys::HtmlCanvasElement>()
+            .expect("#build_a_ring is not a canvas");
+        let started = eframe::WebRunner::new()
+            .start(canvas, eframe::WebOptions::default(), Box::new(|cc| Ok(Box::new(App::new(cc)))))
+            .await;
+        if let Err(e) = started {
+            log::error!("build-a-ring failed to start: {e:?}");
+        }
+    });
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -75,90 +93,254 @@ struct Frame {
     volume_mm3: f64,
 }
 
-fn spawn_worker(ctx: egui::Context) -> (Sender<Job>, Receiver<Frame>) {
-    let (jobs_tx, jobs_rx) = channel::<Job>();
-    let (frames_tx, frames_rx) = channel::<Frame>();
-    std::thread::Builder::new()
-        .name("compose-build".into())
-        .spawn(move || {
-            let mut lib = AlphaLibrary::builtin();
-            let mut mesh: Option<Arc<Mesh>> = None;
-            let mut field: Option<FieldReport> = None;
-            let mut grams: Vec<(String, f64)> = Vec::new();
-            let mut volume = 0.0;
-            while let Ok(mut job) = jobs_rx.recv() {
-                while let Ok(newer) = jobs_rx.try_recv() {
-                    // Keep the newest, but never drop a design change for a
-                    // camera-only frame.
-                    if job.design.is_some() && newer.design.is_none() {
-                        job = Job { design: job.design, ..newer };
-                    } else {
-                        job = newer;
-                    }
-                }
-                if let Some(d) = job.design.take() {
-                    d.bake_texts(&mut lib);
-                    let out = ringdesign_core::mesh::build(&d, &lib, PREVIEW);
-                    volume = out.report.volume_mm3;
-                    grams = out
-                        .report
-                        .metals
-                        .iter()
-                        .map(|m| (m.metal.to_string(), m.grams))
-                        .collect();
-                    field = Some(ringdesign_core::castability::analyze_field(
-                        &d, &lib, &d.draft, 144, 96,
-                    ));
-                    mesh = Some(Arc::new(out.mesh));
-                }
-                let Some(m) = mesh.as_ref() else { continue };
-                let (edge, ss) = if job.fine { (VIEW_PX, 3) } else { (VIEW_PX / 2, 1) };
-                let rgb = render::render_ss(m, job.yaw, job.pitch, edge, edge, ss, render::GOLD);
-                let image = egui::ColorImage::from_rgb([edge, edge], &rgb);
-                if frames_tx
-                    .send(Frame {
-                        generation: job.generation,
-                        image,
-                        field: field.clone(),
-                        grams: grams.clone(),
-                        volume_mm3: volume,
-                    })
-                    .is_err()
-                {
-                    break;
-                }
-                ctx.request_repaint();
-            }
-        })
-        .expect("spawn worker");
-    (jobs_tx, frames_rx)
+/// The build-and-render state one job advances; the same body runs on a
+/// thread natively and inline on the UI thread in the browser.
+struct Worker {
+    lib: AlphaLibrary,
+    mesh: Option<Arc<Mesh>>,
+    field: Option<FieldReport>,
+    grams: Vec<(String, f64)>,
+    volume: f64,
 }
 
-/// One-shot worker: render every base once for the style step's cards.
-fn spawn_thumbs(ctx: egui::Context) -> Receiver<(Base, egui::ColorImage)> {
-    let (tx, rx) = channel();
-    std::thread::Builder::new()
-        .name("compose-thumbs".into())
-        .spawn(move || {
-            let lib = AlphaLibrary::builtin();
-            for &base in Base::ALL {
-                let cfg = Config { base, ..Config::default() };
-                let d = compose(&cfg);
-                let out = ringdesign_core::mesh::build(
-                    &d,
-                    &lib,
-                    BuildParams { theta_steps: 192, profile_steps: 80, ..Default::default() },
-                );
-                let edge = 108usize;
-                let rgb = render::render_ss(&out.mesh, 0.55, 1.12, edge, edge, 2, render::GOLD);
-                if tx.send((base, egui::ColorImage::from_rgb([edge, edge], &rgb))).is_err() {
-                    return;
-                }
-                ctx.request_repaint();
+impl Worker {
+    fn new() -> Self {
+        Self { lib: AlphaLibrary::builtin(), mesh: None, field: None, grams: Vec::new(), volume: 0.0 }
+    }
+
+    /// Keeps the newest pending job, never dropping a design change for a
+    /// camera-only frame.
+    fn coalesce(mut job: Job, rx: &Receiver<Job>) -> Job {
+        while let Ok(newer) = rx.try_recv() {
+            if job.design.is_some() && newer.design.is_none() {
+                job = Job { design: job.design, ..newer };
+            } else {
+                job = newer;
             }
+        }
+        job
+    }
+
+    fn run(&mut self, mut job: Job) -> Option<Frame> {
+        if let Some(d) = job.design.take() {
+            d.bake_texts(&mut self.lib);
+            let out = ringdesign_core::mesh::build(&d, &self.lib, PREVIEW);
+            self.volume = out.report.volume_mm3;
+            self.grams = out.report.metals.iter().map(|m| (m.metal.to_string(), m.grams)).collect();
+            self.field =
+                Some(ringdesign_core::castability::analyze_field(&d, &self.lib, &d.draft, 144, 96));
+            self.mesh = Some(Arc::new(out.mesh));
+        }
+        let m = self.mesh.as_ref()?;
+        let (edge, ss) = if job.fine { (VIEW_PX, 3) } else { (VIEW_PX / 2, 1) };
+        let rgb = render::render_ss(m, job.yaw, job.pitch, edge, edge, ss, render::GOLD);
+        Some(Frame {
+            generation: job.generation,
+            image: egui::ColorImage::from_rgb([edge, edge], &rgb),
+            field: self.field.clone(),
+            grams: self.grams.clone(),
+            volume_mm3: self.volume,
         })
-        .expect("spawn thumbs");
-    rx
+    }
+}
+
+/// Jobs in, frames out: a thread natively, `pump` on the UI thread in the
+/// browser.
+struct Engine {
+    jobs: Sender<Job>,
+    frames: Receiver<Frame>,
+    #[cfg(target_arch = "wasm32")]
+    inline: (Receiver<Job>, Sender<Frame>, Worker),
+}
+
+impl Engine {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn new(ctx: egui::Context) -> Self {
+        let (jobs_tx, jobs_rx) = channel::<Job>();
+        let (frames_tx, frames_rx) = channel::<Frame>();
+        std::thread::Builder::new()
+            .name("compose-build".into())
+            .spawn(move || {
+                let mut worker = Worker::new();
+                while let Ok(job) = jobs_rx.recv() {
+                    let job = Worker::coalesce(job, &jobs_rx);
+                    if let Some(frame) = worker.run(job) {
+                        if frames_tx.send(frame).is_err() {
+                            break;
+                        }
+                        ctx.request_repaint();
+                    }
+                }
+            })
+            .expect("spawn worker");
+        Self { jobs: jobs_tx, frames: frames_rx }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn new(_ctx: egui::Context) -> Self {
+        let (jobs_tx, jobs_rx) = channel::<Job>();
+        let (frames_tx, frames_rx) = channel::<Frame>();
+        Self { jobs: jobs_tx, frames: frames_rx, inline: (jobs_rx, frames_tx, Worker::new()) }
+    }
+
+    fn send(&self, job: Job) {
+        let _ = self.jobs.send(job);
+    }
+
+    /// Runs the pending jobs here where there is no worker thread.
+    fn pump(&mut self) {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let (rx, tx, worker) = &mut self.inline;
+            while let Ok(job) = rx.try_recv() {
+                let job = Worker::coalesce(job, rx);
+                if let Some(frame) = worker.run(job) {
+                    let _ = tx.send(frame);
+                }
+            }
+        }
+    }
+}
+
+/// One base rendered for the style step's cards.
+fn thumb(base: Base, lib: &AlphaLibrary) -> egui::ColorImage {
+    let cfg = Config { base, ..Config::default() };
+    let d = compose(&cfg);
+    let out = ringdesign_core::mesh::build(
+        &d,
+        lib,
+        BuildParams { theta_steps: 192, profile_steps: 80, ..Default::default() },
+    );
+    let edge = 108usize;
+    let rgb = render::render_ss(&out.mesh, 0.55, 1.12, edge, edge, 2, render::GOLD);
+    egui::ColorImage::from_rgb([edge, edge], &rgb)
+}
+
+/// Every base's card, once: a one-shot thread natively, one base per frame
+/// in the browser.
+struct Thumbs {
+    rx: Receiver<(Base, egui::ColorImage)>,
+    #[cfg(target_arch = "wasm32")]
+    inline: (Vec<Base>, Sender<(Base, egui::ColorImage)>, AlphaLibrary),
+}
+
+impl Thumbs {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn new(ctx: egui::Context) -> Self {
+        let (tx, rx) = channel();
+        std::thread::Builder::new()
+            .name("compose-thumbs".into())
+            .spawn(move || {
+                let lib = AlphaLibrary::builtin();
+                for &base in Base::ALL {
+                    if tx.send((base, thumb(base, &lib))).is_err() {
+                        return;
+                    }
+                    ctx.request_repaint();
+                }
+            })
+            .expect("spawn thumbs");
+        Self { rx }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn new(_ctx: egui::Context) -> Self {
+        let (tx, rx) = channel();
+        let mut pending = Base::ALL.to_vec();
+        pending.reverse();
+        Self { rx, inline: (pending, tx, AlphaLibrary::builtin()) }
+    }
+
+    /// One more card where the thumbs run inline, asking for another frame
+    /// while any remain.
+    #[cfg_attr(not(target_arch = "wasm32"), allow(unused_variables))]
+    fn pump(&mut self, ctx: &egui::Context) {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let (pending, tx, lib) = &mut self.inline;
+            if let Some(base) = pending.pop() {
+                let _ = tx.send((base, thumb(base, lib)));
+                if !pending.is_empty() {
+                    ctx.request_repaint();
+                }
+            }
+        }
+    }
+}
+
+/// How an order is built: the full pass the app writes, or a small one for
+/// tests.
+struct OrderParams {
+    build: BuildParams,
+    hero_px: usize,
+    gif_frames: usize,
+    gif_px: usize,
+}
+
+impl OrderParams {
+    const FULL: OrderParams = OrderParams {
+        build: BuildParams { theta_steps: 768, profile_steps: 256, min_wall_mm: 0.5, adaptive: false, refine: None, soften_mm: 0.0 },
+        hero_px: 1280,
+        gif_frames: 36,
+        gif_px: 480,
+    };
+}
+
+/// The order's files — design, choices, sheet, GLB, hero, turntable — as
+/// name and bytes.
+fn order_files(cfg: &Config, p: &OrderParams) -> anyhow::Result<Vec<(&'static str, Vec<u8>)>> {
+    let mut lib = AlphaLibrary::builtin();
+    let d = compose(cfg);
+    d.bake_texts(&mut lib);
+    let out = ringdesign_core::mesh::build(&d, &lib, p.build);
+    let field = ringdesign_core::castability::attributed_field_report(&d, &lib, &d.draft, 192, 128);
+    let stones = ringdesign_core::stones::report(&d, field.parting_z_mm);
+    let dfm = ringdesign_core::dfm::findings(&d);
+    let sheet = ringdesign_core::spec::html(
+        &d,
+        &out.report,
+        &field,
+        stones.as_ref(),
+        &dfm,
+        concat!("Build-a-Ring ", env!("CARGO_PKG_VERSION")),
+    );
+    Ok(vec![
+        ("design.ring.json", library::design_json(&d)?.into_bytes()),
+        ("choices.json", serde_json::to_string_pretty(cfg)?.into_bytes()),
+        ("casting_sheet.html", sheet.into_bytes()),
+        ("ring.glb", ringdesign_core::gltf::to_glb(&out.mesh, &d.name, render::GOLD)),
+        ("hero.png", render::png_bytes(&out.mesh, 0.55, 1.12, p.hero_px, render::GOLD)?),
+        ("turntable.gif", render::turntable_gif_bytes(&out.mesh, p.gif_frames, p.gif_px, render::GOLD)?),
+    ])
+}
+
+/// The customer's name as a folder or file name.
+fn order_slug(cfg: &Config) -> String {
+    let base = if cfg.customer.trim().is_empty() { "order" } else { cfg.customer.trim() };
+    base.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '_' })
+        .collect()
+}
+
+/// Writes the order into one folder named for the customer.
+#[cfg(not(target_arch = "wasm32"))]
+fn deliver_order(slug: &str, files: Vec<(&'static str, Vec<u8>)>) -> anyhow::Result<String> {
+    let dir = library::default_design_dir().with_file_name("orders").join(slug);
+    std::fs::create_dir_all(&dir)?;
+    for (name, bytes) in files {
+        std::fs::write(dir.join(name), bytes)?;
+    }
+    Ok(dir.display().to_string())
+}
+
+/// Hands the order to the browser as one zip download.
+#[cfg(target_arch = "wasm32")]
+fn deliver_order(slug: &str, files: Vec<(&'static str, Vec<u8>)>) -> anyhow::Result<String> {
+    use ringdesign_core::threemf::{zip_store, Entry};
+    let entries: Vec<Entry> = files.into_iter().map(|(n, data)| Entry { name: n.to_string(), data }).collect();
+    let name = format!("order-{slug}.zip");
+    web::download(&name, "application/zip", &zip_store(&entries))?;
+    Ok(format!("your downloads, as {name}"))
 }
 
 // --- The app -----------------------------------------------------------------
@@ -190,8 +372,7 @@ impl Step {
 struct App {
     cfg: Config,
     step: Step,
-    jobs: Sender<Job>,
-    frames: Receiver<Frame>,
+    engine: Engine,
     generation: u64,
     view: Option<egui::TextureHandle>,
     field: Option<FieldReport>,
@@ -202,20 +383,17 @@ struct App {
     dragging: bool,
     saved_to: Option<String>,
     saving: bool,
-    thumbs_rx: Receiver<(Base, egui::ColorImage)>,
+    thumb_jobs: Thumbs,
     thumbs: std::collections::HashMap<Base, egui::TextureHandle>,
     prices: std::collections::HashMap<String, f64>,
 }
 
 impl App {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        let (jobs, frames) = spawn_worker(cc.egui_ctx.clone());
-        let thumbs_rx = spawn_thumbs(cc.egui_ctx.clone());
         let mut app = Self {
             cfg: Config::default(),
             step: Step::Base,
-            jobs,
-            frames,
+            engine: Engine::new(cc.egui_ctx.clone()),
             generation: 0,
             view: None,
             field: None,
@@ -226,7 +404,7 @@ impl App {
             dragging: false,
             saved_to: None,
             saving: false,
-            thumbs_rx,
+            thumb_jobs: Thumbs::new(cc.egui_ctx.clone()),
             thumbs: std::collections::HashMap::new(),
             prices: compose::load_prices(),
         };
@@ -238,7 +416,7 @@ impl App {
         self.cfg.reconcile();
         self.generation += 1;
         self.saved_to = None;
-        let _ = self.jobs.send(Job {
+        self.engine.send(Job {
             generation: self.generation,
             design: Some(compose(&self.cfg)),
             yaw: self.yaw,
@@ -249,7 +427,7 @@ impl App {
 
     fn rerender(&mut self, fine: bool) {
         self.generation += 1;
-        let _ = self.jobs.send(Job {
+        self.engine.send(Job {
             generation: self.generation,
             design: None,
             yaw: self.yaw,
@@ -258,51 +436,12 @@ impl App {
         });
     }
 
-    /// Write the whole order — design, choices, sheet, GLB, turntable — into
-    /// one folder named for the customer.
+    /// The whole order — design, choices, sheet, GLB, hero, turntable —
+    /// into one folder named for the customer, or one zip in the browser.
     fn save_order(&mut self) {
         self.saving = true;
-        let cfg = self.cfg.clone();
-        let slug: String = {
-            let base = if cfg.customer.trim().is_empty() { "order" } else { cfg.customer.trim() };
-            base.chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '_' })
-                .collect()
-        };
-        let dir = library::default_design_dir().with_file_name("orders").join(&slug);
-        let result = (|| -> anyhow::Result<String> {
-            std::fs::create_dir_all(&dir)?;
-            let mut lib = AlphaLibrary::builtin();
-            let d = compose(&cfg);
-            d.bake_texts(&mut lib);
-
-            library::save_design(dir.join("design.ring.json"), &d)?;
-            std::fs::write(dir.join("choices.json"), serde_json::to_string_pretty(&cfg)?)?;
-
-            let out = ringdesign_core::mesh::build(
-                &d,
-                &lib,
-                BuildParams { theta_steps: 768, profile_steps: 256, ..Default::default() },
-            );
-            let field = ringdesign_core::castability::attributed_field_report(
-                &d, &lib, &d.draft, 192, 128,
-            );
-            let stones = ringdesign_core::stones::report(&d, field.parting_z_mm);
-            let dfm = ringdesign_core::dfm::findings(&d);
-            let sheet = ringdesign_core::spec::html(
-                &d,
-                &out.report,
-                &field,
-                stones.as_ref(),
-                &dfm,
-                concat!("Build-a-Ring ", env!("CARGO_PKG_VERSION")),
-            );
-            std::fs::write(dir.join("casting_sheet.html"), sheet)?;
-            ringdesign_core::gltf::write_glb(dir.join("ring.glb"), &out.mesh, &d.name, render::GOLD)?;
-            render::write_png(dir.join("hero.png"), &out.mesh, 0.55, 1.12, 1280, render::GOLD)?;
-            render::write_turntable_gif(dir.join("turntable.gif"), &out.mesh, 36, 480, render::GOLD)?;
-            Ok(dir.display().to_string())
-        })();
+        let slug = order_slug(&self.cfg);
+        let result = order_files(&self.cfg, &OrderParams::FULL).and_then(|files| deliver_order(&slug, files));
         self.saving = false;
         self.saved_to = Some(match result {
             Ok(p) => format!("Saved to {p}"),
@@ -311,7 +450,9 @@ impl App {
     }
 
     fn poll(&mut self, ctx: &egui::Context) {
-        while let Ok((base, img)) = self.thumbs_rx.try_recv() {
+        self.engine.pump();
+        self.thumb_jobs.pump(ctx);
+        while let Ok((base, img)) = self.thumb_jobs.rx.try_recv() {
             let tex = ctx.load_texture(
                 format!("thumb-{}", base.label()),
                 img,
@@ -319,7 +460,7 @@ impl App {
             );
             self.thumbs.insert(base, tex);
         }
-        while let Ok(f) = self.frames.try_recv() {
+        while let Ok(f) = self.engine.frames.try_recv() {
             if f.generation != self.generation {
                 continue;
             }
@@ -744,5 +885,37 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ui, |ui| {
             ui.vertical_centered(|ui| self.preview(ui));
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_order_is_six_files_and_a_slug() {
+        let cfg = Config { customer: "Ada Lovelace!".into(), ..Config::default() };
+        assert_eq!(order_slug(&cfg), "ada_lovelace_");
+        assert_eq!(order_slug(&Config::default()), "order");
+        let small = OrderParams {
+            build: BuildParams { theta_steps: 96, profile_steps: 48, ..Default::default() },
+            hero_px: 64,
+            gif_frames: 4,
+            gif_px: 32,
+        };
+        let files = order_files(&cfg, &small).unwrap();
+        let names: Vec<&str> = files.iter().map(|(n, _)| *n).collect();
+        assert_eq!(
+            names,
+            ["design.ring.json", "choices.json", "casting_sheet.html", "ring.glb", "hero.png", "turntable.gif"]
+        );
+        assert!(files.iter().all(|(_, b)| !b.is_empty()));
+        assert_eq!(&files[3].1[..4], b"glTF");
+        assert_eq!(&files[4].1[..4], b"\x89PNG");
+        assert_eq!(&files[5].1[..6], b"GIF89a");
+        let design = ringdesign_core::library::load_design_str(std::str::from_utf8(&files[0].1).unwrap()).unwrap();
+        assert_eq!(serde_json::to_value(&design).unwrap(), serde_json::to_value(compose(&cfg)).unwrap());
+        let back: Config = serde_json::from_slice(&files[1].1).unwrap();
+        assert_eq!(back.customer, "Ada Lovelace!");
     }
 }

--- a/crates/ringdesign-configurator/src/web.rs
+++ b/crates/ringdesign-configurator/src/web.rs
@@ -1,0 +1,25 @@
+//! Browser file delivery: bytes as a Blob handed to a download link.
+
+use wasm_bindgen::{JsCast, JsValue};
+
+/// Offers `bytes` to the browser as a download named `name`.
+pub fn download(name: &str, mime: &str, bytes: &[u8]) -> anyhow::Result<()> {
+    let err = |e: JsValue| anyhow::anyhow!("{e:?}");
+    let parts = js_sys::Array::new();
+    parts.push(&js_sys::Uint8Array::from(bytes));
+    let opts = web_sys::BlobPropertyBag::new();
+    opts.set_type(mime);
+    let blob = web_sys::Blob::new_with_u8_array_sequence_and_options(&parts, &opts).map_err(err)?;
+    let url = web_sys::Url::create_object_url_with_blob(&blob).map_err(err)?;
+    let document = web_sys::window().and_then(|w| w.document()).ok_or_else(|| anyhow::anyhow!("no document"))?;
+    let a: web_sys::HtmlAnchorElement = document
+        .create_element("a")
+        .map_err(err)?
+        .dyn_into()
+        .map_err(|_| anyhow::anyhow!("not an anchor"))?;
+    a.set_href(&url);
+    a.set_download(name);
+    a.click();
+    web_sys::Url::revoke_object_url(&url).map_err(err)?;
+    Ok(())
+}

--- a/crates/ringdesign-core/src/library.rs
+++ b/crates/ringdesign-core/src/library.rs
@@ -53,10 +53,14 @@ struct VersionedDesign<'a> {
     design: &'a RingDesign,
 }
 
-pub fn save_design(path: impl AsRef<Path>, design: &RingDesign) -> anyhow::Result<()> {
+/// The design document as versioned JSON text.
+pub fn design_json(design: &RingDesign) -> anyhow::Result<String> {
     let doc = VersionedDesign { format_version: FORMAT_VERSION, design };
-    let json = serde_json::to_string_pretty(&doc)?;
-    std::fs::write(path, json)?;
+    Ok(serde_json::to_string_pretty(&doc)?)
+}
+
+pub fn save_design(path: impl AsRef<Path>, design: &RingDesign) -> anyhow::Result<()> {
+    std::fs::write(path, design_json(design)?)?;
     Ok(())
 }
 

--- a/crates/ringdesign-core/src/render.rs
+++ b/crates/ringdesign-core/src/render.rs
@@ -134,6 +134,14 @@ pub fn write_png_parts(
     Ok(())
 }
 
+/// One antialiased hero frame as PNG bytes.
+pub fn png_bytes(m: &Mesh, yaw: f64, pitch: f64, edge: usize, tint: [f32; 3]) -> anyhow::Result<Vec<u8>> {
+    let img = render_ss(m, yaw, pitch, edge, edge, 3, tint);
+    let mut out = std::io::Cursor::new(Vec::new());
+    image::write_buffer_with_format(&mut out, &img, edge as u32, edge as u32, image::ColorType::Rgb8, image::ImageFormat::Png)?;
+    Ok(out.into_inner())
+}
+
 /// One antialiased hero frame to a PNG.
 pub fn write_png(
     path: impl AsRef<Path>,
@@ -143,9 +151,15 @@ pub fn write_png(
     edge: usize,
     tint: [f32; 3],
 ) -> anyhow::Result<()> {
-    let img = render_ss(m, yaw, pitch, edge, edge, 3, tint);
-    image::save_buffer(path, &img, edge as u32, edge as u32, image::ColorType::Rgb8)?;
+    std::fs::write(path, png_bytes(m, yaw, pitch, edge, tint)?)?;
     Ok(())
+}
+
+/// A looping turntable GIF as bytes: `frames` yaw steps around one revolution.
+pub fn turntable_gif_bytes(m: &Mesh, frames: usize, edge: usize, tint: [f32; 3]) -> anyhow::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    encode_turntable(&mut out, m, frames, edge, tint)?;
+    Ok(out)
 }
 
 /// A looping turntable GIF: `frames` yaw steps around one revolution.
@@ -156,12 +170,15 @@ pub fn write_turntable_gif(
     edge: usize,
     tint: [f32; 3],
 ) -> anyhow::Result<()> {
+    encode_turntable(std::fs::File::create(path)?, m, frames, edge, tint)
+}
+
+fn encode_turntable<W: std::io::Write>(w: W, m: &Mesh, frames: usize, edge: usize, tint: [f32; 3]) -> anyhow::Result<()> {
     use image::codecs::gif::{GifEncoder, Repeat};
     use image::{Delay, Frame, RgbaImage};
 
     let frames = frames.clamp(4, 120);
-    let file = std::fs::File::create(path)?;
-    let mut enc = GifEncoder::new_with_speed(file, 10);
+    let mut enc = GifEncoder::new_with_speed(w, 10);
     enc.set_repeat(Repeat::Infinite)?;
     for k in 0..frames {
         let yaw = k as f64 / frames as f64 * std::f64::consts::TAU;
@@ -170,12 +187,7 @@ pub fn write_turntable_gif(
         for (i, p) in rgba.pixels_mut().enumerate() {
             *p = image::Rgba([rgb[i * 3], rgb[i * 3 + 1], rgb[i * 3 + 2], 255]);
         }
-        enc.encode_frame(Frame::from_parts(
-            rgba,
-            0,
-            0,
-            Delay::from_numer_denom_ms(70, 1),
-        ))?;
+        enc.encode_frame(Frame::from_parts(rgba, 0, 0, Delay::from_numer_denom_ms(70, 1)))?;
     }
     Ok(())
 }
@@ -376,5 +388,28 @@ mod tests {
         write_png(&png, &out.mesh, 0.55, 1.12, 96, GOLD).unwrap();
         assert!(std::fs::metadata(&png).unwrap().len() > 500);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(test)]
+mod byte_tests {
+    use super::*;
+
+    #[test]
+    fn the_byte_writers_match_the_file_writers() {
+        let d = crate::RingDesign::default();
+        let lib = crate::AlphaLibrary::builtin();
+        let out = crate::mesh::build(&d, &lib, crate::mesh::BuildParams { theta_steps: 48, profile_steps: 24, ..Default::default() });
+        let png = png_bytes(&out.mesh, 0.5, 1.1, 32, GOLD).unwrap();
+        assert_eq!(&png[..4], b"\x89PNG");
+        let gif = turntable_gif_bytes(&out.mesh, 4, 24, GOLD).unwrap();
+        assert_eq!(&gif[..6], b"GIF89a");
+        let dir = std::env::temp_dir().join(format!("rd-render-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        write_png(dir.join("h.png"), &out.mesh, 0.5, 1.1, 32, GOLD).unwrap();
+        write_turntable_gif(dir.join("t.gif"), &out.mesh, 4, 24, GOLD).unwrap();
+        assert_eq!(std::fs::read(dir.join("h.png")).unwrap(), png);
+        assert_eq!(std::fs::read(dir.join("t.gif")).unwrap(), gif);
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/crates/ringdesign-core/src/threemf.rs
+++ b/crates/ringdesign-core/src/threemf.rs
@@ -11,9 +11,10 @@ use std::path::Path;
 use crate::mesh::Mesh;
 
 /// One entry queued for the package.
-struct Entry {
-    name: &'static str,
-    data: Vec<u8>,
+/// One stored file in a package.
+pub struct Entry {
+    pub name: String,
+    pub data: Vec<u8>,
 }
 
 /// CRC-32 (IEEE), the zip checksum.
@@ -34,7 +35,8 @@ fn crc32(data: &[u8]) -> u32 {
 }
 
 /// Store-only zip: local headers, central directory, end record.
-fn zip_store(entries: &[Entry]) -> Vec<u8> {
+/// A store-only zip of `entries`, zeroed timestamps, deterministic bytes.
+pub fn zip_store(entries: &[Entry]) -> Vec<u8> {
     let mut out = Vec::new();
     let mut central = Vec::new();
     let mut offsets = Vec::with_capacity(entries.len());
@@ -155,14 +157,14 @@ pub fn to_3mf(mesh: &Mesh, name: &str, size_label: &str) -> Vec<u8> {
 
     let entries = [
         Entry {
-            name: "[Content_Types].xml",
+            name: "[Content_Types].xml".into(),
             data: b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">\n <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>\n <Default Extension=\"model\" ContentType=\"application/vnd.ms-package.3dmanufacturing-3dmodel+xml\"/>\n</Types>\n".to_vec(),
         },
         Entry {
-            name: "_rels/.rels",
+            name: "_rels/.rels".into(),
             data: b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">\n <Relationship Target=\"/3D/3dmodel.model\" Id=\"rel0\" Type=\"http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel\"/>\n</Relationships>\n".to_vec(),
         },
-        Entry { name: "3D/3dmodel.model", data: model.into_bytes() },
+        Entry { name: "3D/3dmodel.model".into(), data: model.into_bytes() },
     ];
     zip_store(&entries)
 }
@@ -248,6 +250,18 @@ mod tests {
         let (_, a) = ring_bytes();
         let (_, b) = ring_bytes();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn a_store_zip_of_named_entries_reads_back() {
+        let entries = vec![
+            Entry { name: "a/one.txt".into(), data: b"one".to_vec() },
+            Entry { name: "two.bin".into(), data: vec![0, 1, 2, 255] },
+        ];
+        let files = read_store_zip(&zip_store(&entries));
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0], ("a/one.txt".to_string(), b"one".to_vec()));
+        assert_eq!(files[1], ("two.bin".to_string(), vec![0, 1, 2, 255]));
     }
 
     #[test]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,7 +159,7 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   lock); graphs arrive by the design sync and evaluate locally.
 - [ ] **M8.2 Mobile leftovers** (M). Intent filters, durable mirror, export worker, the full
   phone-shaped port.
-- [ ] **M8.3 Web configurator** (M). `build-a-ring` on wasm; `compose::Config` reused verbatim.
+- [x] **M8.3 Web configurator** (M, #71). `build-a-ring` on wasm; `compose::Config` reused verbatim.
 
 ## M9 — Backlog (parking lot) — epic #25
 


### PR DESCRIPTION
Closes #71

- `trunk serve` in `crates/ringdesign-configurator` builds and serves `build-a-ring` on wasm32 (`index.html` carries `--no-default-features` so core runs serial; `Trunk.toml` builds release on port 8787). An eframe `WebRunner` starts the app on the `#build_a_ring` canvas.
- No thread in a browser: the job body is a `Worker` shared by both targets — `Engine::new` wraps it in the build thread natively, `Engine::pump` runs pending jobs on the UI thread from `poll` with the same coalescing. The style cards render one base per frame.
- An order is bytes before it is files: `order_files` builds the six documents in memory and `deliver_order` writes the folder natively or hands the browser one `order-<slug>.zip` (the 3MF writer's store-only zip, now `threemf::{zip_store, Entry}`) through a Blob download link.
- Core gains `library::design_json`, `render::png_bytes`, `render::turntable_gif_bytes`; the file writers are those plus a write, pinned equal by a test.

Verified: the release bundle (7.2 MB wasm) loads and `main` reaches `WebRunner::start` in the in-app browser pane, which has no WebGL of its own — the rendered page needs a real browser. Native behaviour is unchanged; the guarded suite is green (core 309, configurator 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)