### PR TITLE
M9.3: the bezel stands on its stone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1375,6 +1375,25 @@ run 1.7 and 1.6), its dome is a medium 0.45 of width, its weight is half an
 ellipsoid at 0.0176 ct/mm³, and it sits *on* its bed in the preview instead
 of burying a pavilion it does not have.
 
+### The bezel stands on its stone
+
+A bezel's collar has no height of its own. `fit_stone` derives it — the
+recess the girdle sits down, plus `bezel_lip` (default 0.3) of the stone's
+crown height (`Gem::crown_mm`: the third of the depth a faceted stone
+keeps above its girdle, the whole dome for a cabochon) — so a 4 mm round
+at a 0.5 mm recess gets a 0.76 mm collar and a 6 mm cab a taller one,
+which is what a burnished bezel is: metal pushed a little way up the
+crown. The pocket floor is a bearing ledge `bezel_bearing_mm` (0.3) wide
+inside the wall, and inside the ledge the floor dishes toward the
+pavilion as a paraboloid — steepening toward its ledge, never below 0.1
+mm of pad — only when the seat carries a stone, so a stone-less bezel is
+the flat cup it was. The plan already followed the girdle: the pocket is
+the stone's own superellipse inset by the wall. Measured clean on a 7×5
+side face with its stone; the crown warning is unchanged. The section
+view now draws the girdle at `stand_off_mm`, where the preview and the
+report have always put it — it drew it at the pad's top, which the one
+stone record made visible.
+
 ### How deep the stone sits is one number
 
 `SeatPadLayer::set_depth_mm` (`Option`, `None` = the style's own) is how far

--- a/crates/ringdesign-core/src/field.rs
+++ b/crates/ringdesign-core/src/field.rs
@@ -1021,6 +1021,14 @@ pub struct SeatPadLayer {
     /// Bezel only: pocket depth below the rim, mm.
     #[serde(default = "default_recess")]
     pub recess_mm: f64,
+    /// Bezel only: how far up the stone's crown the collar stands, as a
+    /// fraction of the crown height; `fit_stone` derives the height from it.
+    #[serde(default = "default_bezel_lip")]
+    pub bezel_lip: f64,
+    /// Bezel only: the ledge the girdle rests on inside the wall, mm; the
+    /// floor inside it dishes toward the pavilion.
+    #[serde(default = "default_bezel_bearing")]
+    pub bezel_bearing_mm: f64,
     /// Drafted cone bumps on the seat circle — cast oversize, notched and
     /// shaped at the bench, which is how prongs survive sand. 0 is none.
     #[serde(default)]
@@ -1081,6 +1089,14 @@ fn default_recess() -> f64 {
     0.5
 }
 
+fn default_bezel_lip() -> f64 {
+    0.3
+}
+
+fn default_bezel_bearing() -> f64 {
+    0.3
+}
+
 fn default_prong() -> f64 {
     0.9
 }
@@ -1097,6 +1113,8 @@ impl Default for SeatPadLayer {
             style: SeatStyle::Boss,
             bezel_wall_mm: default_bezel_wall(),
             recess_mm: default_recess(),
+            bezel_lip: default_bezel_lip(),
+            bezel_bearing_mm: default_bezel_bearing(),
             prongs: 0,
             prong_mm: default_prong(),
             gem: None,
@@ -1206,6 +1224,11 @@ impl SeatPadLayer {
         self.plan_pow = gem.cut.plan_pow();
         if self.style == SeatStyle::GypsyMound {
             self.crown = 1.0;
+        }
+        // A bezel stands on its stone: the girdle on the bearing a recess
+        // down, the collar a lip up the crown over it.
+        if self.style == SeatStyle::Bezel {
+            self.height_mm = (self.recess_mm.max(0.0) + self.bezel_lip.clamp(0.0, 1.0) * gem.crown_mm()).max(0.2);
         }
         self.gem = Some(gem);
     }
@@ -1329,7 +1352,24 @@ impl SeatPadLayer {
                 let soft = (wall * 0.35).max(0.08);
                 if d <= r {
                     let rim = self.height_mm;
-                    rim + (floor - rim) * (1.0 - smoothstep(r_in - soft, r_in, d))
+                    // The girdle's bearing is a flat ledge inside the wall;
+                    // inside it the floor dishes toward the pavilion, a
+                    // paraboloid so the dish steepens toward its ledge.
+                    let bearing = self.bezel_bearing_mm.clamp(0.0, r_in);
+                    let dish_r = r_in - bearing;
+                    let relief = self
+                        .gem
+                        .map(|g| g.pavilion_mm())
+                        .unwrap_or(0.0)
+                        .min(floor - 0.1)
+                        .max(0.0);
+                    let floor_at = if dish_r > 1e-6 && d < dish_r {
+                        let t = d / dish_r;
+                        floor - relief * (1.0 - t * t)
+                    } else {
+                        floor
+                    };
+                    rim + (floor_at - rim) * (1.0 - smoothstep(r_in - soft, r_in, d))
                 } else {
                     self.skirt(d, r, blend)
                 }
@@ -4650,5 +4690,96 @@ mod tilt_tests {
         v.as_object_mut().unwrap().remove("tilt_deg");
         let run: SeatRunLayer = serde_json::from_value(v).unwrap();
         assert_eq!(run.tilt_deg, 0.0);
+    }
+}
+
+#[cfg(test)]
+mod bezel_tests {
+    use super::*;
+    use crate::gem::{Gem, GemCut};
+    use crate::{LayerEntry, RingDesign};
+
+    fn bezel(gem: Gem) -> SeatPadLayer {
+        let mut s = SeatPadLayer { style: SeatStyle::Bezel, recess_mm: 0.5, ..Default::default() };
+        s.fit_stone(gem);
+        s
+    }
+
+    #[test]
+    fn a_fitted_bezel_stands_a_lip_up_the_crown() {
+        let gem = Gem::calibrated(GemCut::Round, 4.0);
+        let s = bezel(gem);
+        let crown = gem.crown_mm();
+        assert!((crown - 0.35 * 0.62 * 4.0).abs() < 1e-9);
+        assert!((s.height_mm - (0.5 + 0.3 * crown)).abs() < 1e-9, "{}", s.height_mm);
+        assert!((s.girdle_drop_mm(gem) - 0.5).abs() < 1e-12, "the girdle lands on the bearing");
+        assert!((s.stand_off_mm(gem) - 0.3 * crown).abs() < 1e-9, "the lip is what stands over the girdle");
+        let cab = Gem::cabochon(GemCut::Oval, 6.0);
+        let c = bezel(cab);
+        assert!((c.height_mm - (0.5 + 0.3 * cab.depth_mm())).abs() < 1e-9, "a cabochon's crown is its dome");
+        let mut boss = SeatPadLayer::default();
+        let before = boss.height_mm;
+        boss.fit_stone(gem);
+        assert_eq!(boss.height_mm, before, "a boss keeps its own height");
+    }
+
+    #[test]
+    fn the_pocket_floor_dishes_toward_the_pavilion_inside_a_bearing() {
+        let gem = Gem::calibrated(GemCut::Round, 4.0);
+        let s = bezel(gem);
+        let mut ctx = FieldContext::default();
+        ctx.circumference_mm = 60.0;
+        ctx.band_v_len_mm = 8.0;
+        let u0 = ctx.u_of_theta(s.theta_deg);
+        let h = |d: f64| s.height(Uv { u: u0 + d, v: s.v_mm }, &ctx);
+        let r = s.semi_axes_mm().1;
+        let r_in = r - s.bezel_wall_mm;
+        let floor = s.height_mm - s.recess_mm;
+        // The ledge's inner end: the pocket wall's draft takes its outer 0.175 mm.
+        assert!((h(r_in - s.bezel_bearing_mm + 0.02) - floor).abs() < 1e-6, "the bearing is flat at the floor");
+        assert!(h(0.0) < floor - 0.05, "the centre dishes below the bearing: {} vs {floor}", h(0.0));
+        assert!((h(r - 0.01) - s.height_mm).abs() < 0.05, "the rim stands at the collar height");
+        let mut last = h(0.0);
+        let mut d = 0.0;
+        while d < r {
+            let now = h(d);
+            assert!(now >= last - 1e-9, "a pocket rises monotonically to its rim: {now} < {last} at {d}");
+            last = now;
+            d += 0.01;
+        }
+        let mut bare = s;
+        bare.gem = None;
+        assert!((bare.height(Uv { u: u0, v: s.v_mm }, &ctx) - floor).abs() < 1e-6, "no stone, no dish");
+    }
+
+    #[test]
+    fn a_bezel_with_its_stone_on_a_side_face_still_pulls() {
+        let lib = crate::AlphaLibrary::builtin();
+        let mut d = RingDesign::default();
+        d.profile.width_mm = 7.0;
+        d.profile.thickness_mm = 5.0;
+        d.profile.apply_style(crate::ProfileStyle::Flat);
+        d.profile.flatten_sides();
+        let ctx = d.field_context();
+        let sf = ctx.side_faces_std().expect("side faces");
+        let face = sf.low.or(sf.high).unwrap();
+        let mut s = bezel(Gem::calibrated(GemCut::Round, 3.0));
+        s.theta_deg = 90.0;
+        s.v_mm = 0.5 * (face.0 + face.1);
+        d.layers.layers.push(LayerEntry::new("Bezel", Layer::SeatPad(s)));
+        let f = crate::castability::analyze_field(&d, &lib, &d.draft, 192, 128);
+        assert!(f.undercut_fraction() < 5e-4, "{}", f.undercut_fraction());
+        let report = crate::stones::report(&d, f.parting_z_mm).unwrap();
+        assert!(report.seats[0].warnings.iter().all(|w| !w.contains("bezel")), "{:?}", report.seats[0].warnings);
+    }
+
+    #[test]
+    fn a_bezel_saved_before_the_lip_reads_the_defaults() {
+        let mut v = serde_json::to_value(SeatPadLayer::default()).unwrap();
+        let o = v.as_object_mut().unwrap();
+        o.remove("bezel_lip");
+        o.remove("bezel_bearing_mm");
+        let s: SeatPadLayer = serde_json::from_value(v).unwrap();
+        assert_eq!((s.bezel_lip, s.bezel_bearing_mm), (0.3, 0.3));
     }
 }

--- a/crates/ringdesign-core/src/gem.rs
+++ b/crates/ringdesign-core/src/gem.rs
@@ -272,6 +272,16 @@ impl Gem {
         }
     }
 
+    /// Height of the crown above the girdle, mm — the whole dome for a
+    /// cabochon, the third of the depth a faceted stone keeps above its
+    /// girdle.
+    pub fn crown_mm(&self) -> f64 {
+        match self.form {
+            GemForm::Faceted => self.depth_mm() - self.pavilion_mm(),
+            GemForm::Cabochon => self.depth_mm(),
+        }
+    }
+
     /// Depth of the pavilion below the girdle, mm — what a seat must swallow.
     /// The crown above the girdle is roughly a third of the depth.
     ///

--- a/crates/ringdesign-graph/src/nodes/layer.rs
+++ b/crates/ringdesign-graph/src/nodes/layer.rs
@@ -172,6 +172,8 @@ fn seat_node() -> NodeSpec {
     .field(PinSpec::select("style", enum_names(SeatStyle::ALL)).doc("Boss, bezel or gypsy mound."))
     .field(PinSpec::item("bezel_wall_mm", ValueKind::Number).doc("Bezel wall, mm."))
     .field(PinSpec::item("recess_mm", ValueKind::Number).doc("Bezel recess, mm."))
+    .field(PinSpec::item("bezel_lip", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 0.8 }).doc("How far up the crown the collar stands, fraction; fit derives the height."))
+    .field(PinSpec::item("bezel_bearing_mm", ValueKind::Number).doc("The girdle's ledge inside the wall, mm."))
     .field(PinSpec::item("prongs", ValueKind::Int).doc("Prong bumps; 0 for none."))
     .field(PinSpec::item("prong_mm", ValueKind::Number).doc("Prong diameter, mm."))
     .field(PinSpec::item("gem", ValueKind::Gem).doc("The stone this seat carries."))

--- a/crates/ringdesign-gui/src/panels/layers.rs
+++ b/crates/ringdesign-gui/src/panels/layers.rs
@@ -2462,6 +2462,25 @@ fn seat_pad(ui: &mut egui::Ui, p: &mut SeatPadLayer, fctx: &FieldContext) -> boo
                 .on_hover_text("Pocket depth below the rim")
                 .changed();
             ui.end_row();
+
+            ui.label("Lip");
+            c |= ui
+                .add(egui::Slider::new(&mut p.bezel_lip, 0.0..=0.8).step_by(0.05))
+                .on_hover_text("How far up the stone's crown the collar stands; Fit derives the height from it")
+                .changed();
+            ui.end_row();
+
+            ui.label("Bearing");
+            c |= ui
+                .add(
+                    egui::DragValue::new(&mut p.bezel_bearing_mm)
+                        .speed(0.01)
+                        .range(0.1..=0.8)
+                        .suffix(" mm"),
+                )
+                .on_hover_text("The ledge the girdle rests on inside the wall; the floor dishes toward the pavilion inside it")
+                .changed();
+            ui.end_row();
         }
 
         ui.label("Bur dimple");

--- a/crates/ringdesign-gui/src/panels/section.rs
+++ b/crates/ringdesign-gui/src/panels/section.rs
@@ -305,8 +305,10 @@ fn canvas(app: &RingDesignerApp, ui: &mut egui::Ui, pane: usize, opts_id: egui::
             let len = (nr * nr + nz * nz).sqrt().max(1e-9);
             let (nr, nz) = (nr / len, nz / len);
             let (tr, tz) = (-nz, nr);
-            // Girdle sits on the pad top; pavilion dives along the normal.
-            let top = (r + nr * seat.height_mm, z + nz * seat.height_mm);
+            // Girdle at the seat's stand-off — the same settle the preview
+            // and the report use — with the pavilion diving along the normal.
+            let lift = seat.stand_off_mm(gem);
+            let top = (r + nr * lift, z + nz * lift);
             let ga = map(top.0 + tr * half, top.1 + tz * half);
             let gb = map(top.0 - tr * half, top.1 - tz * half);
             let culet = map(top.0 - nr * depth, top.1 - nz * depth);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -171,8 +171,9 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   `setstone::SetStone`, enumerated once, read by the census, the preview and the section view.
 - [x] Graduated tilted stones on a run (S–M, gated on a field check, #79): `SeatRunLayer::tilt_deg`,
   clean on the crest and on a side face.
-- Bezel realism following the girdle (S–M); gallery/hollow underside (M–L); the bypass read as a
-  `ShankKind` (M).
+- [x] Bezel realism following the girdle (S–M, #81): the collar's height from the stone's crown, a
+  bearing ledge with a dished floor, the section view's girdle at the stand-off.
+- Gallery/hollow underside (M–L); the bypass read as a `ShankKind` (M).
 - Shelf: stone spacing map SVG; march instances along a guide path; blue-noise scatter
   generator; mm-true mask morphology; alpha granulometry; nesting-depth stepped relief; honest
   rope rail; `stones::probe_seat`; pearl stock; flat-edged seat plans.


### PR DESCRIPTION
Closes #81

- `Gem::crown_mm`; `SeatPadLayer::bezel_lip` (0.3) and `bezel_bearing_mm` (0.3), serde defaults. `fit_stone` on a bezel derives the collar height as recess + lip × crown; a boss keeps its own height.
- The bezel floor is a flat bearing ledge inside the wall and, when the seat carries a stone, dishes toward the pavilion as a paraboloid that never goes below 0.1 mm of pad; a stone-less bezel is unchanged.
- The section view draws the girdle at `stand_off_mm` — the preview and the report always did; it drew it at the pad top.
- Panel rows (Lip, Bearing) and `layer.seatpad` pins.
- Tests: the derived height for a round and a cabochon; the ledge flat, the centre dished, the pocket monotone to its rim, no dish without a stone; a bezel with its stone on a 7×5 side face fields clean with no bezel warning; old files read the defaults. Full guarded suite green (core 319).

🤖 Generated with [Claude Code](https://claude.com/claude-code)