### PR TITLE
M9.1: one record per stone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1297,6 +1297,25 @@ bezel collars, gypsy mounds, prong bumps. Three pieces keep that honest:
   `stones_land_on_their_seats` test writes a software-rasterized sheet for
   eyeballing placement.
 
+### One record per stone
+
+`setstone.rs` is where a stone *is*. `set_stones(design)` walks the stack
+once — pads carrying a gem, every kept station of a run at the size the
+grade gives it and on a seat scaled with it, pavé seats and halo markers
+inside groups, windows honoured, disabled entries skipped — and returns a
+`SetStone` per stone: label path, source, `theta`/`v`, the gem, and the
+seat as that stone meets it. The report's crowding census, the gem preview
+(`gems::preview_vertices`) and the section view all read that list and
+nothing else, so they cannot disagree about where a stone is. Before it,
+the report and the preview each walked the layers themselves and the
+section view knew only pads and runs — a pavé group's stones and a halo's
+melee never appeared in a section. `stones_near` is the section view's
+filter: every stone whose seat reaches the slice. The per-layer
+`SeatCheck`s (pavilion room, edge clearance, bridges, prongs) still come
+from the report's own walk, because they are properties of a seat *layer*
+rather than of a stone; `every_consumer_counts_the_same_stones` pins the
+report's count and carats to the record's.
+
 ### A seat is the stone's plan, not a circle round it
 
 `SeatPadLayer` carries `elong` (long over short, `diameter_mm` staying the

--- a/crates/ringdesign-core/src/gems.rs
+++ b/crates/ringdesign-core/src/gems.rs
@@ -8,7 +8,7 @@
 
 use crate::alpha::AlphaLibrary;
 use crate::castability::section_at;
-use crate::field::{FieldContext, Layer, LayerEntry, LayerStack, Uv};
+use crate::field::FieldContext;
 use crate::gem::{Gem, GemCut};
 use crate::RingDesign;
 
@@ -23,7 +23,9 @@ pub const GEM_TINT: [f32; 3] = [0.72, 0.82, 0.92];
 pub fn preview_vertices(design: &RingDesign, lib: &AlphaLibrary) -> Vec<f32> {
     let ctx = design.field_context();
     let mut out = Vec::new();
-    walk(design, lib, &ctx, &design.layers, &mut out);
+    for st in crate::setstone::set_stones(design) {
+        place(design, lib, &ctx, st.theta_deg, st.v_mm, st.gem, &st.seat, &mut out);
+    }
     out
 }
 
@@ -55,48 +57,6 @@ pub fn preview_mesh(design: &RingDesign, lib: &AlphaLibrary) -> Option<crate::me
         m.faces.push([i, i + 1, i + 2]);
     }
     Some(m)
-}
-
-fn walk(
-    design: &RingDesign,
-    lib: &AlphaLibrary,
-    ctx: &FieldContext,
-    stack: &LayerStack,
-    out: &mut Vec<f32>,
-) {
-    for entry in &stack.layers {
-        if !entry.enabled {
-            continue;
-        }
-        match &entry.layer {
-            Layer::SeatPad(seat) => {
-                if let Some(gem) = seat.gem {
-                    if kept(entry, ctx, seat.theta_deg, seat.v_mm) {
-                        place(design, lib, ctx, seat.theta_deg, seat.v_mm, gem, seat, out);
-                    }
-                }
-            }
-            Layer::SeatRun(run) => {
-                let n = run.count.clamp(1, 200);
-                let mut seat = run.seat;
-                seat.fit_stone(run.gem);
-                for k in 0..n {
-                    let theta = run.theta_of_station(k as f64, ctx);
-                    if kept(entry, ctx, theta, seat.v_mm) {
-                        // Graded runs draw the stone they actually carry.
-                        place(design, lib, ctx, theta, seat.v_mm, run.gem_at(theta), &seat, out);
-                    }
-                }
-            }
-            Layer::Group(g) => walk(design, lib, ctx, &g.stack, out),
-            _ => {}
-        }
-    }
-}
-
-fn kept(entry: &LayerEntry, ctx: &FieldContext, theta_deg: f64, v_mm: f64) -> bool {
-    let uv = Uv { u: ctx.u_of_theta(theta_deg.rem_euclid(360.0)), v: v_mm };
-    entry.window.mask(uv, ctx) > 0.5
 }
 
 /// One stone: find the displaced surface under the seat, build a frame on it,
@@ -449,6 +409,7 @@ fn normalize(v: [f64; 3]) -> [f64; 3] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::field::Layer;
     use crate::field::{SeatPadLayer, SeatRunLayer};
     use crate::LayerEntry;
 

--- a/crates/ringdesign-core/src/lib.rs
+++ b/crates/ringdesign-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod pave;
 pub mod profile;
 pub mod refine;
 pub mod render;
+pub mod setstone;
 pub mod sizing;
 pub mod spec;
 pub mod stl;

--- a/crates/ringdesign-core/src/setstone.rs
+++ b/crates/ringdesign-core/src/setstone.rs
@@ -1,0 +1,229 @@
+//! One record per stone the design sets — a pad, a run's station, a pavé
+//! seat, a halo marker — read by the report's census, the gem preview and
+//! the section view, so no two of them can disagree about where a stone is.
+
+use crate::field::{wrap_delta, FieldContext, Layer, LayerEntry, LayerStack, SeatPadLayer, Uv};
+use crate::gem::Gem;
+use crate::RingDesign;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StoneSource {
+    /// A seat pad of its own.
+    Pad,
+    /// Station `station` of a seat run.
+    Run { station: u32 },
+}
+
+/// A stone where the design sets it.
+#[derive(Clone, Debug)]
+pub struct SetStone {
+    /// The entry's path, `"Halo / Centre"` for a nested layer.
+    pub label: String,
+    pub source: StoneSource,
+    pub theta_deg: f64,
+    pub v_mm: f64,
+    pub gem: Gem,
+    /// The seat as this stone meets it: a run's seat fitted to its gem and
+    /// scaled with the grade.
+    pub seat: SeatPadLayer,
+}
+
+impl SetStone {
+    /// Height of the girdle over the bare band, mm.
+    pub fn stand_off_mm(&self) -> f64 {
+        self.seat.stand_off_mm(self.gem)
+    }
+
+    /// Bearing of the stone's long axis in the chart, degrees.
+    pub fn rot_deg(&self) -> f64 {
+        self.seat.rot_deg
+    }
+
+    /// How far the seat reaches round the ring at the crest radius, degrees.
+    pub fn reach_deg(&self, ctx: &FieldContext) -> f64 {
+        (self.seat.half_extents_mm().0 + self.seat.blend_mm) / ctx.crest_radius_mm.max(1e-9) * 180.0
+            / std::f64::consts::PI
+    }
+
+    pub fn carats(&self) -> f64 {
+        self.gem.carats()
+    }
+}
+
+/// Whether a station survives its entry's window.
+pub fn kept(entry: &LayerEntry, ctx: &FieldContext, theta_deg: f64, v_mm: f64) -> bool {
+    let uv = Uv { u: ctx.u_of_theta(theta_deg.rem_euclid(360.0)), v: v_mm };
+    entry.window.mask(uv, ctx) > 0.5
+}
+
+/// Every stone the design sets, in stack order, windows honoured. A seat
+/// without a stone is stock, not a stone, and is not listed.
+pub fn set_stones(design: &RingDesign) -> Vec<SetStone> {
+    let ctx = design.field_context();
+    let mut out = Vec::new();
+    walk(&ctx, &design.layers, "", &mut out);
+    out
+}
+
+/// The stones whose seat reaches a slice at `theta_deg`, never narrower
+/// than `min_deg` either side.
+pub fn stones_near<'a>(
+    stones: &'a [SetStone],
+    ctx: &FieldContext,
+    theta_deg: f64,
+    min_deg: f64,
+) -> Vec<&'a SetStone> {
+    stones
+        .iter()
+        .filter(|st| wrap_delta(theta_deg - st.theta_deg, 360.0).abs() <= st.reach_deg(ctx).max(min_deg))
+        .collect()
+}
+
+fn walk(ctx: &FieldContext, stack: &LayerStack, prefix: &str, out: &mut Vec<SetStone>) {
+    for entry in &stack.layers {
+        if !entry.enabled {
+            continue;
+        }
+        match &entry.layer {
+            Layer::SeatPad(seat) => {
+                if let Some(gem) = seat.gem {
+                    if kept(entry, ctx, seat.theta_deg, seat.v_mm) {
+                        out.push(SetStone {
+                            label: format!("{prefix}{}", entry.name),
+                            source: StoneSource::Pad,
+                            theta_deg: seat.theta_deg,
+                            v_mm: seat.v_mm,
+                            gem,
+                            seat: *seat,
+                        });
+                    }
+                }
+            }
+            Layer::SeatRun(run) => {
+                let n = run.count.clamp(1, 200);
+                let mut fitted = run.seat;
+                fitted.fit_stone(run.gem);
+                for k in 0..n {
+                    let theta = run.theta_of_station(k as f64, ctx);
+                    if !kept(entry, ctx, theta, fitted.v_mm) {
+                        continue;
+                    }
+                    // The field scales the whole seat with its stone.
+                    let mut seat = fitted;
+                    seat.height_mm *= run.scale_at(theta);
+                    out.push(SetStone {
+                        label: format!("{prefix}{}", entry.name),
+                        source: StoneSource::Run { station: k },
+                        theta_deg: theta,
+                        v_mm: fitted.v_mm,
+                        gem: run.gem_at(theta),
+                        seat,
+                    });
+                }
+            }
+            Layer::Group(g) => walk(ctx, &g.stack, &format!("{prefix}{} / ", entry.name), out),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::{GroupLayer, SeatRunLayer, Window};
+    use crate::gem::GemCut;
+
+    fn pad(theta: f64, v: f64, gem: Option<Gem>) -> SeatPadLayer {
+        let mut s = SeatPadLayer::default();
+        s.theta_deg = theta;
+        s.v_mm = v;
+        s.gem = gem;
+        if let Some(g) = gem {
+            s.fit_stone(g);
+        }
+        s
+    }
+
+    fn design() -> (RingDesign, usize) {
+        let mut d = RingDesign::default();
+        let ctx = d.field_context();
+        let v = ctx.band_v_len_mm * 0.5;
+        let round = |mm: f64| Gem::calibrated(GemCut::Round, mm);
+        d.layers.layers.push(LayerEntry::new("Centre", Layer::SeatPad(pad(90.0, v, Some(round(4.0))))));
+        d.layers.layers.push(LayerEntry::new("Blank stock", Layer::SeatPad(pad(270.0, v, None))));
+        let mut off = LayerEntry::new("Off", Layer::SeatPad(pad(180.0, v, Some(round(2.0)))));
+        off.enabled = false;
+        d.layers.layers.push(off);
+        let mut run = SeatRunLayer::default();
+        run.gem = round(1.5);
+        run.seat.v_mm = v;
+        run.count = 20;
+        run.solve_spacing(&ctx);
+        let mut row = LayerEntry::new("Row", Layer::SeatRun(run));
+        row.window = Window::around(270.0, 120.0);
+        let kept_stations = (0..20)
+            .filter(|&k| {
+                let t = run.theta_of_station(k as f64, &ctx);
+                kept(&row, &ctx, t, v)
+            })
+            .count();
+        d.layers.layers.push(row);
+        let mut g = GroupLayer::default();
+        g.stack.layers.push(LayerEntry::new("Seat 1", Layer::SeatPad(pad(30.0, v, Some(round(1.2))))));
+        g.stack.layers.push(LayerEntry::new("Seat 2", Layer::SeatPad(pad(40.0, v, Some(round(1.2))))));
+        g.stack.layers.push(LayerEntry::new("Marker", Layer::SeatPad(pad(50.0, v, None))));
+        d.layers.layers.push(LayerEntry::new("Pavé", Layer::Group(g)));
+        (d, 1 + kept_stations + 2)
+    }
+
+    #[test]
+    fn every_consumer_counts_the_same_stones() {
+        let (d, expected) = design();
+        let stones = set_stones(&d);
+        assert_eq!(stones.len(), expected);
+        assert!(expected > 4, "the window keeps some stations: {expected}");
+        assert!(stones.iter().any(|s| s.label == "Pavé / Seat 2"));
+        assert!(stones.iter().all(|s| s.label != "Off" && s.label != "Blank stock"));
+        let lib = crate::AlphaLibrary::builtin();
+        let report = crate::stones::report(&d, 0.0).unwrap();
+        assert_eq!(report.stone_count as usize, stones.len(), "the report counts the record's stones");
+        assert!((report.total_carats - stones.iter().map(|s| s.carats()).sum::<f64>()).abs() < 1e-9);
+        let mesh = crate::gems::preview_mesh(&d, &lib).unwrap();
+        assert_eq!(mesh.faces.len() % stones.len(), 0, "every stone draws the same facet count");
+    }
+
+    #[test]
+    fn a_graded_run_records_each_stone_at_its_own_size() {
+        let mut d = RingDesign::default();
+        let ctx = d.field_context();
+        let mut run = SeatRunLayer::default();
+        run.gem = Gem::calibrated(GemCut::Round, 2.0);
+        run.seat.v_mm = ctx.band_v_len_mm * 0.5;
+        run.taper = 0.6;
+        run.taper_theta_deg = 90.0;
+        run.solve_spacing(&ctx);
+        d.layers.layers.push(LayerEntry::new("Graded", Layer::SeatRun(run)));
+        let stones = set_stones(&d);
+        let big = stones.iter().max_by(|a, b| a.gem.w_mm.total_cmp(&b.gem.w_mm)).unwrap();
+        let small = stones.iter().min_by(|a, b| a.gem.w_mm.total_cmp(&b.gem.w_mm)).unwrap();
+        assert!(wrap_delta(big.theta_deg - 90.0, 360.0).abs() < 20.0, "largest at the pole");
+        assert!(small.gem.w_mm < big.gem.w_mm * 0.6);
+        assert!(small.seat.height_mm < big.seat.height_mm, "the seat scales with its stone");
+        assert!(matches!(small.source, StoneSource::Run { .. }));
+    }
+
+    #[test]
+    fn stones_near_picks_the_slices_neighbours() {
+        let mut d = RingDesign::default();
+        let ctx = d.field_context();
+        let v = ctx.band_v_len_mm * 0.5;
+        let g = Gem::calibrated(GemCut::Round, 3.0);
+        d.layers.layers.push(LayerEntry::new("Top", Layer::SeatPad(pad(90.0, v, Some(g)))));
+        d.layers.layers.push(LayerEntry::new("Bottom", Layer::SeatPad(pad(270.0, v, Some(g)))));
+        let stones = set_stones(&d);
+        let near = stones_near(&stones, &ctx, 92.0, 2.0);
+        assert_eq!(near.len(), 1);
+        assert_eq!(near[0].label, "Top");
+        assert!(stones_near(&stones, &ctx, 180.0, 2.0).is_empty());
+    }
+}

--- a/crates/ringdesign-core/src/stones.rs
+++ b/crates/ringdesign-core/src/stones.rs
@@ -8,12 +8,13 @@
 
 use crate::castability::draft_angle;
 use crate::field::{
-    FieldContext, Layer, LayerEntry, LayerStack, SeatPadLayer, SeatStyle, Uv,
+    FieldContext, Layer, LayerEntry, LayerStack, SeatPadLayer, SeatStyle,
     SIDE_FACE_MIN_DRAFT_DEG,
 };
 use crate::gem::Gem;
 use crate::mesh::MIN_WALL_MM;
 use crate::profile::MIN_EDGE_MM;
+use crate::setstone::SetStone;
 use crate::RingDesign;
 
 /// What the base surface under a seat is, castability-wise.
@@ -148,10 +149,13 @@ pub fn report(design: &RingDesign, parting_z_mm: f64) -> Option<StonesReport> {
 
     let mut acc = Acc::default();
     walk(design, &ctx, inner_r, crest_r, parting_z_mm, &design.layers, "", &mut acc);
-    let Acc { seats, stations } = acc;
+    let Acc { seats } = acc;
     if seats.is_empty() {
         return None;
     }
+    // Every stone in its own right, from the one record every consumer
+    // reads; the census measures them against each other.
+    let stations = crate::setstone::set_stones(design);
     let stone_count = seats.iter().filter(|s| s.gem.is_some()).map(|s| s.count).sum();
     let total_carats = seats.iter().map(|s| s.carats()).sum();
     let (crowding, tight_pairs, closest) =
@@ -159,42 +163,9 @@ pub fn report(design: &RingDesign, parting_z_mm: f64) -> Option<StonesReport> {
     Some(StonesReport { seats, stone_count, total_carats, crowding, tight_pairs, closest })
 }
 
-/// One stone, wherever it came from — the unit the pairwise census works in.
-struct Station {
-    label: String,
-    theta_deg: f64,
-    v_mm: f64,
-    gem: crate::gem::Gem,
-    /// Height of the girdle over the bare band, mm.
-    stand_off: f64,
-    /// Bearing of the stone's long axis in the chart, degrees.
-    rot_deg: f64,
-}
-
 #[derive(Default)]
 struct Acc {
     seats: Vec<SeatCheck>,
-    stations: Vec<Station>,
-}
-
-impl Acc {
-    fn station(
-        &mut self,
-        label: &str,
-        seat: &SeatPadLayer,
-        gem: crate::gem::Gem,
-        theta_deg: f64,
-        v_mm: f64,
-    ) {
-        self.stations.push(Station {
-            label: label.to_string(),
-            theta_deg,
-            v_mm,
-            gem,
-            stand_off: stand_off(seat),
-            rot_deg: seat.rot_deg,
-        });
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -228,9 +199,6 @@ fn walk(
                 check.count = kept as u32;
                 if !kept {
                     check.warnings.push("gated out by its own window — not on the ring".into());
-                }
-                if let (true, Some(gem)) = (kept, seat.gem) {
-                    acc.station(&check.label, seat, gem, seat.theta_deg, seat.v_mm);
                 }
                 acc.seats.push(check);
             }
@@ -298,17 +266,6 @@ fn walk(
                         ));
                     }
                 }
-                // Every station a run keeps is a stone in its own right;
-                // the census reads them against everything else on the band.
-                for &(t, v) in &stations {
-                    // The field scales the whole seat with its stone, so the
-                    // stand-off the girdle rides scales too.
-                    let graded = run.gem_at(t);
-                    let scale = run.scale_at(t);
-                    let mut seat = run.seat;
-                    seat.height_mm *= scale;
-                    acc.station(&check.label, &seat, graded, t, v);
-                }
                 acc.seats.push(check);
             }
             Layer::Group(g) => {
@@ -329,11 +286,6 @@ fn walk(
                             design, ctx, inner_r, crest_r, parting_z, seat, stations, label,
                         );
                         check.count = stations.len() as u32;
-                        if let Some(gem) = seat.gem {
-                            for &(t, v) in stations {
-                                acc.station(&check.label, seat, gem, t, v);
-                            }
-                        }
                         acc.seats.push(check);
                     }
                     continue;
@@ -367,7 +319,7 @@ fn crowding(
     ctx: &FieldContext,
     inner_r: f64,
     crest_r: f64,
-    stations: &[Station],
+    stations: &[SetStone],
 ) -> (Vec<StonePair>, usize, Option<StonePair>) {
     if stations.len() < 2 {
         return (Vec::new(), 0, None);
@@ -455,20 +407,20 @@ fn frame_at(
     ctx: &FieldContext,
     inner_r: f64,
     crest_r: f64,
-    st: &Station,
+    st: &SetStone,
 ) -> Frame {
     let b = base_at(design, inner_r, crest_r, ctx, st.theta_deg, st.v_mm);
     let (sin, cos) = st.theta_deg.to_radians().sin_cos();
     let normal = [b.nr * cos, b.nr * sin, b.nz];
     let girdle = [
-        b.r * cos + normal[0] * st.stand_off,
-        b.r * sin + normal[1] * st.stand_off,
-        b.z + normal[2] * st.stand_off,
+        b.r * cos + normal[0] * st.stand_off_mm(),
+        b.r * sin + normal[1] * st.stand_off_mm(),
+        b.z + normal[2] * st.stand_off_mm(),
     ];
     // The band's own two tangents: along the ring, and across the section.
     let t = [-sin, cos, 0.0];
     let across = [-b.nz * cos, -b.nz * sin, b.nr];
-    let (rs, rc) = st.rot_deg.to_radians().sin_cos();
+    let (rs, rc) = st.rot_deg().to_radians().sin_cos();
     let long = [
         t[0] * rc + across[0] * rs,
         t[1] * rc + across[1] * rs,
@@ -560,8 +512,7 @@ fn seats_by_shape<'a>(
 
 /// Whether a station survives the entry's angular window.
 fn station_kept(entry: &LayerEntry, ctx: &FieldContext, theta_deg: f64, v_mm: f64) -> bool {
-    let uv = Uv { u: ctx.u_of_theta(theta_deg.rem_euclid(360.0)), v: v_mm };
-    entry.window.mask(uv, ctx) > 0.5
+    crate::setstone::kept(entry, ctx, theta_deg, v_mm)
 }
 
 /// The checks for one seat shape at a set of stations; every measured number
@@ -673,6 +624,8 @@ fn check_seat(
 /// Height the girdle sits above the base surface, mm — the pad's stand-off
 /// less how deep the stone is set into it. A seat with no stone assigned is
 /// judged on the one it says it could hold.
+/// Height of the girdle over the bare band for the seat's own stone, or a
+/// round suggested by its size when it carries none.
 fn stand_off(seat: &SeatPadLayer) -> f64 {
     let gem = seat.gem.unwrap_or_else(|| {
         crate::gem::Gem::calibrated(crate::gem::GemCut::Round, seat.suggested_stone_mm())

--- a/crates/ringdesign-gui/src/panels/section.rs
+++ b/crates/ringdesign-gui/src/panels/section.rs
@@ -298,14 +298,8 @@ fn canvas(app: &RingDesignerApp, ui: &mut egui::Ui, pane: usize, opts_id: egui::
             }
             None
         };
-        let mut draw_stone = |seat: &ringdesign_core::field::SeatPadLayer| {
+        let draw_stone = |seat: &ringdesign_core::field::SeatPadLayer, gem: ringdesign_core::gem::Gem| {
             let Some((r, z, nr, nz)) = at_v(seat.v_mm) else { return };
-            let gem = seat
-                .gem
-                .unwrap_or_else(|| ringdesign_core::gem::Gem::calibrated(
-                    ringdesign_core::gem::GemCut::Round,
-                    seat.suggested_stone_mm(),
-                ));
             let half = seat.stone_half_v_mm(gem);
             let depth = gem.pavilion_mm();
             let len = (nr * nr + nz * nz).sqrt().max(1e-9);
@@ -321,31 +315,12 @@ fn canvas(app: &RingDesignerApp, ui: &mut egui::Ui, pane: usize, opts_id: egui::
             painter.line_segment([ga, culet], stroke);
             painter.line_segment([gb, culet], stroke);
         };
-        for e in app.design.layers.layers.iter().filter(|e| e.enabled) {
-            match &e.layer {
-                ringdesign_core::field::Layer::SeatPad(p) => {
-                    // How far the pad reaches round the ring, which is its
-                    // length when an elongated stone lies along the band.
-                    let arc = (p.half_extents_mm().0 + p.blend_mm)
-                        / (section.max_r.max(1e-9))
-                        * 180.0
-                        / std::f64::consts::PI;
-                    let d = ringdesign_core::field::wrap_delta(
-                        section.theta_deg - p.theta_deg,
-                        360.0,
-                    )
-                    .abs();
-                    if d <= arc.max(2.0) {
-                        draw_stone(p);
-                    }
-                }
-                ringdesign_core::field::Layer::SeatRun(run) => {
-                    // A run has a seat at every station; the slice always
-                    // sits within half a pitch of one.
-                    draw_stone(&run.seat);
-                }
-                _ => {}
-            }
+        // Every stone the design sets — pads, run stations, pavé seats, halo
+        // markers — whose seat reaches this slice.
+        let stones = ringdesign_core::setstone::set_stones(&app.design);
+        let fctx = app.design.field_context();
+        for st in ringdesign_core::setstone::stones_near(&stones, &fctx, section.theta_deg, 2.0) {
+            draw_stone(&st.seat, st.gem);
         }
     }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,9 +167,10 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 
 ## M9 — Backlog (parking lot) — epic #25
 
-- A first-class set-stone record shared by report, preview, seats and generators (M); graduated
-  tilted stones on a run (S–M, gated on a field check); bezel realism following the girdle (S–M);
-  gallery/hollow underside (M–L); the bypass read as a `ShankKind` (M).
+- [x] A first-class set-stone record shared by report, preview, seats and generators (M, #77):
+  `setstone::SetStone`, enumerated once, read by the census, the preview and the section view.
+- Graduated tilted stones on a run (S–M, gated on a field check); bezel realism following the
+  girdle (S–M); gallery/hollow underside (M–L); the bypass read as a `ShankKind` (M).
 - Shelf: stone spacing map SVG; march instances along a guide path; blue-noise scatter
   generator; mm-true mask morphology; alpha granulometry; nesting-depth stepped relief; honest
   rope rail; `stones::probe_seat`; pearl stock; flat-edged seat plans.


### PR DESCRIPTION
Closes #77

- `setstone::SetStone` + `set_stones(design)`: pads carrying a gem, every kept station of a run at its graded size on a seat scaled with it, pavé seats and halo markers inside groups — windows honoured, disabled entries skipped. `stones_near` filters by the seat's reach round the ring.
- The stones report's crowding census, `gems::preview_vertices` and the section view now read that list; the report's per-layer `SeatCheck`s keep their own walk (they are properties of a seat layer, not of a stone).
- The section view shows every stone whose seat reaches the slice, including pavé and halo stones it never drew before.
- Tests: the report's count and carats pinned to the record's; a graded run records each stone at its own size; the near-filter. Full guarded suite green (core 312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)