### PR TITLE
M8.2a: export worker and a durable copy on the phone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1774,6 +1774,16 @@ Lock toggle (`Editor::editable`). Verify with `cargo test -p
 ringdesigner_android` on the host and `cargo ndk -t arm64-v8a check -p
 ringdesigner_android` from the crate dir with `ANDROID_NDK_HOME` set.
 
+The phone's exports (`export.rs`) run one thread per job — STL, 3MF, GLB,
+sheet, render, turntable — and open the share sheet from `poll_exports`
+when the file lands, so an export is never coalesced away behind a
+preview build, the guarantee the desktop's `export.rs` also makes. "Save a
+copy to Downloads" is the durable mirror: `HostExt::save_to_gallery`
+inserts a non-media file into MediaStore Downloads, which survives an
+uninstall where app storage does not. Opening a `.ring.json` from another
+app is still not possible — the framework has no incoming-intent plumbing,
+and an intent filter the app then ignores would be worse than none.
+
 ## The `parallel` feature and the wasm door
 
 `ringdesign-core` puts rayon behind a default-on **`parallel`** feature;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -158,8 +158,11 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - [x] **M8.1 Android graph tab** (M, #73). Touch mechanics (drag classification, long-press menus,
   lock); graphs arrive by the design sync and evaluate locally. Shipped in the EguiMobile
   workspace as ringdesigner-android 0.9.0.
-- [ ] **M8.2 Mobile leftovers** (M). Intent filters, durable mirror, export worker, the full
-  phone-shaped port.
+- [x] **M8.2a Export worker and a durable copy** (S, #75). Exports on their own threads, never
+  dropped behind a preview build; the design file copied to Downloads through MediaStore.
+- [ ] **M8.2b Intent filters and the phone-shaped port** (M). Opening a design file from another
+  app needs incoming-intent plumbing in the shared egui-android crate (Java + JNI, none exists)
+  and a device to test; the layer stack editor, section view and report stay desktop-only for now.
 - [x] **M8.3 Web configurator** (M, #71). `build-a-ring` on wasm; `compose::Config` reused verbatim.
 
 ## M9 — Backlog (parking lot) — epic #25


### PR DESCRIPTION
Closes #75

In the EguiMobile workspace (`examples/ringdesigner-android` 0.9.0, commit `a26c63f`): `export.rs` builds and writes every export on its own thread and opens the share sheet when the file lands — exports never queue behind preview builds — and Files > Save a copy to Downloads puts the design file into shared storage through MediaStore. Host tests 44 green; `cargo ndk -t arm64-v8a check` clean.

Here: the roadmap line split into what shipped and what waits on incoming-intent plumbing in the shared framework crate (M8.2b), plus the CLAUDE.md note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)