### PR TITLE
The graph editor in the comfyui-android look

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1791,6 +1791,40 @@ Fit and the minimap read the view transform snarl hands to
 change as a document — converted, edited, baked — which is why
 `first_difference` treats a key present on one side only as a change.
 
+### The editor looks like the comfyui-android graph
+
+`ringdesign_graph_ui::style` is that app's graph view, number for number,
+and both the desktop pane and the phone tab draw through it: an AMOLED
+canvas (`CANVAS`) lit by three pools of colour — violet, aqua, pink —
+anchored to the visible rect so the light does not slide as you pan, a
+dot grid in graph units (spacing 28, coarsened by powers of two when
+zoomed out, dim teal), glass nodes (`NODE_FILL` at alpha 190, corner 8)
+under a white hairline rim that turns hot pink when chosen and the error
+colour when the node carries diagnostics, axis-aligned wires with 8 px
+corners at 2.6 px, 15 px pins standing 3 px outside the body, inputs
+stacked above outputs (`NodeLayout::sandwich`). Pins keep their kind's
+hue at the palette's muted saturation and value; labels are plain ink.
+`apply_visuals` installs that app's egui visuals — black page, glass
+panes, aqua hover, pink press and selection — inside the editor's `scope`
+only, so the app around it keeps its own theme. `NODE_FIELD_W` caps a
+field row at 260 graph units because a width taken from
+`available_width` feeds back into the node size it is derived from and
+ratchets the node wider every frame. The frosted-glass blur behind each
+node is the one thing not carried: it is the phone's `backdrop-blur`
+grab pass, which the desktop's glow window has no equivalent for; the
+translucent fill over the lit canvas is what remains of it. Header-only
+dragging (body drags pan) is the other comfyui mechanic still to port.
+Arrange lays nodes out by depth from their **measured** sizes
+(`final_node_rect`, keyed by graph id so a rebuilt snarl keeps them) with
+that app's gaps, and re-runs while the measures it used disagree with the
+current ones, three passes at most — snarl's first frame measures a node
+before its widgets settle (the Court band's profile node read 125 wide on
+frame one and 253 on frame two), and a layout from those numbers overlaps.
+`RD_GRAPH_SHOT=/dir cargo test -p ringdesign-graph-ui --features shot shot_the_editor`
+renders the editor through wgpu offscreen to `graph.png` for an eyeball
+pass; the `shot` feature keeps wgpu out of every other build, because it
+unifies `egui/bytemuck` into the whole UI stack and costs a full rebuild.
+
 ### Paint-on-band: pressure is millimetres, the ceiling is the draft
 
 `paint.rs` (core) is the brush both apps share: `bite()` resolves a press

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +457,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
+ "serde",
+ "termcolor",
  "unicode-width",
 ]
 
@@ -471,6 +482,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "combine"
@@ -687,6 +708,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dify"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ce0fb972943b4e88cd03b8f92953df0c71bb05e0bde8e5b684895d808013cc"
+dependencies = [
+ "anyhow",
+ "colored",
+ "getopts",
+ "image",
+ "rayon",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +809,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
+ "pollster 1.0.1",
  "profiling",
  "raw-window-handle",
  "ron",
@@ -783,6 +818,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "web-time",
+ "wgpu",
  "windows-sys 0.61.2",
  "winit",
 ]
@@ -897,11 +933,19 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0faf48edfa198e2343de2083bd10628a41197c1a17855cd12cec4c0f140dd3b"
 dependencies = [
+ "dify",
+ "eframe",
  "egui",
+ "egui-wgpu",
+ "image",
  "kittest",
  "log",
+ "open",
+ "pollster 1.0.1",
  "serde",
+ "tempfile",
  "toml",
+ "wgpu",
 ]
 
 [[package]]
@@ -1030,6 +1074,12 @@ checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -1238,6 +1288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1471,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.19",
+ "windows",
+]
+
+[[package]]
 name = "guillotiere"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1553,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -1650,6 +1725,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1880,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
 name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,6 +1917,12 @@ dependencies = [
  "polycool",
  "smallvec",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1998,6 +2109,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
+ "spirv",
  "thiserror 2.0.19",
  "unicode-ident",
 ]
@@ -2199,7 +2311,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -2285,7 +2397,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -2367,6 +2479,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,7 +2500,21 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -2404,7 +2542,7 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -2462,6 +2600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
+dependencies = [
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,6 +2617,15 @@ checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2597,6 +2754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "pollster"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
+
+[[package]]
 name = "polycool"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2782,12 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
@@ -2761,10 +2930,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
 
 [[package]]
 name = "rawpointer"
@@ -2916,7 +3103,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "percent-encoding",
- "pollster",
+ "pollster 0.4.0",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3575,6 +3762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "sse-stream"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3645,6 +3841,28 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "thin-vec"
@@ -4256,6 +4474,8 @@ dependencies = [
  "hashbrown 0.17.1",
  "js-sys",
  "log",
+ "naga",
+ "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
@@ -4295,10 +4515,40 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.19",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-naga-bridge",
  "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6c13228950f36a56023976a6c4ee6714b27fb40e3d52a33f7d3bb6d109c0b1"
+dependencies = [
+ "wgpu-hal",
 ]
 
 [[package]]
@@ -4316,22 +4566,54 @@ version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
 dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
  "bitflags 2.13.1",
+ "block2 0.6.2",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
  "hashbrown 0.17.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
  "libloading",
  "log",
  "naga",
  "naga-types",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
+ "profiling",
+ "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
+ "smallvec",
  "static_assertions",
  "thiserror 2.0.19",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
 ]
 
 [[package]]
@@ -4380,6 +4662,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4390,6 +4693,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4419,6 +4733,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -4505,6 +4829,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/ringdesign-graph-ui/Cargo.toml
+++ b/crates/ringdesign-graph-ui/Cargo.toml
@@ -5,6 +5,11 @@ version.workspace = true
 license.workspace = true
 description = "The node editor for ringdesign-graph, on egui-snarl"
 
+[features]
+## Renders the editor offscreen through wgpu for the screenshot test;
+## off by default so the workspace build never pulls wgpu.
+shot = ["egui_kittest/wgpu", "egui_kittest/snapshot"]
+
 [dependencies]
 ringdesign-core = { path = "../ringdesign-core", default-features = false }
 ringdesign-graph = { path = "../ringdesign-graph", default-features = false }

--- a/crates/ringdesign-graph-ui/src/editor.rs
+++ b/crates/ringdesign-graph-ui/src/editor.rs
@@ -6,16 +6,16 @@
 //! from what went in, the graph is updated and the revision moves. Nodes
 //! added in the view carry no id until extraction hands them a fresh one.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use egui::{Color32, RichText, Ui};
-use egui_snarl::ui::{PinInfo, SnarlStyle, SnarlViewer};
+use egui_snarl::ui::{BackgroundPattern, PinInfo, SnarlStyle, SnarlViewer};
 use egui_snarl::{InPin, InPinId, NodeId as SnarlId, OutPin, OutPinId, Snarl};
 use ringdesign_graph::graph::{Access, Graph, GraphError, Node, NodeId, Wire};
 use ringdesign_graph::registry::{Category, NodeSpec, PinSpec, Registry};
 use ringdesign_graph::value::{Literal, ValueKind};
 
-use crate::widgets::{kind_color, pin_widget};
+use crate::widgets::pin_widget;
 
 /// A node as the view holds it: the graph's data plus the pins resolved
 /// from the registry, so drawing needs no registry at all.
@@ -182,12 +182,48 @@ pub struct Editor {
     /// The persistent id the snarl was last shown under, for selection.
     snarl_id: Option<egui::Id>,
     pub show_minimap: bool,
+    /// Every node's drawn size, by graph id so a rebuilt snarl keeps them.
+    sizes: HashMap<NodeId, egui::Vec2>,
+    /// The sizes the last arrange laid out from, and how many correction
+    /// passes it may still take: snarl's first frame measures a node before
+    /// its widgets have settled, so a layout is re-run while the measures
+    /// it used disagree with the current ones.
+    arranged_sizes: HashMap<NodeId, egui::Vec2>,
+    refine_left: u8,
+    /// The editor moved nodes itself this frame; reported as a change.
+    layout_changed: bool,
 }
 
 impl Editor {
     pub fn new(graph: Graph, reg: &Registry) -> Self {
         let (snarl, ids) = build_snarl(&graph, reg);
-        Self { graph, snarl, ids, revision: 0, selected: None, editable: true, style: SnarlStyle::new(), pending_focus: None, pending_fit: false, transform: None, snarl_id: None, show_minimap: true }
+        Self {
+            graph,
+            snarl,
+            ids,
+            revision: 0,
+            selected: None,
+            editable: true,
+            style: crate::style::snarl_style(),
+            pending_focus: None,
+            pending_fit: false,
+            transform: None,
+            snarl_id: None,
+            show_minimap: true,
+            sizes: HashMap::new(),
+            arranged_sizes: HashMap::new(),
+            refine_left: 0,
+            layout_changed: false,
+        }
+    }
+
+    /// A node's drawn size, or the nominal footprint before it has been drawn.
+    fn size_of(&self, sid: SnarlId) -> egui::Vec2 {
+        self.ids.to_graph.get(&sid).and_then(|g| self.sizes.get(g)).copied().unwrap_or(NODE_SIZE)
+    }
+
+    fn all_measured(&self) -> bool {
+        self.graph.nodes.iter().all(|n| self.sizes.contains_key(&n.id))
     }
 
     pub fn graph(&self) -> &Graph {
@@ -295,12 +331,29 @@ impl Editor {
             seen_transform: None,
             collapse_request: None,
             mode: self.graph.mode,
+            selected: self.selected.and_then(|g| self.ids.to_snarl.get(&g).copied()),
+            sizes: &mut self.sizes,
         };
-        self.snarl.show(&mut viewer, &self.style, id_salt, ui);
+        // That app's visuals on everything inside the editor, and nothing outside it.
+        ui.scope(|ui| {
+            crate::style::apply_visuals(ui.style_mut());
+            self.snarl.show(&mut viewer, &self.style, id_salt, ui);
+        });
         let clicked = viewer.clicked;
         let refused = viewer.refused.take();
         let collapse_request = viewer.collapse_request.take();
         self.transform = viewer.seen_transform.or(self.transform);
+        // The first arrange ran on nominal sizes; once every node has been
+        // drawn once, lay them out again from what they really measure.
+        if self.refine_left > 0 && self.all_measured() {
+            if sizes_agree(&self.arranged_sizes, &self.sizes) {
+                self.refine_left = 0;
+            } else {
+                self.refine_left -= 1;
+                self.lay_out(reg);
+                self.layout_changed = true;
+            }
+        }
         if self.show_minimap {
             self.paint_minimap(ui, viewport);
         }
@@ -311,7 +364,7 @@ impl Editor {
                 return EditorResponse { changed: true, selected: self.selected, refused: None };
             }
         }
-        let mut resp = EditorResponse { refused, ..Default::default() };
+        let mut resp = EditorResponse { refused, changed: std::mem::take(&mut self.layout_changed), ..Default::default() };
         if let Some(sid) = clicked {
             self.selected = self.ids.to_graph.get(&sid).copied();
         }
@@ -437,12 +490,78 @@ impl Editor {
         hit
     }
 
-    /// Lay the nodes out by depth, as the template files are.
+    /// Lay the nodes out by depth from their measured sizes — columns by
+    /// longest path, nodes stacked within a column, columns centred across
+    /// the flow — so nothing overlaps. Nodes not yet drawn take the nominal
+    /// footprint and a second pass follows once they have been.
     pub fn arrange(&mut self, reg: &Registry) {
-        let mut g = self.graph.clone();
-        ringdesign_graph::templates::arrange(&mut g);
-        self.set_graph(g, reg);
+        self.refine_left = 3;
+        self.lay_out(reg);
     }
+
+    fn lay_out(&mut self, reg: &Registry) {
+        const FLOW_GAP: f32 = 60.0;
+        const CROSS_GAP: f32 = 24.0;
+        let Ok(order) = self.graph.topo() else { return };
+        let mut depth: BTreeMap<NodeId, usize> = BTreeMap::new();
+        for id in &order {
+            let d = self.graph.wires_into(*id).filter_map(|w| depth.get(&w.from)).max().map(|m| m + 1).unwrap_or(0);
+            depth.insert(*id, d);
+        }
+        let deepest = depth.values().copied().max().unwrap_or(0);
+        let mut columns: Vec<Vec<NodeId>> = vec![Vec::new(); deepest + 1];
+        for id in &order {
+            columns[depth[id]].push(*id);
+        }
+        // Each column ordered by where its feeders sit, so wires run across.
+        let mut row: BTreeMap<NodeId, f32> = BTreeMap::new();
+        for column in columns.iter_mut() {
+            let mut keyed: Vec<(NodeId, f32)> = column
+                .iter()
+                .enumerate()
+                .map(|(i, id)| {
+                    let feeders: Vec<f32> = self.graph.wires_into(*id).filter_map(|w| row.get(&w.from).copied()).collect();
+                    let key = if feeders.is_empty() { i as f32 } else { feeders.iter().sum::<f32>() / feeders.len() as f32 };
+                    (*id, key)
+                })
+                .collect();
+            keyed.sort_by(|a, b| a.1.total_cmp(&b.1));
+            *column = keyed.iter().map(|(id, _)| *id).collect();
+            for (i, id) in column.iter().enumerate() {
+                row.insert(*id, i as f32);
+            }
+        }
+        let size = |id: NodeId| self.sizes.get(&id).copied().unwrap_or(NODE_SIZE);
+        let mut x = 0.0f32;
+        let mut pos: BTreeMap<NodeId, [f32; 2]> = BTreeMap::new();
+        for column in &columns {
+            if column.is_empty() {
+                continue;
+            }
+            let total: f32 = column.iter().map(|id| size(*id).y + CROSS_GAP).sum::<f32>() - CROSS_GAP;
+            let mut y = -total / 2.0;
+            for id in column {
+                pos.insert(*id, [x, y]);
+                y += size(*id).y + CROSS_GAP;
+            }
+            x += column.iter().map(|id| size(*id).x).fold(1.0f32, f32::max) + FLOW_GAP;
+        }
+        let mut g = self.graph.clone();
+        for n in g.nodes.iter_mut() {
+            if let Some(p) = pos.get(&n.id) {
+                n.pos = [p[0].round(), p[1].round()];
+            }
+        }
+        self.arranged_sizes = self.sizes.clone();
+        self.set_graph(g, reg);
+        self.pending_fit = true;
+    }
+}
+
+/// Two measure snapshots describe the same canvas: same nodes, none moved
+/// by more than a unit.
+fn sizes_agree(a: &HashMap<NodeId, egui::Vec2>, b: &HashMap<NodeId, egui::Vec2>) -> bool {
+    a.len() == b.len() && a.iter().all(|(id, s)| b.get(id).is_some_and(|p| (*s - *p).abs().max_elem() <= 1.0))
 }
 
 struct Viewer<'a> {
@@ -458,59 +577,68 @@ struct Viewer<'a> {
     seen_transform: Option<egui::emath::TSTransform>,
     collapse_request: Option<SnarlId>,
     mode: ringdesign_graph::graph::Mode,
+    /// The chosen node, for its rim.
+    selected: Option<SnarlId>,
+    /// Measured node sizes, filled as nodes are drawn.
+    sizes: &'a mut HashMap<NodeId, egui::Vec2>,
 }
 
-/// The footprint a node is assumed to take when fitting or mapping.
+/// The footprint a node is assumed to take before it has been drawn.
 const NODE_SIZE: egui::Vec2 = egui::vec2(220.0, 140.0);
 
-fn node_bounds(snarl: &Snarl<NodeCard>) -> Option<egui::Rect> {
+/// Every node's rect from its measured size, in graph space.
+fn node_bounds(snarl: &Snarl<NodeCard>, sizes: &HashMap<NodeId, egui::Vec2>, ids: &IdMap) -> Option<egui::Rect> {
     let mut rect: Option<egui::Rect> = None;
-    for (_, pos, _) in snarl.nodes_pos_ids() {
-        let r = egui::Rect::from_min_size(pos, NODE_SIZE);
+    for (sid, pos, _) in snarl.nodes_pos_ids() {
+        let size = ids.to_graph.get(&sid).and_then(|g| sizes.get(g)).copied().unwrap_or(NODE_SIZE);
+        let r = egui::Rect::from_min_size(pos, size);
         rect = Some(rect.map_or(r, |b| b.union(r)));
     }
     rect
 }
 
 impl Editor {
-    /// A small map of every node and the current view, in the corner.
+    /// A small map of every node and the current view, in the top-left
+    /// corner as that app keeps it.
     fn paint_minimap(&self, ui: &Ui, viewport: egui::Rect) {
-        let Some(bounds) = node_bounds(&self.snarl) else { return };
-        if self.snarl.node_ids().count() < 2 {
+        let Some(bounds) = node_bounds(&self.snarl, &self.sizes, &self.ids) else { return };
+        if self.snarl.node_ids().count() < 2 || !viewport.is_finite() || viewport.width() < 160.0 || viewport.height() < 160.0 {
             return;
         }
-        let map = egui::Rect::from_min_size(viewport.right_top() + egui::vec2(-172.0, 12.0), egui::vec2(160.0, 100.0));
+        let pad = bounds.expand(60.0);
+        let w = (viewport.width() * 0.30).clamp(96.0, 200.0);
+        let h = (w * (pad.height() / pad.width().max(1.0)).clamp(0.35, 1.4)).clamp(60.0, 200.0);
+        let map = egui::Rect::from_min_size(viewport.left_top() + egui::vec2(10.0, 10.0), egui::vec2(w, h));
         let painter = ui.painter().with_clip_rect(viewport);
         painter.rect_filled(map, 4.0, Color32::from_black_alpha(170));
-        painter.rect_stroke(map, 4.0, egui::Stroke::new(1.0, Color32::from_gray(90)), egui::StrokeKind::Inside);
-        let pad = bounds.expand(80.0);
-        let to_map = |p: egui::Pos2| -> egui::Pos2 {
-            let u = ((p.x - pad.min.x) / pad.width().max(1.0)).clamp(0.0, 1.0);
-            let v = ((p.y - pad.min.y) / pad.height().max(1.0)).clamp(0.0, 1.0);
-            map.min + egui::vec2(u * map.width(), v * map.height())
-        };
+        let scale = (map.size() / pad.size()).min_elem();
+        let tf = egui::emath::TSTransform::new(map.center().to_vec2() - pad.center().to_vec2() * scale, scale);
         for (sid, pos, card) in self.snarl.nodes_pos_ids() {
-            let c = to_map(pos + NODE_SIZE * 0.5);
+            let mut m = tf * egui::Rect::from_min_size(pos, self.size_of(sid));
+            if m.width() < 2.0 || m.height() < 2.0 {
+                m = egui::Rect::from_center_size(m.center(), m.size().max(egui::vec2(2.0, 2.0)));
+            }
             let selected = self.ids.to_graph.get(&sid).is_some_and(|g| self.selected == Some(*g));
-            let color = if !card.diag.is_empty() { Color32::from_rgb(220, 70, 70) } else if selected { Color32::from_rgb(255, 215, 120) } else { Color32::from_gray(200) };
-            painter.circle_filled(c, if selected { 3.5 } else { 2.5 }, color);
+            let color = if !card.diag.is_empty() {
+                crate::style::ERROR
+            } else if selected {
+                Color32::from_rgb(110, 170, 255)
+            } else {
+                Color32::from_gray(150)
+            };
+            painter.rect_filled(m.intersect(map), 1.0, color);
         }
         if let Some(t) = self.transform {
             let inv = t.inverse();
             let view = egui::Rect::from_min_max(inv * viewport.min, inv * viewport.max);
-            let r = egui::Rect::from_min_max(to_map(view.min), to_map(view.max));
-            painter.rect_stroke(r, 2.0, egui::Stroke::new(1.0, Color32::from_rgb(120, 190, 255)), egui::StrokeKind::Inside);
+            painter.rect_stroke((tf * view).intersect(map), 0.0, egui::Stroke::new(1.0, Color32::WHITE), egui::StrokeKind::Inside);
         }
+        painter.rect_stroke(map, 4.0, egui::Stroke::new(1.0, Color32::from_gray(90)), egui::StrokeKind::Inside);
     }
 }
 
 fn pin_info(pin: &PinSpec) -> PinInfo {
-    let color = kind_color(pin.kind);
-    let info = match pin.access {
-        Access::Item => PinInfo::circle(),
-        Access::List => PinInfo::square(),
-    };
-    info.with_fill(color).with_stroke(egui::Stroke::new(1.0, color.gamma_multiply(0.6)))
+    crate::style::pin_info(pin.kind, pin.access)
 }
 
 impl SnarlViewer<NodeCard> for Viewer<'_> {
@@ -519,11 +647,13 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
     }
 
     fn node_frame(&mut self, default: egui::Frame, node: SnarlId, _inputs: &[InPin], _outputs: &[OutPin], snarl: &Snarl<NodeCard>) -> egui::Frame {
-        match snarl.get_node(node) {
-            Some(c) if !c.diag.is_empty() => default.stroke(egui::Stroke::new(2.0, Color32::from_rgb(220, 70, 70))),
-            Some(c) if self.ids.to_graph.get(&node).is_some_and(|g| c.graph_id() == Some(*g)) => default,
-            _ => default,
-        }
+        let trouble = snarl.get_node(node).is_some_and(|c| !c.diag.is_empty());
+        crate::style::node_frame(default, self.selected == Some(node), trouble)
+    }
+
+    fn draw_background(&mut self, _background: Option<&BackgroundPattern>, viewport: &egui::Rect, _snarl_style: &SnarlStyle, _style: &egui::Style, painter: &egui::Painter, _snarl: &Snarl<NodeCard>) {
+        let scale = self.seen_transform.map(|t| t.scaling).unwrap_or(1.0);
+        crate::style::paint_canvas(painter, *viewport, scale);
     }
 
     fn inputs(&mut self, node: &NodeCard) -> usize {
@@ -537,8 +667,9 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
     fn show_input(&mut self, pin: &InPin, ui: &mut Ui, snarl: &mut Snarl<NodeCard>) -> impl egui_snarl::ui::SnarlPin + 'static {
         let card = &mut snarl[pin.id.node];
         let Some(spec) = card.pins_in.get(pin.id.input).cloned() else { return PinInfo::circle() };
+        ui.set_max_width(crate::style::NODE_FIELD_W);
         ui.horizontal(|ui| {
-            ui.label(RichText::new(&spec.name).small().color(kind_color(spec.kind))).on_hover_text(format!("{}\n{}", spec.kind.label(), spec.doc));
+            ui.label(RichText::new(&spec.name).color(crate::style::INK)).on_hover_text(format!("{}\n{}", spec.kind.label(), spec.doc));
             if pin.remotes.is_empty() && self.editable {
                 let mut lit = card.inputs.get(&spec.name).cloned();
                 if pin_widget(ui, &spec, &mut lit) {
@@ -561,9 +692,9 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
         let Some(spec) = card.pins_out.get(pin.id.output).cloned() else { return PinInfo::circle() };
         ui.horizontal(|ui| {
             if let Some(v) = card.values.get(&spec.name) {
-                ui.weak(RichText::new(v).small());
+                ui.label(RichText::new(v).small().color(crate::style::INK_DIM));
             }
-            ui.label(RichText::new(&spec.name).small().color(kind_color(spec.kind))).on_hover_text(format!("{}\n{}", spec.kind.label(), spec.doc));
+            ui.label(RichText::new(&spec.name).color(crate::style::INK)).on_hover_text(format!("{}\n{}", spec.kind.label(), spec.doc));
         });
         pin_info(&spec)
     }
@@ -574,15 +705,15 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
 
     fn show_on_hover_popup(&mut self, node: SnarlId, _inputs: &[InPin], _outputs: &[OutPin], ui: &mut Ui, snarl: &mut Snarl<NodeCard>) {
         for d in &snarl[node].diag {
-            ui.colored_label(Color32::from_rgb(220, 90, 90), d);
+            ui.colored_label(crate::style::ERROR, d);
         }
     }
 
     fn current_transform(&mut self, to_global: &mut egui::emath::TSTransform, snarl: &mut Snarl<NodeCard>) {
         if let Some(viewport) = self.fit.take() {
-            if let Some(bounds) = node_bounds(snarl) {
+            if let Some(bounds) = node_bounds(snarl, self.sizes, self.ids) {
                 let pad = bounds.expand(40.0);
-                let scale = (viewport.width() / pad.width().max(1.0)).min(viewport.height() / pad.height().max(1.0)).clamp(0.15, 1.5);
+                let scale = (viewport.width() / pad.width().max(1.0)).min(viewport.height() / pad.height().max(1.0)).clamp(crate::style::MIN_SCALE, crate::style::MAX_SCALE);
                 to_global.scaling = scale;
                 to_global.translation = viewport.center().to_vec2() - pad.center().to_vec2() * scale;
             }
@@ -600,6 +731,10 @@ impl SnarlViewer<NodeCard> for Viewer<'_> {
     }
 
     fn final_node_rect(&mut self, node: SnarlId, rect: egui::Rect, ui: &mut Ui, _snarl: &mut Snarl<NodeCard>) {
+        if let Some(gid) = self.ids.to_graph.get(&node) {
+            // Clamped so one pathological measure cannot throw the layout.
+            self.sizes.insert(*gid, rect.size().min(egui::vec2(1600.0, 3000.0)));
+        }
         let clicked = ui.input(|i| i.pointer.primary_clicked() && i.pointer.interact_pos().is_some_and(|p| rect.contains(p)));
         if clicked {
             self.clicked = Some(node);
@@ -756,7 +891,7 @@ mod tests {
 
         // Text -> Number is refused by the viewer; Number -> Number replaces.
         let (mut snarl, ids) = build_snarl(&g, &reg);
-        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids, focus: None, fit: None, viewport_center: egui::Pos2::ZERO, seen_transform: None, collapse_request: None, mode: Mode::SandRing };
+        let mut viewer = Viewer { reg: &reg, editable: true, clicked: None, refused: None, search: String::new(), ids: &ids, focus: None, fit: None, viewport_center: egui::Pos2::ZERO, seen_transform: None, collapse_request: None, mode: Mode::SandRing , selected: None, sizes: &mut HashMap::new() };
         let text_out = OutPin { id: OutPinId { node: ids.to_snarl[&t], output: 0 }, remotes: vec![] };
         let add_b = InPin { id: InPinId { node: ids.to_snarl[&a], input: 1 }, remotes: vec![] };
         viewer.connect(&text_out, &add_b, &mut snarl);
@@ -852,5 +987,34 @@ mod tests {
         for want in ["Band profile", "Shank", "New design", "Output"] {
             assert!(harness.query_by_label(want).is_some(), "{want} not drawn");
         }
+    }
+}
+
+#[cfg(all(test, feature = "shot"))]
+mod shot {
+    /// `RD_GRAPH_SHOT=/some/dir cargo test -p ringdesign-graph-ui --features shot shot_the_editor`
+    /// renders the editor over the Court band's graph through wgpu and
+    /// writes `graph.png` there, for an eyeball pass on the look.
+    #[test]
+    fn shot_the_editor() {
+        let Some(dir) = std::env::var_os("RD_GRAPH_SHOT") else { return };
+        let reg = ringdesign_graph::registry::Registry::builtin();
+        let (_, g) = ringdesign_graph::templates::all().into_iter().next().expect("a template graph");
+        let mut ed = super::Editor::new(g, &reg);
+        ed.arrange(&reg);
+        ed.fit();
+        ed.selected = ed.graph().nodes.get(2).map(|n| n.id);
+        let mut harness = egui_kittest::Harness::builder()
+            .with_size(egui::vec2(1280.0, 800.0))
+            .with_pixels_per_point(1.0)
+            .wgpu()
+            .build_ui(|ui| {
+                ed.show(&reg, ui, "shot");
+            });
+        harness.run_steps(8);
+        let img = harness.render().expect("wgpu renders offscreen");
+        let path = std::path::Path::new(&dir).join("graph.png");
+        img.save(&path).expect("png");
+        eprintln!("wrote {}", path.display());
     }
 }

--- a/crates/ringdesign-graph-ui/src/lib.rs
+++ b/crates/ringdesign-graph-ui/src/lib.rs
@@ -10,6 +10,7 @@
 //! tree. [`editor`] is filled in by M3.2.
 
 pub mod editor;
+pub mod style;
 pub mod widgets;
 
 pub use editor::{Editor, EditorResponse, NodeCard, build_snarl, extract_graph};

--- a/crates/ringdesign-graph-ui/src/style.rs
+++ b/crates/ringdesign-graph-ui/src/style.rs
@@ -1,0 +1,248 @@
+//! The editor's look — the comfyui-android graph view's, number for number:
+//! an AMOLED canvas lit by three pools of colour under a graph-space dot
+//! grid, glass nodes with a white hairline rim (pink when chosen),
+//! axis-aligned wires, fat pins outside the body, inputs stacked above
+//! outputs, and that app's visuals on every widget inside a node.
+
+use egui::{Color32, CornerRadius, Stroke};
+use egui_snarl::ui::{BackgroundPattern, NodeLayout, PinInfo, PinPlacement, SnarlStyle, WireStyle};
+use ringdesign_graph::graph::Access;
+use ringdesign_graph::value::ValueKind;
+
+/// Primary accent — hot pink, reserved for what is chosen.
+pub const PINK: Color32 = Color32::from_rgb(255, 61, 139);
+pub const PINK_BRIGHT: Color32 = Color32::from_rgb(255, 110, 168);
+/// Secondary accent — aqua: hover, links, live.
+pub const AQUA: Color32 = Color32::from_rgb(43, 226, 214);
+pub const AQUA_BRIGHT: Color32 = Color32::from_rgb(120, 240, 232);
+/// Ambient light, never a signal.
+pub const VIOLET: Color32 = Color32::from_rgb(163, 140, 255);
+/// A pane's edge: a dim white hairline, because glass has no colour at its edge.
+pub const RIM: Color32 = Color32::from_rgba_premultiplied(46, 46, 52, 46);
+pub const RIM_BRIGHT: Color32 = Color32::from_rgba_premultiplied(72, 72, 80, 72);
+/// Body ink — cool near-white.
+pub const INK: Color32 = Color32::from_rgb(233, 233, 239);
+pub const INK_DIM: Color32 = Color32::from_rgb(150, 148, 162);
+/// A node in trouble.
+pub const ERROR: Color32 = Color32::from_rgb(237, 69, 92);
+
+/// The AMOLED canvas.
+pub const CANVAS: Color32 = Color32::from_rgb(3, 3, 5);
+/// A node body: dark glass a step above the black canvas, `(22, 21, 34)` at alpha 190.
+pub const NODE_FILL: Color32 = Color32::from_rgba_premultiplied(16, 16, 25, 190);
+pub const NODE_CORNER: f32 = 8.0;
+/// Dot grid spacing and radius in graph units, so the grid scales with the nodes.
+pub const DOT_SPACING: f32 = 28.0;
+pub const DOT_RADIUS: f32 = 1.7;
+/// Dim teal ink for the dot grid.
+pub const DOT_COLOR: Color32 = Color32::from_rgb(30, 70, 74);
+pub const MIN_SCALE: f32 = 0.05;
+pub const MAX_SCALE: f32 = 2.5;
+/// Graph-space width of a node's field row. A width taken from
+/// `available_width` feeds back into the node size it is derived from and
+/// ratchets the node wider every frame; a constant does not.
+pub const NODE_FIELD_W: f32 = 260.0;
+
+/// The snarl settings: orthogonal wires with rounded corners, pins outside
+/// the body, inputs above outputs, no built-in pattern (the canvas is drawn
+/// by [`paint_canvas`]).
+pub fn snarl_style() -> SnarlStyle {
+    let mut s = SnarlStyle::new();
+    s.bg_frame = Some(egui::Frame::new().fill(CANVAS));
+    s.bg_pattern = Some(BackgroundPattern::NoPattern);
+    s.min_scale = Some(MIN_SCALE);
+    s.max_scale = Some(MAX_SCALE);
+    s.centering = Some(true);
+    s.wire_style = Some(WireStyle::AxisAligned { corner_radius: 8.0 });
+    s.wire_width = Some(2.6);
+    s.pin_placement = Some(PinPlacement::Outside { margin: 3.0 });
+    s.pin_size = Some(15.0);
+    s.node_layout = Some(NodeLayout::sandwich());
+    s
+}
+
+/// A node's frame: glass over the canvas, a hairline rim at rest, pink when
+/// chosen, the error colour when it carries diagnostics.
+pub fn node_frame(default: egui::Frame, selected: bool, trouble: bool) -> egui::Frame {
+    let frame = default.fill(NODE_FILL).corner_radius(NODE_CORNER);
+    if trouble {
+        frame.stroke(Stroke::new(2.0, ERROR))
+    } else if selected {
+        frame.stroke(Stroke::new(2.0, PINK))
+    } else {
+        frame.stroke(Stroke::new(1.0, RIM_BRIGHT))
+    }
+}
+
+/// A pin's colour: the kind's own hue at the palette's muted saturation and
+/// value; the kinds without a hue stay grey.
+pub fn pin_color(kind: ValueKind) -> Color32 {
+    let mut h = egui::ecolor::Hsva::from(crate::widgets::kind_color(kind));
+    if h.s < 0.15 {
+        return Color32::from_gray(110);
+    }
+    h.s = 0.5;
+    h.v = 0.5;
+    h.a = 1.0;
+    h.into()
+}
+
+/// A pin: a circle for an item, a square for a list, filled with its kind's colour.
+pub fn pin_info(kind: ValueKind, access: Access) -> PinInfo {
+    let info = match access {
+        Access::Item => PinInfo::circle(),
+        Access::List => PinInfo::square(),
+    };
+    info.with_fill(pin_color(kind))
+}
+
+/// The canvas behind the nodes: light, then the dot grid. `viewport` is the
+/// visible rect in graph space and `scale` the view's zoom.
+pub fn paint_canvas(painter: &egui::Painter, viewport: egui::Rect, scale: f32) {
+    if !viewport.is_finite() {
+        return;
+    }
+    ambience(painter, viewport, 3);
+    let scale = scale.max(0.001);
+    let mut spacing = DOT_SPACING;
+    while spacing * scale < 26.0 {
+        spacing *= 2.0;
+    }
+    let min_x = (viewport.min.x / spacing).floor() as i64;
+    let max_x = (viewport.max.x / spacing).ceil() as i64;
+    let min_y = (viewport.min.y / spacing).floor() as i64;
+    let max_y = (viewport.max.y / spacing).ceil() as i64;
+    if (max_x - min_x).saturating_mul(max_y - min_y) > 6500 {
+        return;
+    }
+    for xi in min_x..=max_x {
+        for yi in min_y..=max_y {
+            painter.circle_filled(egui::pos2(xi as f32 * spacing, yi as f32 * spacing), DOT_RADIUS, DOT_COLOR);
+        }
+    }
+}
+
+/// Three pools of light — violet, aqua, pink — anchored to the visible rect
+/// so the canvas stays evenly lit as it pans.
+pub fn ambience(painter: &egui::Painter, rect: egui::Rect, ring_alpha: u8) {
+    let d = rect.width().min(rect.height()).max(1.0);
+    for (fx, fy, fr, color) in [(0.12, 0.14, 0.46, VIOLET), (0.94, 0.38, 0.38, AQUA), (0.46, 0.97, 0.42, PINK)] {
+        light_pool(painter, rect.lerp_inside(egui::vec2(fx, fy)), d * fr, color, ring_alpha);
+    }
+}
+
+/// One pool of light: nested discs of a constant low alpha, largest first.
+fn light_pool(painter: &egui::Painter, center: egui::Pos2, radius: f32, color: Color32, ring_alpha: u8) {
+    const RINGS: usize = 16;
+    let fill = Color32::from_rgba_unmultiplied(color.r(), color.g(), color.b(), ring_alpha);
+    for i in 0..RINGS {
+        let t = 1.0 - i as f32 / RINGS as f32;
+        painter.circle_filled(center, radius * t, fill);
+    }
+}
+
+/// That app's visuals on the widgets inside the editor: a black page, glass
+/// panes with a cool rim, aqua hover, pink press and selection.
+pub fn apply_visuals(style: &mut egui::Style) {
+    let rgba = Color32::from_rgba_unmultiplied;
+    let mut v = egui::Visuals::dark();
+    v.override_text_color = Some(INK);
+    v.panel_fill = rgba(0, 0, 0, 232);
+    v.window_fill = rgba(19, 17, 30, 120);
+    v.window_stroke = Stroke::new(1.2, RIM);
+    v.faint_bg_color = Color32::from_rgb(11, 10, 16);
+    v.extreme_bg_color = Color32::from_rgb(8, 7, 13);
+    v.code_bg_color = Color32::from_rgb(6, 5, 10);
+    v.hyperlink_color = AQUA;
+    v.warn_fg_color = AQUA_BRIGHT;
+    v.error_fg_color = PINK;
+    v.selection.bg_fill = rgba(255, 61, 139, 140);
+    v.selection.stroke = Stroke::new(1.4, rgba(255, 110, 168, 255));
+    v.window_shadow = egui::epaint::Shadow { offset: [0, 2], blur: 12, spread: 2, color: rgba(0, 0, 0, 200) };
+    v.popup_shadow = egui::epaint::Shadow { offset: [0, 2], blur: 10, spread: 1, color: rgba(0, 0, 0, 170) };
+    v.window_corner_radius = CornerRadius::same(8);
+    v.menu_corner_radius = CornerRadius::same(8);
+    widget_palette(&mut v.widgets);
+    v.striped = true;
+    v.collapsing_header_frame = true;
+    v.indent_has_left_vline = true;
+    style.visuals = v;
+    style.spacing.item_spacing = egui::vec2(6.0, 6.0);
+    style.spacing.button_padding = egui::vec2(8.0, 6.0);
+}
+
+fn widget_palette(w: &mut egui::style::Widgets) {
+    let rgba = Color32::from_rgba_unmultiplied;
+    let text = INK;
+    let text_bright = Color32::from_rgb(248, 250, 252);
+    let radius = CornerRadius::same(5);
+    w.noninteractive.bg_fill = rgba(18, 16, 28, 132);
+    w.noninteractive.weak_bg_fill = rgba(14, 12, 22, 120);
+    w.noninteractive.bg_stroke = Stroke::new(1.0, RIM);
+    w.noninteractive.fg_stroke = Stroke::new(1.0, text);
+    w.noninteractive.corner_radius = radius;
+    w.inactive.bg_fill = rgba(31, 28, 47, 165);
+    w.inactive.weak_bg_fill = rgba(25, 23, 38, 150);
+    w.inactive.bg_stroke = Stroke::new(1.0, RIM_BRIGHT);
+    w.inactive.fg_stroke = Stroke::new(1.0, text);
+    w.inactive.corner_radius = radius;
+    w.hovered.bg_fill = rgba(43, 226, 214, 42);
+    w.hovered.weak_bg_fill = rgba(43, 226, 214, 42);
+    w.hovered.bg_stroke = Stroke::new(1.5, rgba(43, 226, 214, 240));
+    w.hovered.fg_stroke = Stroke::new(1.5, text_bright);
+    w.hovered.corner_radius = radius;
+    w.active.bg_fill = rgba(255, 61, 139, 54);
+    w.active.weak_bg_fill = rgba(255, 61, 139, 54);
+    w.active.bg_stroke = Stroke::new(1.7, rgba(255, 61, 139, 245));
+    w.active.fg_stroke = Stroke::new(2.0, Color32::WHITE);
+    w.active.corner_radius = radius;
+    w.open.bg_fill = rgba(31, 28, 47, 165);
+    w.open.weak_bg_fill = rgba(25, 23, 38, 150);
+    w.open.bg_stroke = Stroke::new(1.3, rgba(43, 226, 214, 205));
+    w.open.fg_stroke = Stroke::new(1.0, text);
+    w.open.corner_radius = radius;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_style_is_the_comfyui_one() {
+        let s = snarl_style();
+        assert!(matches!(s.wire_style, Some(WireStyle::AxisAligned { corner_radius }) if corner_radius == 8.0));
+        assert!(matches!(s.pin_placement, Some(PinPlacement::Outside { margin }) if margin == 3.0));
+        assert_eq!((s.pin_size, s.wire_width, s.min_scale, s.max_scale), (Some(15.0), Some(2.6), Some(MIN_SCALE), Some(MAX_SCALE)));
+        assert!(matches!(s.bg_pattern, Some(BackgroundPattern::NoPattern)));
+        assert!(s.node_layout.is_some());
+        assert_eq!(s.bg_frame.unwrap().fill, CANVAS);
+    }
+
+    #[test]
+    fn pins_keep_their_kind_but_wear_the_palette() {
+        assert_ne!(pin_color(ValueKind::Number), pin_color(ValueKind::Layer));
+        let h = egui::ecolor::Hsva::from(pin_color(ValueKind::Design));
+        assert!((h.s - 0.5).abs() < 0.05 && (h.v - 0.5).abs() < 0.05, "{h:?}");
+        assert_eq!(pin_color(ValueKind::Any), Color32::from_gray(110));
+    }
+
+    #[test]
+    fn frames_read_their_state() {
+        let d = egui::Frame::new();
+        assert_eq!(node_frame(d, true, false).stroke.color, PINK);
+        assert_eq!(node_frame(d, true, true).stroke.color, ERROR, "trouble outranks selection");
+        let rest = node_frame(d, false, false);
+        assert_eq!((rest.stroke.color, rest.fill), (RIM_BRIGHT, NODE_FILL));
+    }
+
+    #[test]
+    fn the_visuals_are_pink_and_aqua_on_black() {
+        let mut style = egui::Style::default();
+        apply_visuals(&mut style);
+        let v = &style.visuals;
+        assert_eq!(v.override_text_color, Some(INK));
+        assert_eq!(v.selection.bg_fill, Color32::from_rgba_unmultiplied(255, 61, 139, 140));
+        assert_eq!(v.hyperlink_color, AQUA);
+        assert_eq!(v.widgets.hovered.bg_stroke.color, Color32::from_rgba_unmultiplied(43, 226, 214, 240));
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -180,6 +180,8 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - Shelf: stone spacing map SVG; march instances along a guide path; blue-noise scatter
   generator; mm-true mask morphology; alpha granulometry; nesting-depth stepped relief; honest
   rope rail; `stones::probe_seat`; pearl stock; flat-edged seat plans.
+- [x] The graph editor in the comfyui-android look (#87): `ringdesign_graph_ui::style`, shared by the
+  desktop pane and the phone tab.
 - Niceties: gate & sprue advisor; DPI true-scale; reference-mesh import + deviation report as a
   core feature (the exact point-to-triangle measure and the crease census, today script-only);
   comparison views beyond the ghost.


### PR DESCRIPTION
Closes #87

- `ringdesign_graph_ui::style`: the comfyui-android graph view's look, number for number — AMOLED canvas with the three light pools and the graph-space dot grid, glass node fill under a white hairline rim (pink when selected, the error colour with diagnostics), axis-aligned wires at 2.6 px with 8 px corners, 15 px pins 3 px outside the body, sandwich layout, kind-coloured pins at the palette's muted saturation and value, plain-ink labels, and that app's visuals applied inside the editor's scope only. Shared by the desktop pane and the phone tab.
- Arrange now lays out from measured node sizes with that app's gaps and settles over up to three passes (snarl's first frame measures a node before its widgets settle; the first layout overlapped), reporting the move as a change so the design's positions follow; fit and the minimap read the same measured bounds; the minimap sits top-left in that app's colours.
- `--features shot` + `RD_GRAPH_SHOT=/dir` renders the editor offscreen through wgpu to a PNG; kept behind a feature because wgpu unifies `egui/bytemuck` into the whole UI stack and costs every build a rebuild.
- Not carried: the frosted-glass blur behind nodes (the phone's backdrop-blur grab pass) and header-only dragging — both noted in CLAUDE.md.

Verified by looking at the rendered editor; full guarded suite green (core 321, graph-ui 10); phone host tests 44 and `cargo ndk check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)