### PR TITLE
Alpha granulometry: the DFM reads the textures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -986,7 +986,22 @@ pins both directions. On top of that:
 - **Per-layer DFM** (`dfm.rs`): layers are analytic, so their finest feature
   is a parameter, not a measurement — `feature_footprints` against
   `min_detail_mm`, surfaced as warning badges on the layer rows, in the
-  report notes, and on MCP as `castability.dfm`.
+  report notes, and on MCP as `castability.dfm`. A texture is the
+  exception: a tiling's cell pitch says nothing about the strokes inside
+  it, so `findings_in(design, lib)` — what every app surface calls — also
+  reads each tiling's and openwork's mask by **granulometry**
+  (`Alpha::min_feature_px`: the opening diameter at which a tenth of the
+  ink, and of the gaps, disappears, bisected over the radius on the
+  distance field, 3×3-tiled so a seamless mask reads seamless, cached by
+  content) at the layer's own mm-per-texel, after the layer's
+  contrast/bias/invert shaping. Greek Key on 2.7 mm cells passes the
+  pitch check and measures 0.06 mm strokes — that is the finding. Run on
+  the shipped templates (`dfm::measured_tests::the_templates_measured`,
+  `--nocapture`) it names three: Waves at 0.10 mm strokes on the waved
+  hexagon signet's 11.8 × 1.8 mm cells, Chevron at 0.07 mm gaps on the
+  shouldered cushion's shoulders, Braid at 0.04 mm gaps on the braided
+  band — all castable by the field, all casting softer than drawn, which
+  is what the chip now says instead of nothing.
 - **Undercut attribution** (`castability::attribute_undercuts`): undercut
   arcs are clustered in theta off the field samples, then each enabled layer
   is muted in turn at the *same parting plane* — the culprit is the layer

--- a/crates/ringdesign-configurator/src/main.rs
+++ b/crates/ringdesign-configurator/src/main.rs
@@ -295,7 +295,7 @@ fn order_files(cfg: &Config, p: &OrderParams) -> anyhow::Result<Vec<(&'static st
     let out = ringdesign_core::mesh::build(&d, &lib, p.build);
     let field = ringdesign_core::castability::attributed_field_report(&d, &lib, &d.draft, 192, 128);
     let stones = ringdesign_core::stones::report(&d, field.parting_z_mm);
-    let dfm = ringdesign_core::dfm::findings(&d);
+    let dfm = ringdesign_core::dfm::findings_in(&d, &lib);
     let sheet = ringdesign_core::spec::html(
         &d,
         &out.report,

--- a/crates/ringdesign-core/src/alpha.rs
+++ b/crates/ringdesign-core/src/alpha.rs
@@ -462,6 +462,93 @@ impl Alpha {
     }
 }
 
+impl Alpha {
+    /// The finest features in the mask, in pixels, as `(ink, gap)`: the
+    /// diameter of the smallest strokes and of the smallest gaps between
+    /// them, each read as the opening diameter at which a tenth of that
+    /// phase's area disappears — granulometry on the distance field,
+    /// bisected over the radius, on a 3x3 tiling so a seamless mask reads
+    /// seamless. `None` for an empty or single-phase mask. Cached by content.
+    pub fn min_feature_px(&self) -> Option<(f64, f64)> {
+        use std::collections::HashMap;
+        use std::hash::{Hash, Hasher};
+        use std::sync::{Mutex, OnceLock};
+        static CACHE: OnceLock<Mutex<HashMap<u64, Option<(f64, f64)>>>> = OnceLock::new();
+        if self.is_empty() {
+            return None;
+        }
+        let mut h = std::hash::DefaultHasher::new();
+        (self.width, self.height).hash(&mut h);
+        for v in &self.data {
+            v.to_bits().hash(&mut h);
+        }
+        let key = h.finish();
+        let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        if let Some(hit) = cache.lock().ok().and_then(|c| c.get(&key).copied()) {
+            return hit;
+        }
+        let got = self.measure_features();
+        if let Ok(mut c) = cache.lock() {
+            if c.len() > 512 {
+                c.clear();
+            }
+            c.insert(key, got);
+        }
+        got
+    }
+
+    fn measure_features(&self) -> Option<(f64, f64)> {
+        const LOST: f64 = 0.10;
+        let (w, h) = (self.width, self.height);
+        let (bw, bh) = (w * 3, h * 3);
+        let ink: Vec<bool> = (0..bw * bh).map(|i| self.data[(i / bw % h) * w + (i % bw % w)] >= 0.5).collect();
+        let n_ink = ink.iter().filter(|&&b| b).count();
+        if n_ink == 0 || n_ink == ink.len() {
+            return None;
+        }
+        let dist_to = |set: &[bool]| -> Vec<f32> {
+            let mut g: Vec<f32> = set.iter().map(|&b| if b { 0.0 } else { 1e12 }).collect();
+            edt_squared(&mut g, bw, bh);
+            g.iter_mut().for_each(|v| *v = v.sqrt());
+            g
+        };
+        let ground: Vec<bool> = ink.iter().map(|&b| !b).collect();
+        let d_ink = dist_to(&ground);
+        let d_ground = dist_to(&ink);
+        // Share of a phase (centre tile) that an opening by disc radius r removes.
+        let loss = |phase: &[bool], d: &[f32], r: f32| -> f64 {
+            let eroded: Vec<bool> = d.iter().map(|&v| v >= r).collect();
+            let back = dist_to(&eroded);
+            let (mut lost, mut all) = (0usize, 0usize);
+            for y in h..2 * h {
+                for x in w..2 * w {
+                    let i = y * bw + x;
+                    if phase[i] {
+                        all += 1;
+                        if back[i] > r {
+                            lost += 1;
+                        }
+                    }
+                }
+            }
+            if all == 0 { 1.0 } else { lost as f64 / all as f64 }
+        };
+        let feature = |phase: &[bool], d: &[f32]| -> f64 {
+            let r_max = (w.min(h) as f32) * 0.5;
+            if loss(phase, d, r_max) < LOST {
+                return 2.0 * r_max as f64;
+            }
+            let (mut lo, mut hi) = (0.0f32, r_max);
+            while hi - lo > 0.25 {
+                let mid = 0.5 * (lo + hi);
+                if loss(phase, d, mid) >= LOST { hi = mid } else { lo = mid }
+            }
+            2.0 * hi as f64
+        };
+        Some((feature(&ink, &d_ink), feature(&ground, &d_ground)))
+    }
+}
+
 /// Library name a mask's derived signed-distance field lands under.
 pub fn sdf_name(name: &str) -> String {
     format!("{name}##sdf")
@@ -2786,3 +2873,22 @@ impl Alpha {
 
 }
 
+#[cfg(test)]
+mod feature_tests {
+    use super::*;
+
+    #[test]
+    fn stripes_measure_their_own_width_and_gap() {
+        let n = 64;
+        let data: Vec<f32> = (0..n * n).map(|i| if (i % n) % 16 < 4 { 1.0 } else { 0.0 }).collect();
+        let a = Alpha::new("stripes", n, n, data);
+        let (ink, gap) = a.min_feature_px().unwrap();
+        assert!((ink - 4.0).abs() <= 1.0, "ink {ink}");
+        assert!((gap - 12.0).abs() <= 2.0, "gap {gap}");
+        let blank = Alpha::new("blank", 8, 8, vec![0.0; 64]);
+        assert!(blank.min_feature_px().is_none());
+        let disc: Vec<f32> = (0..n * n).map(|i| { let (x, y) = ((i % n) as f64 - 32.0, (i / n) as f64 - 32.0); if x * x + y * y < 100.0 { 1.0 } else { 0.0 } }).collect();
+        let (ink, _) = Alpha::new("disc", n, n, disc).min_feature_px().unwrap();
+        assert!((ink - 20.0).abs() <= 2.0, "a 20 px disc: {ink}");
+    }
+}

--- a/crates/ringdesign-core/src/dfm.rs
+++ b/crates/ringdesign-core/src/dfm.rs
@@ -17,6 +17,64 @@ pub struct DfmFinding {
     pub message: String,
 }
 
+/// [`findings`] plus what the textures measure: a tiling's or openwork's
+/// mask read by granulometry ([`crate::alpha::Alpha::min_feature_px`]) at
+/// the layer's own cell scale, so a fine-lined alpha on coarse cells is
+/// still caught. The analytic check sees only the cell pitch.
+pub fn findings_in(design: &RingDesign, lib: &crate::AlphaLibrary) -> Vec<DfmFinding> {
+    let mut out = findings(design);
+    let ctx = design.field_context();
+    let min = design.draft.min_detail_mm.max(0.0);
+    if min <= 0.0 {
+        return out;
+    }
+    fn tilings<'a>(stack: &'a crate::field::LayerStack, out: &mut Vec<&'a crate::tiling::TilingLayer>) {
+        for e in stack.layers.iter().filter(|e| e.enabled) {
+            match &e.layer {
+                Layer::Tiling(t) => out.push(t),
+                Layer::Openwork(o) => out.push(&o.tiling),
+                Layer::Group(g) => tilings(&g.stack, out),
+                _ => {}
+            }
+        }
+    }
+    for (i, entry) in design.layers.layers.iter().enumerate() {
+        if !entry.enabled || out.iter().any(|f| f.layer == i) {
+            continue;
+        }
+        let mut ts = Vec::new();
+        let one = crate::field::LayerStack { layers: vec![entry.clone()] };
+        tilings(&one, &mut ts);
+        for t in ts {
+            let Some(alpha) = lib.get(&t.alpha) else { continue };
+            let shaped = if t.invert || (t.contrast - 1.0).abs() > 1e-9 || t.bias.abs() > 1e-9 {
+                let data = alpha.data.iter().map(|&v| alpha.shaped(v, t.contrast, t.bias, t.invert) as f32).collect();
+                crate::alpha::Alpha::new(format!("{} shaped", alpha.name), alpha.width, alpha.height, data)
+            } else {
+                alpha.clone()
+            };
+            let Some((ink_px, gap_px)) = shaped.min_feature_px() else { continue };
+            let (cw, ch) = t.cell_size(&ctx);
+            let scale = (cw / alpha.width.max(1) as f64).min(ch / alpha.height.max(1) as f64);
+            let (ink, gap) = (ink_px * scale, gap_px * scale);
+            let (what, finest) = if ink <= gap { ("strokes", ink) } else { ("gaps", gap) };
+            if finest >= min {
+                continue;
+            }
+            out.push(DfmFinding {
+                layer: i,
+                label: entry.name.clone(),
+                message: format!(
+                    "the {} texture's finest {what} measure {finest:.2} mm on {cw:.1} x {ch:.1} mm cells against the sand's {min:.2} mm floor — they will cast as mush. Coarsen the pattern, use fewer repeats, or accept the softness.",
+                    t.alpha
+                ),
+            });
+            break;
+        }
+    }
+    out
+}
+
 /// Every enabled layer whose finest feature the sand cannot hold.
 pub fn findings(design: &RingDesign) -> Vec<DfmFinding> {
     let ctx = design.field_context();
@@ -101,5 +159,47 @@ mod tests {
         let f = findings(&d);
         assert_eq!(f.len(), 1, "{f:?}");
         assert!(f[0].message.contains("tile cells"));
+    }
+}
+
+#[cfg(test)]
+mod measured_tests {
+    use super::*;
+    use crate::field::LayerEntry;
+    use crate::tiling::TilingLayer;
+
+    #[test]
+    fn a_fine_lined_texture_on_honest_cells_is_caught_by_the_measure() {
+        let lib = crate::AlphaLibrary::builtin();
+        let mut d = RingDesign::default();
+        let ctx = d.field_context();
+        let mut t = TilingLayer::default_for("Greek Key", &ctx);
+        t.repeats_around = 12;
+        t.rows = 1;
+        t.v_center_mm = ctx.crest_v_mm;
+        t.v_span_mm = 2.0;
+        d.layers.layers.push(LayerEntry::new("Key", Layer::Tiling(t)));
+        let (cw, _) = match &d.layers.layers[0].layer { Layer::Tiling(t) => t.cell_size(&ctx), _ => unreachable!() };
+        assert!(cw > 2.0, "cells are coarser than the floor: {cw}");
+        assert!(findings(&d).is_empty(), "the cell pitch alone passes");
+        let measured = findings_in(&d, &lib);
+        assert_eq!(measured.len(), 1, "{measured:?}");
+        assert!(measured[0].message.contains("Greek Key"), "{}", measured[0].message);
+        d.draft.min_detail_mm = 0.0;
+        assert!(findings_in(&d, &lib).is_empty(), "no floor, no finding");
+    }
+
+    /// What the measure says about the shipped templates, printed under
+    /// `--nocapture`; the analytic check stays clean on all of them.
+    #[test]
+    fn the_templates_measured() {
+        let lib = crate::AlphaLibrary::builtin();
+        for t in crate::templates::all() {
+            let d = t.design();
+            assert!(findings(&d).is_empty(), "{}: {:?}", t.name, findings(&d));
+            for f in findings_in(&d, &lib) {
+                eprintln!("{}: {} — {}", t.name, f.label, f.message);
+            }
+        }
     }
 }

--- a/crates/ringdesign-core/src/spec.rs
+++ b/crates/ringdesign-core/src/spec.rs
@@ -233,7 +233,7 @@ mod tests {
         );
         let field = crate::castability::analyze_field(&d, &lib, &d.draft, 96, 64);
         let stones = crate::stones::report(&d, field.parting_z_mm);
-        let dfm = crate::dfm::findings(&d);
+        let dfm = crate::dfm::findings_in(&d, &lib);
         let page = html(&d, &out.report, &field, stones.as_ref(), &dfm, "test build");
 
         assert!(page.contains("Logan's &lt;Heart&gt; &amp; Band"));

--- a/crates/ringdesign-graph/src/nodes/sink.rs
+++ b/crates/ringdesign-graph/src/nodes/sink.rs
@@ -211,9 +211,10 @@ fn castability_stones(d: &RingDesign, parting: f64) -> StonesReport {
     ringdesign_core::stones::report(d, parting).unwrap_or_default()
 }
 
-fn dfm_findings(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
+fn dfm_findings(ctx: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
     let d = design_of(i, "design")?;
-    let f = dfm::findings(&d);
+    let lib = baked(&d, ctx.lib);
+    let f = dfm::findings_in(&d, &lib);
     let items: Vec<Value> = f
         .iter()
         .map(|x| Value::Json(Arc::new(serde_json::json!({"layer": x.layer, "label": x.label, "message": x.message}))))
@@ -240,7 +241,7 @@ fn sheet(ctx: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeErr
         Value::Stones(s) => Some((**s).clone()),
         _ => ringdesign_core::stones::report(&d, field.parting_z_mm),
     };
-    let findings = dfm::findings(&d);
+    let findings = dfm::findings_in(&d, &lib);
     let html = spec::html(&d, &report, &field, stones.as_ref(), &findings, i.text("provenance")?);
     Ok(Outputs::one("html", html))
 }

--- a/crates/ringdesign-gui/src/export.rs
+++ b/crates/ringdesign-gui/src/export.rs
@@ -272,7 +272,7 @@ pub fn export_spec(app: &mut RingDesignerApp) {
             128,
         );
         let stones = ringdesign_core::stones::report(&job.design, field.parting_z_mm);
-        let dfm = ringdesign_core::dfm::findings(&job.design);
+        let dfm = ringdesign_core::dfm::findings_in(&job.design, &job.lib);
         let provenance = format!(
             "RingDesigner {} • {} x {} sweep",
             env!("CARGO_PKG_VERSION"),

--- a/crates/ringdesign-gui/src/panels/layers.rs
+++ b/crates/ringdesign-gui/src/panels/layers.rs
@@ -355,7 +355,7 @@ fn list(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
 
     let mut action: Option<Action> = None;
     let mut dirty = false;
-    let dfm = ringdesign_core::dfm::findings(&app.design);
+    let dfm = ringdesign_core::dfm::findings_in(&app.design, &app.lib);
 
     for i in 0..n {
         let selected = app.selected_layer == Some(i);

--- a/crates/ringdesign-gui/src/panels/report.rs
+++ b/crates/ringdesign-gui/src/panels/report.rs
@@ -25,7 +25,7 @@ pub fn ui(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
     let already_draft =
         app.panes[pane].shade == ShadeMode::Draft && app.panes[pane].kind == PaneKind::Solid;
     let mut want_draft = false;
-    let dfm = ringdesign_core::dfm::findings(&app.design);
+    let dfm = ringdesign_core::dfm::findings_in(&app.design, &app.lib);
     match app.cast.as_ref() {
         Some(cast) => {
             want_draft = castability(

--- a/crates/ringdesign-mcp/src/tools.rs
+++ b/crates/ringdesign-mcp/src/tools.rs
@@ -2250,7 +2250,7 @@ impl RingDesignServer {
         let stones =
             ringdesign_core::stones::report(e.design(), cast.parting_z_mm).map(|r| stones_json(&r));
         let field = field_json(&e.field_report());
-        let dfm = ringdesign_core::dfm::findings(e.design())
+        let dfm = ringdesign_core::dfm::findings_in(e.design(), e.library())
             .into_iter()
             .map(|f| format!("{}: {}", f.label, f.message))
             .collect();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -177,9 +177,11 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   their union, the crest on the parting plane, Split's side-face seam.
 - [x] Gallery/hollow underside (M–L, #85): `SignetHead::hollow_mm`, a scoop from the finger hole
   into the head's belly carried as `ShankMod::bore_lift_mm`; the bore is a vertical wall at any radius.
+- [x] Alpha granulometry (#90): `Alpha::min_feature_px` and `dfm::findings_in` — the measured
+  finest stroke and gap of a texture at the layer's cell scale, against the sand floor.
 - Shelf: stone spacing map SVG; march instances along a guide path; blue-noise scatter
-  generator; mm-true mask morphology; alpha granulometry; nesting-depth stepped relief; honest
-  rope rail; `stones::probe_seat`; pearl stock; flat-edged seat plans.
+  generator; mm-true mask morphology; nesting-depth stepped relief; honest rope rail;
+  `stones::probe_seat`; pearl stock; flat-edged seat plans.
 - [x] The graph editor in the comfyui-android look (#87): `ringdesign_graph_ui::style`, shared by the
   desktop pane and the phone tab.
 - Niceties: gate & sprue advisor; DPI true-scale; reference-mesh import + deviation report as a


### PR DESCRIPTION
Closes #90

- `Alpha::min_feature_px` → `(ink, gap)` in pixels: the opening diameter at which a tenth of the ink, and of the gaps, disappears — granulometry on the exact distance field, bisected over the radius, on a 3×3 tiling so seamless masks read seamless, cached by content hash.
- `dfm::findings_in(design, lib)`: the analytic findings plus a measured one for every tiling and openwork (groups walked) whose strokes or gaps, at the layer's own mm-per-texel and after its contrast/bias/invert shaping, fall under `min_detail_mm`. The GUI report and layer panels, the export sheet, MCP, the graph's dfm and sheet sinks, the configurator and the phone all call it.
- Tests: synthetic stripes measure 4 px strokes / 12 px gaps, a 20 px disc measures 20; Greek Key on 2.7 mm cells passes the pitch check and is caught by the measure; a probe over the shipped templates names three (Waves 0.10 mm strokes, Chevron 0.07 mm gaps, Braid 0.04 mm gaps) — castable by the field, softer than drawn, now said in the chip.

Full guarded suite green (core 324); phone host tests and `cargo ndk check` clean (EguiMobile `a6c9cab`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)