### PR TITLE
M9.5: the hollow under the head

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,6 +348,27 @@ every shoulder from 10° to 40°. A band that widens *and* rises toward the top 
 single-valued in Z over `(r, theta)`, so it is a terrain and releases by
 construction — the same guarantee as the superellipse drop, not a tuning result.
 
+#### The hollow under the head
+
+`SignetHead::hollow_mm` (0–4, default 0; GUI "Hollow", MCP
+`head_hollow_mm`, graph `hollow_mm`) scoops the head's belly out from the
+finger hole: `ShankStyle::modulation` carries it as
+`ShankMod::bore_lift_mm`, the dominant head's own `on_head` presence
+smoothed over the shoulder, and `sample_spaced` adds it to the bore
+closure — the whole bore chord lifts and the side walls rise from the
+lifted corner, capped so an edge of `MIN_EDGE_MM` always survives above
+the comfort dome. Nothing outside moves: the crest is absolute on a head
+and the outer surface is built from `inner_r`, so the scoop only removes
+metal. It is castable for the reason the bore is reported as a vertical
+wall and never an undercut: the pull is along Z and a bore surface's
+normal is radial at any radius, so the verdict reads the scoop's roof
+and its fading ends as vertical wall and only the **wall it leaves**
+changes, which `thinnest_wall_mm` measures per slice. Measured on a
+12 mm lofted signet with a 0.6 mm hollow: bore lifted 0.600 under the
+face, palm bore nominal, the lift falling monotonically to zero across
+the shoulder, field clean, and the ring lighter. A toi et moi's second
+head follows the primary's setting.
+
 #### Three bought signets, measured
 
 `/home/shadowbroker/jewelry-scan/RING/Signets/` holds a heart, a hexagon and an

--- a/crates/ringdesign-core/src/profile.rs
+++ b/crates/ringdesign-core/src/profile.rs
@@ -826,7 +826,10 @@ impl BandProfile {
             let x = if bias.abs() > 1e-9 { x.powf(gamma(low)) } else { x };
             cap_r(inner_r + thickness + e_facet - crown * drop_at(x))
         };
-        let bore_r = |z: f64| -> f64 { inner_r + comfort * ((z - b_c) / hw.max(1e-9)).powi(2) };
+        // The hollow lifts the whole bore chord; capped so the side wall
+        // still has an edge to rise to.
+        let lift = ok(m.bore_lift_mm).clamp(0.0, (edge_t - comfort - MIN_EDGE_MM).max(0.0));
+        let bore_r = |z: f64| -> f64 { inner_r + lift + comfort * ((z - b_c) / hw.max(1e-9)).powi(2) };
 
         // --- Flange band, clamped to sit inside the outer profile. ---
         let flange = self.flange.enabled.then(|| {
@@ -1341,6 +1344,13 @@ pub struct SignetHead {
     /// dead-flat one is the zero-draft plane behind the refined-build phantom.
     #[serde(default)]
     pub table_dome_mm: f64,
+    /// Hollow under the head, mm: a scoop from the finger hole up into the
+    /// head's belly, full under the face and fading with the head's own
+    /// presence over the shoulder. Lightens a heavy head. The bore is a
+    /// vertical wall at any radius, so it costs nothing at the pull; the
+    /// wall it leaves is what the verdict measures.
+    #[serde(default)]
+    pub hollow_mm: f64,
     /// Rounding between the table and the head's walls, mm. The face outline
     /// is the head's one real edge, and this is how hard it reads. Measured on
     /// the reference heart: the rim's rounding reaches 0.9 mm below the plane,
@@ -1510,6 +1520,7 @@ impl Default for SignetHead {
             body_fair: HEAD_BODY_FAIR,
             table_flat: 1.0,
             table_dome_mm: 0.0,
+            hollow_mm: 0.0,
             rim_round_mm: HEAD_RIM_ROUND,
             dome: 0.0,
             loft: 0.0,
@@ -2307,6 +2318,11 @@ pub struct ShankMod {
     /// The groove's floor faces along the pull and its walls stand radial,
     /// so it is castable wherever a side face is.
     pub side_groove_mm: f64,
+    /// Extra bore radius here, mm — the hollow under a head, a scoop from
+    /// the finger hole up into the head's belly. The bore is a vertical
+    /// wall whichever radius it takes, so the scoop costs nothing at the
+    /// pull; the wall it leaves is what the field verdict measures.
+    pub bore_lift_mm: f64,
     /// Cut-dome facet half-width in unmodulated half-width units; 0 is none.
     /// With `outer_max_r` set, the section raises its dome so the cap slices
     /// it open to exactly this half-width.
@@ -2356,6 +2372,7 @@ impl ShankMod {
             head: 0.0,
             head_rim_mm: 0.0,
             side_groove_mm: 0.0,
+            bore_lift_mm: 0.0,
             facet_half: 0.0,
             facet_rim_mm: 0.0,
             crown_min_mm: None,
@@ -2701,6 +2718,9 @@ impl ShankStyle {
                     ridge_drop: a.wall_mix * crate::field::smoothstep(0.0, 0.05, a.ridge_crown),
                     ridge_table: a.ridge_table,
                     straddle_soft: crate::field::smootherstep(0.55, 0.92, a.x.abs()),
+                    // The hollow follows the dominant head's own presence.
+                    bore_lift_mm: self.head.hollow_mm.clamp(0.0, 4.0)
+                        * crate::field::smootherstep(0.0, 1.0, a.on_head),
                     wall: a.wall,
                     wall_mix: a.wall_mix,
                 }
@@ -5309,5 +5329,56 @@ mod tests {
         let (rep, watertight) = flanged_report(0.5);
         assert!(watertight);
         assert_eq!(rep.undercut, 0, "{:?}", rep.notes);
+    }
+}
+
+#[cfg(test)]
+mod hollow_tests {
+    use super::*;
+
+    #[test]
+    fn a_hollow_under_the_head_scoops_the_bore_and_still_fields_clean() {
+        let mut v = serde_json::to_value(SignetHead::default()).unwrap();
+        v.as_object_mut().unwrap().remove("hollow_mm");
+        assert_eq!(serde_json::from_value::<SignetHead>(v).unwrap().hollow_mm, 0.0);
+
+        let mut d = crate::RingDesign::default();
+        d.profile.apply_style(ProfileStyle::Flat);
+        d.profile.width_mm = 12.0;
+        d.profile.thickness_mm = 1.8;
+        d.profile.flatten_sides();
+        d.shank.apply_signet(12.0);
+        let lib = crate::AlphaLibrary::default();
+        let params = crate::BuildParams { theta_steps: 192, profile_steps: 96, ..Default::default() };
+        let solid = crate::mesh::build(&d, &lib, params);
+        let ir = d.inner_radius_mm();
+        let cr = ir + d.profile.thickness_mm;
+        let section = |d: &crate::RingDesign, t: f64| d.profile.sample_mod(ir, 192, &d.modulation_at(t, ir, cr));
+        let bore_of = |l: &ProfileLoop| l.pts.iter().filter(|p| !p.surface).map(|p| p.r).fold(f64::MAX, f64::min);
+        let crest_of = |l: &ProfileLoop| l.pts.iter().filter(|p| p.surface).map(|p| p.r).fold(f64::MIN, f64::max);
+        let before = section(&d, TOP_DEG);
+
+        d.shank.head.hollow_mm = 0.6;
+        let top = section(&d, TOP_DEG);
+        assert!((bore_of(&top) - (ir + 0.6)).abs() < 0.02, "under the face the bore lifts by the hollow: {}", bore_of(&top) - ir);
+        assert!((crest_of(&top) - crest_of(&before)).abs() < 1e-9, "the outside is untouched");
+        assert!((bore_of(&section(&d, TOP_DEG + 180.0)) - ir).abs() < 1e-6, "the palm keeps its bore");
+        // A 12 mm face spans about ±35°; somewhere on the shoulder past it
+        // the scoop is partway out, and by 120° it is gone.
+        let lifts: Vec<f64> = (30..=120).step_by(5).map(|off| bore_of(&section(&d, TOP_DEG + off as f64)) - ir).collect();
+        assert!(lifts.iter().any(|&l| l > 0.05 && l < 0.55), "the scoop fades over the shoulder: {lifts:?}");
+        assert!(lifts.last().unwrap().abs() < 1e-6, "gone by 120 degrees: {lifts:?}");
+        assert!(lifts.windows(2).all(|w| w[1] <= w[0] + 1e-4), "and it only falls: {lifts:?}");
+
+        let f = crate::castability::analyze_field(&d, &lib, &d.draft, 160, 96);
+        assert!(f.undercut_fraction() < 5e-4, "{:.4}% at {:.1} deg", f.undercut_fraction() * 100.0, f.worst_draft_deg);
+        let hollow = crate::mesh::build(&d, &lib, params);
+        assert!(hollow.report.validation.watertight);
+        assert!(hollow.report.volume_mm3 < solid.report.volume_mm3 - 1.0, "lighter: {} vs {}", hollow.report.volume_mm3, solid.report.volume_mm3);
+
+        // The lift is capped so the side wall still has an edge to rise to.
+        d.shank.head.hollow_mm = 4.0;
+        let deep = section(&d, TOP_DEG);
+        assert!(bore_of(&deep) < crest_of(&deep) - MIN_EDGE_MM, "a wall survives the deepest scoop");
     }
 }

--- a/crates/ringdesign-graph/src/nodes/shank.rs
+++ b/crates/ringdesign-graph/src/nodes/shank.rs
@@ -91,6 +91,7 @@ fn head_node() -> NodeSpec {
     .field(PinSpec::item("body_fair", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("How much the body is faired under the face, 0..1."))
     .field(PinSpec::item("table_flat", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("1 is a true plane to engrave."))
     .field(PinSpec::item("table_dome_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 3.0 }).doc("A cabochon cap on the table; on a lofted head, the apex height of the smooth table."))
+    .field(PinSpec::item("hollow_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 4.0 }).doc("A scoop from the finger hole up into the head's belly, mm; lightens a heavy head."))
     .field(PinSpec::item("rim_round_mm", ValueKind::Number).widget(Widget::Mm { min: 0.0, max: 2.0 }).doc("The table rim's fillet, mm."))
     .field(PinSpec::item("dome", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("The cut-dome construction; takes precedence over the loft."))
     .field(PinSpec::item("loft", ValueKind::Number).widget(Widget::Slider { min: 0.0, max: 1.0 }).doc("The lofted body; 1 for a new signet."))

--- a/crates/ringdesign-gui/src/panels/design.rs
+++ b/crates/ringdesign-gui/src/panels/design.rs
@@ -1070,6 +1070,21 @@ fn signet_head(app: &mut RingDesignerApp, ui: &mut egui::Ui) -> bool {
 
     changed |= ui
         .add(
+            egui::Slider::new(&mut head.hollow_mm, 0.0..=4.0)
+                .fixed_decimals(2)
+                .suffix(" mm")
+                .text("Hollow"),
+        )
+        .on_hover_text(
+            "A scoop from the finger hole up into the head's belly, fading out over the \
+             shoulder: lightens a heavy head. The bore is a vertical wall at any radius, \
+             so it costs nothing at the pull; the wall it leaves is what the verdict \
+             measures.",
+        )
+        .changed();
+
+    changed |= ui
+        .add(
             egui::Slider::new(&mut head.rim_round_mm, 0.0..=1.5)
                 .fixed_decimals(2)
                 .suffix(" mm")

--- a/crates/ringdesign-mcp/src/tools.rs
+++ b/crates/ringdesign-mcp/src/tools.rs
@@ -439,6 +439,11 @@ pub struct SetShankParams {
     /// and passes a 0.6-scaled outline at that height, so a lobed plan
     /// reads as a lobed dome.
     pub head_table_dome_mm: Option<f64>,
+    /// Signet only: hollow under the head, mm (0 to 4) — a scoop from the
+    /// finger hole up into the head's belly, fading over the shoulder. The
+    /// bore is a vertical wall at any radius, so it costs nothing at the
+    /// pull; the wall it leaves is what the verdict measures.
+    pub head_hollow_mm: Option<f64>,
     /// Signet only: share of the lofted construction, 0 to 1. 1 builds the
     /// head the way the factory presets do — one loose loft from the table's
     /// rim through a body outline 3 mm under it down to the ring's equator
@@ -1600,6 +1605,7 @@ impl RingDesignServer {
         put_range(&mut h.table_flat, p.head_table_flat, "head_table_flat", 0.0, 1.0, &mut applied)?;
         put_range(&mut h.rim_round_mm, p.head_rim_round_mm, "head_rim_round_mm", 0.0, 2.0, &mut applied)?;
         put_range(&mut h.table_dome_mm, p.head_table_dome_mm, "head_table_dome_mm", 0.0, 3.0, &mut applied)?;
+        put_range(&mut h.hollow_mm, p.head_hollow_mm, "head_hollow_mm", 0.0, 4.0, &mut applied)?;
         put_range(&mut h.loft, p.head_loft, "head_loft", 0.0, 1.0, &mut applied)?;
         put_range(&mut h.loft_frontal_mm, p.head_loft_frontal_mm, "head_loft_frontal_mm", 0.0, 20.0, &mut applied)?;
         put_range(&mut h.loft_lateral_mm, p.head_loft_lateral_mm, "head_loft_lateral_mm", 0.0, 20.0, &mut applied)?;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -175,7 +175,8 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   bearing ledge with a dished floor, the section view's girdle at the stand-off.
 - [x] The bypass read as a `ShankKind` (M, #83): two explicit arms with rounded tips, the section
   their union, the crest on the parting plane, Split's side-face seam.
-- Gallery/hollow underside (M–L).
+- [x] Gallery/hollow underside (M–L, #85): `SignetHead::hollow_mm`, a scoop from the finger hole
+  into the head's belly carried as `ShankMod::bore_lift_mm`; the bore is a vertical wall at any radius.
 - Shelf: stone spacing map SVG; march instances along a guide path; blue-noise scatter
   generator; mm-true mask morphology; alpha granulometry; nesting-depth stepped relief; honest
   rope rail; `stones::probe_seat`; pearl stock; flat-edged seat plans.


### PR DESCRIPTION
Closes #85

- `SignetHead::hollow_mm` (0–4, serde default 0): a scoop from the finger hole up into the head's belly. `ShankStyle::modulation` carries it as `ShankMod::bore_lift_mm`, the dominant head's `on_head` presence smoothed over the shoulder; `sample_spaced` adds it to the bore closure, capped so an edge of `MIN_EDGE_MM` always survives above the comfort dome. Nothing outside moves.
- Castable for the reason the bore is reported as a vertical wall: its normal is radial at any radius, so only the wall the scoop leaves changes, which `thinnest_wall_mm` measures.
- GUI "Hollow" slider, MCP `head_hollow_mm`, graph `head.hollow_mm` pin.
- Test: on a 12 mm lofted signet, 0.600 mm lift under the face, outside untouched, palm bore nominal, the lift falling monotonically to zero across the shoulder, field clean, watertight, lighter; the cap survives a 4 mm ask; a head saved without the field reads 0.

Full guarded suite green (core 321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)