### PR TITLE
The stone spacing map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1195,6 +1195,14 @@ emits one line per distinct seat.
   dimensions, weight in every alloy with its pattern scale, the field
   verdict with notes and DFM findings, the stones table with bench warnings,
   provenance. Desktop File menu and the Android share sheet both emit it.
+- **The stone map** (`stonemap.rs`): the setter's sheet — every stone the
+  design sets drawn to scale at 2:1, in plan (each girdle projected onto
+  the ring's plane from the census's own `StoneFrame`) and on the band
+  unrolled (each plan at its chart bearing), labelled with its size, with
+  the census's tight pairs drawn in red between the stones and the gap
+  that decides written on the line. File > Stone map…, MCP
+  `export_stone_map`, CLI `--formats stonemap`, the phone's Share menu.
+  Refuses a design that sets no stones.
 - **The parting line** (`castability::parting_line`): the widest surface
   point per slice — where the sand parts — exported as a printable SVG
   (plan view plus the line's height unrolled, File > Parting line…).

--- a/crates/ringdesign-cli/src/main.rs
+++ b/crates/ringdesign-cli/src/main.rs
@@ -47,7 +47,7 @@ const USAGE: &str = "usage:
 
 options:
   --sizes 5:9:0.5 | 6,7,8   sizes to run (default: the design's own)
-  --formats stl,obj,3mf,glb,ply   files per size (default: stl)
+  --formats stl,obj,3mf,glb,ply,stonemap   files per size (default: stl); stonemap is the setter's SVG
   --shrink <metal>          cut patterns oversize for this metal's shrink
                             (sterling, bronze, 14k, ... — see the app's table)
   --out <dir>               output directory (default: beside the design)
@@ -130,8 +130,8 @@ fn export(
             "--formats" => {
                 formats = value()?.split(',').map(|s| s.trim().to_lowercase()).collect();
                 for f in &formats {
-                    if !matches!(f.as_str(), "stl" | "obj" | "3mf" | "glb" | "ply") {
-                        anyhow::bail!("unknown format {f:?} (stl, obj, 3mf, glb, ply)");
+                    if !matches!(f.as_str(), "stl" | "obj" | "3mf" | "glb" | "ply" | "stonemap") {
+                        anyhow::bail!("unknown format {f:?} (stl, obj, 3mf, glb, ply, stonemap)");
                     }
                 }
             }
@@ -197,8 +197,16 @@ fn export(
                 }
                 None => String::new(),
             };
-            let file = out_dir.join(format!("{slug}_size{}{}.{fmt}", fmt_size(size), tag));
+            let file = if fmt == "stonemap" {
+                out_dir.join(format!("{slug}_size{}_stones.svg", fmt_size(size)))
+            } else {
+                out_dir.join(format!("{slug}_size{}{}.{fmt}", fmt_size(size), tag))
+            };
             let bytes = match fmt.as_str() {
+                "stonemap" => {
+                    let stones = stones::report(&d, f.parting_z_mm);
+                    ringdesign_core::stonemap::write_stone_map_svg(&file, &d, stones.as_ref())?
+                }
                 "stl" => stl::write_stl(&file, &mesh, &name)?,
                 "obj" => stl::write_obj(&file, &mesh, &name)?,
                 "glb" => ringdesign_core::gltf::write_glb(&file, &mesh, &name, ringdesign_core::render::GOLD)?,

--- a/crates/ringdesign-core/src/lib.rs
+++ b/crates/ringdesign-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod setstone;
 pub mod sizing;
 pub mod spec;
 pub mod stl;
+pub mod stonemap;
 pub mod stones;
 pub mod svg;
 pub mod templates;

--- a/crates/ringdesign-core/src/stonemap.rs
+++ b/crates/ringdesign-core/src/stonemap.rs
@@ -1,0 +1,200 @@
+//! The stone spacing map: every stone the design sets, printed to scale —
+//! plan view and the unrolled chart — with the census's tight gaps drawn
+//! between the pairs the setter has to watch.
+
+use crate::field::wrap_delta;
+use crate::stones::StonesReport;
+use crate::RingDesign;
+
+/// Drawn at this magnification; the title says so.
+const K: f64 = 2.0;
+const PAD: f64 = 4.0;
+
+/// The map as SVG text, or `None` when the design sets no stones.
+pub fn stone_map_svg(design: &RingDesign, report: Option<&StonesReport>) -> Option<String> {
+    let frames = crate::stones::stone_frames(design);
+    if frames.is_empty() {
+        return None;
+    }
+    let ctx = design.field_context();
+    let r_out = frames
+        .iter()
+        .map(|(_, f)| f.girdle[0].hypot(f.girdle[1]) + f.reach)
+        .fold(ctx.crest_radius_mm, f64::max)
+        + 1.0;
+    let plan = 2.0 * r_out * K;
+    let chart_w = ctx.circumference_mm * K;
+    let chart_h = ctx.band_v_len_mm * K;
+    let legend_h = 14.0;
+    let w = plan.max(chart_w) + 2.0 * PAD;
+    let h = plan + chart_h + legend_h + 4.0 * PAD;
+    let esc = |t: &str| t.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;");
+    let mut s = String::with_capacity(frames.len() * 400 + 2048);
+    s.push_str(&format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{w:.1}mm\" height=\"{h:.1}mm\" viewBox=\"0 0 {w:.2} {h:.2}\" font-family=\"sans-serif\">\n<title>{} stone map, drawn 2:1 (mm)</title>\n",
+        esc(&design.name)
+    ));
+    // Plan view: the crest and bore circles, every stone drawn face-on at
+    // its position — a bench map, not a projection: a crest-set stone seen
+    // down the finger is an edge, which tells the setter nothing.
+    let (cx, cy) = (w * 0.5, PAD + r_out * K);
+    s.push_str(&format!("<circle cx=\"{cx:.2}\" cy=\"{cy:.2}\" r=\"{:.2}\" fill=\"none\" stroke=\"#888\" stroke-width=\"0.2\"/>\n", ctx.crest_radius_mm * K));
+    s.push_str(&format!("<circle cx=\"{cx:.2}\" cy=\"{cy:.2}\" r=\"{:.2}\" fill=\"none\" stroke=\"#888\" stroke-width=\"0.15\" stroke-dasharray=\"1,1\"/>\n", design.inner_radius_mm() * K));
+    for (st, f) in &frames {
+        let (sin_t, cos_t) = st.theta_deg.to_radians().sin_cos();
+        let (tangent, radial) = ([-sin_t, cos_t], [cos_t, sin_t]);
+        let (rs, rc) = st.rot_deg().to_radians().sin_cos();
+        s.push_str("<path class=\"stone\" fill=\"#dfe\" stroke=\"black\" stroke-width=\"0.2\" d=\"");
+        for k in 0..=48 {
+            let t = k as f64 / 48.0 * std::f64::consts::TAU;
+            let (a, b) = superellipse(t, f.semi.0, f.semi.1, f.plan_pow);
+            // The long axis lies along the ring at the seat's bearing.
+            let (along, across) = (a * rc - b * rs, a * rs + b * rc);
+            let p = [
+                f.girdle[0] + tangent[0] * along + radial[0] * across,
+                f.girdle[1] + tangent[1] * along + radial[1] * across,
+            ];
+            s.push_str(&format!("{}{:.2},{:.2} ", if k == 0 { 'M' } else { 'L' }, cx + p[0] * K, cy - p[1] * K));
+        }
+        s.push_str("Z\"/>\n");
+    }
+    // The chart: u around the ring, v across the band, every stone's plan at its bearing.
+    let (x0, y0) = (PAD, PAD + plan + PAD);
+    s.push_str(&format!("<rect x=\"{x0:.2}\" y=\"{y0:.2}\" width=\"{chart_w:.2}\" height=\"{chart_h:.2}\" fill=\"none\" stroke=\"#888\" stroke-width=\"0.2\"/>\n"));
+    let centre = |st: &crate::setstone::SetStone| -> (f64, f64) {
+        (x0 + ctx.u_of_theta(st.theta_deg.rem_euclid(360.0)) * K, y0 + st.v_mm * K)
+    };
+    // One label per family: a pad of its own, a run, or a group's seats —
+    // sixteen identical labels on a row collide into nothing.
+    let family = |st: &crate::setstone::SetStone| -> String {
+        match st.source {
+            crate::setstone::StoneSource::Run { .. } => st.label.clone(),
+            crate::setstone::StoneSource::Pad => match st.label.rsplit_once(" / ") {
+                Some((group, _)) => group.to_string(),
+                None => format!("{}@{:.1}", st.label, st.theta_deg),
+            },
+        }
+    };
+    let mut labelled: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (st, f) in &frames {
+        let (cxs, cys) = centre(st);
+        let (rs, rc) = st.rot_deg().to_radians().sin_cos();
+        s.push_str("<path class=\"stone\" fill=\"#dfe\" stroke=\"black\" stroke-width=\"0.2\" d=\"");
+        for k in 0..=48 {
+            let t = k as f64 / 48.0 * std::f64::consts::TAU;
+            let (a, b) = superellipse(t, f.semi.0, f.semi.1, f.plan_pow);
+            let (x, y) = (a * rc - b * rs, a * rs + b * rc);
+            s.push_str(&format!("{}{:.2},{:.2} ", if k == 0 { 'M' } else { 'L' }, cxs + x * K, cys + y * K));
+        }
+        s.push_str("Z\"/>\n");
+        let key = family(st);
+        let text = if labelled.insert(key.clone()) {
+            let n = frames.iter().filter(|(o, _)| family(o) == key).count();
+            let name = key.split('@').next().unwrap_or(&key);
+            Some(if n > 1 { format!("{name} x{n} {:.1}", st.gem.w_mm) } else { format!("{name} {:.1}", st.gem.w_mm) })
+        } else {
+            None
+        };
+        if let Some(text) = text {
+            // Kept inside the chart: a label's centre is its stone, unless
+            // that would run it off an edge.
+            let half = 0.45 * 1.6 * text.chars().count() as f64;
+            let x = cxs.clamp(x0 + half, (x0 + chart_w - half).max(x0 + half));
+            s.push_str(&format!(
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-size=\"1.6\" text-anchor=\"middle\">{}</text>\n",
+                x,
+                cys + f.semi.1 * K + 2.0,
+                esc(&text)
+            ));
+        }
+    }
+    // The census's tight pairs, drawn between the two stones with the gap that decides.
+    if let Some(r) = report {
+        for pair in &r.crowding {
+            let find = |label: &str, theta: f64| frames.iter().find(|(st, _)| st.label == label && wrap_delta(st.theta_deg - theta, 360.0).abs() < 0.5);
+            let (Some((a, _)), Some((b, _))) = (find(&pair.a, pair.a_theta_deg), find(&pair.b, pair.b_theta_deg)) else { continue };
+            let (ax, ay) = centre(a);
+            let (bx, by) = centre(b);
+            s.push_str(&format!("<line class=\"gap\" x1=\"{ax:.2}\" y1=\"{ay:.2}\" x2=\"{bx:.2}\" y2=\"{by:.2}\" stroke=\"#c33\" stroke-width=\"0.3\"/>\n"));
+            s.push_str(&format!(
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-size=\"1.6\" fill=\"#c33\" text-anchor=\"middle\">gap {:.2} mm</text>\n",
+                (ax + bx) * 0.5,
+                (ay + by) * 0.5 - 1.0,
+                pair.worst_mm()
+            ));
+        }
+    }
+    // Legend.
+    let carats: f64 = frames.iter().map(|(st, _)| st.carats()).sum();
+    let yl = y0 + chart_h + PAD + 4.0;
+    s.push_str(&format!(
+        "<text x=\"{PAD:.2}\" y=\"{yl:.2}\" font-size=\"2.4\">{} — size {} — {} stones, {:.2} ct — drawn 2:1, mm</text>\n",
+        esc(&design.name),
+        design.size.display(),
+        frames.len(),
+        carats
+    ));
+    s.push_str(&format!(
+        "<text x=\"{PAD:.2}\" y=\"{:.2}\" font-size=\"1.8\">plan view above, the band unrolled below (u around the ring, v across); red lines are gaps under the sand's {:.2} mm fill floor</text>\n",
+        yl + 3.5,
+        design.draft.min_section_mm
+    ));
+    s.push_str("</svg>\n");
+    Some(s)
+}
+
+/// A superellipse point at parameter `t`, semi-axes `a` (long) and `b`.
+fn superellipse(t: f64, a: f64, b: f64, n: f64) -> (f64, f64) {
+    let (st, ct) = t.sin_cos();
+    let e = 2.0 / n.max(1.0);
+    (a * ct.signum() * ct.abs().powf(e), b * st.signum() * st.abs().powf(e))
+}
+
+/// Writes the map; an error when the design sets no stones.
+pub fn write_stone_map_svg(path: impl AsRef<std::path::Path>, design: &RingDesign, report: Option<&StonesReport>) -> anyhow::Result<usize> {
+    let svg = stone_map_svg(design, report).ok_or_else(|| anyhow::anyhow!("the design sets no stones"))?;
+    std::fs::write(path, svg.as_bytes())?;
+    Ok(svg.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::{Layer, LayerEntry, SeatPadLayer, SeatRunLayer};
+    use crate::gem::{Gem, GemCut};
+
+    #[test]
+    fn the_map_draws_every_stone_and_the_tight_pairs() {
+        let mut d = RingDesign::default();
+        let ctx = d.field_context();
+        let v = ctx.crest_v_mm;
+        let pad = |theta: f64, name: &str| {
+            let mut s = SeatPadLayer { theta_deg: theta, v_mm: v, ..Default::default() };
+            s.fit_stone(Gem::calibrated(GemCut::Round, 2.5));
+            LayerEntry::new(name, Layer::SeatPad(s))
+        };
+        d.layers.layers.push(pad(90.0, "A"));
+        d.layers.layers.push(pad(96.0, "B"));
+        let mut run = SeatRunLayer::default();
+        run.gem = Gem::calibrated(GemCut::Princess, 1.5);
+        run.seat.v_mm = v;
+        run.count = 12;
+        run.solve_spacing(&ctx);
+        d.layers.layers.push(LayerEntry::new("Row", Layer::SeatRun(run)));
+        let report = crate::stones::report(&d, 0.0).unwrap();
+        let stones = crate::setstone::set_stones(&d).len();
+        let svg = stone_map_svg(&d, Some(&report)).unwrap();
+        assert_eq!(svg.matches("class=\"stone\"").count(), 2 * stones, "plan and chart, one path each per stone");
+        assert!(svg.contains(">A 2.5<") && svg.contains(">B 2.5<"), "labels with sizes");
+        let in_row = crate::setstone::set_stones(&d).iter().filter(|s| s.label == "Row").count();
+        assert_eq!(svg.matches(&format!("Row x{in_row} ")).count(), 1, "a run is labelled once, with its count");
+        assert!(svg.contains("class=\"gap\"") && svg.contains("gap "), "A and B are 6 degrees apart: a tight pair");
+        assert!(svg.contains("drawn 2:1"));
+        let dir = std::env::temp_dir().join(format!("rd-map-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let n = write_stone_map_svg(dir.join("m.svg"), &d, Some(&report)).unwrap();
+        assert!(n > 1000);
+        let _ = std::fs::remove_dir_all(dir);
+        assert!(stone_map_svg(&RingDesign::default(), None).is_none(), "no stones, no map");
+    }
+}

--- a/crates/ringdesign-core/src/stones.rs
+++ b/crates/ringdesign-core/src/stones.rs
@@ -299,6 +299,21 @@ fn walk(
     }
 }
 
+/// Every stone the design sets with its girdle frame, in the order the
+/// record lists them.
+pub fn stone_frames(design: &RingDesign) -> Vec<(SetStone, StoneFrame)> {
+    let ctx = design.field_context();
+    let inner_r = design.inner_radius_mm();
+    let crest_r = ctx.crest_radius_mm;
+    crate::setstone::set_stones(design)
+        .into_iter()
+        .map(|st| {
+            let f = frame_at(design, &ctx, inner_r, crest_r, &st);
+            (st, f)
+        })
+        .collect()
+}
+
 /// Every stone against every other, in millimetres of real metal.
 ///
 /// The per-layer bridge only knows about a run's own neighbours, so a pad
@@ -325,7 +340,7 @@ fn crowding(
     if stations.len() < 2 {
         return (Vec::new(), 0, None);
     }
-    let frames: Vec<Frame> = stations
+    let frames: Vec<StoneFrame> = stations
         .iter()
         .map(|st| frame_at(design, ctx, inner_r, crest_r, st))
         .collect();
@@ -377,20 +392,23 @@ fn crowding(
 
 /// A stone standing on the band: where its girdle is, which way it faces,
 /// and the plan it presents in every direction.
-struct Frame {
-    girdle: [f64; 3],
-    normal: [f64; 3],
+/// A stone's girdle in space: where the census measures it and where the
+/// map draws it.
+#[derive(Clone, Debug)]
+pub struct StoneFrame {
+    pub girdle: [f64; 3],
+    pub normal: [f64; 3],
     /// The stone's long axis and its short one, in world space.
-    long: [f64; 3],
-    short: [f64; 3],
-    semi: (f64, f64),
-    plan_pow: f64,
+    pub long: [f64; 3],
+    pub short: [f64; 3],
+    pub semi: (f64, f64),
+    pub plan_pow: f64,
     /// The furthest the girdle reaches from its centre, mm.
-    reach: f64,
-    pavilion: f64,
+    pub reach: f64,
+    pub pavilion: f64,
 }
 
-impl Frame {
+impl StoneFrame {
     /// The girdle's own radius toward `d`, mm.
     fn plan_r(&self, d: [f64; 3]) -> f64 {
         crate::field::superellipse_radius_mm(
@@ -409,7 +427,7 @@ fn frame_at(
     inner_r: f64,
     crest_r: f64,
     st: &SetStone,
-) -> Frame {
+) -> StoneFrame {
     let b = base_at(design, inner_r, crest_r, ctx, st.theta_deg, st.v_mm);
     let (sin, cos) = st.theta_deg.to_radians().sin_cos();
     let normal = [b.nr * cos, b.nr * sin, b.nz];
@@ -435,7 +453,7 @@ fn frame_at(
     let semi = (st.gem.l_mm * 0.5, st.gem.w_mm * 0.5);
     let n = st.gem.cut.plan_pow();
     let reach = if n <= 2.0 { semi.0 } else { (semi.0 * semi.0 + semi.1 * semi.1).sqrt() };
-    Frame {
+    StoneFrame {
         girdle,
         normal,
         long,

--- a/crates/ringdesign-gui/src/export.rs
+++ b/crates/ringdesign-gui/src/export.rs
@@ -252,6 +252,25 @@ pub fn export_parting(app: &mut RingDesignerApp) {
     }
 }
 
+/// Export the stone spacing map: every stone to scale, plan and unrolled,
+/// with the census's tight gaps drawn.
+pub fn export_stone_map(app: &mut RingDesignerApp) {
+    let Some(path) = rfd::FileDialog::new()
+        .add_filter("SVG", &["svg"])
+        .set_directory(dir("exports"))
+        .set_file_name(format!("{}_stones.svg", slug(&app.design.name)))
+        .save_file()
+    else {
+        return;
+    };
+    let parting = app.field.as_ref().map(|f| f.parting_z_mm).unwrap_or(0.0);
+    let report = ringdesign_core::stones::report(&app.design, parting);
+    match ringdesign_core::stonemap::write_stone_map_svg(&path, &app.design, report.as_ref()) {
+        Ok(_) => app.set_status(format!("Wrote {}", path.display())),
+        Err(e) => app.set_status(format!("Stone map failed: {e}")),
+    }
+}
+
 pub fn export_spec(app: &mut RingDesignerApp) {
     let Some(path) = rfd::FileDialog::new()
         .add_filter("Casting sheet", &["html"])

--- a/crates/ringdesign-gui/src/panels/mod.rs
+++ b/crates/ringdesign-gui/src/panels/mod.rs
@@ -336,6 +336,7 @@ enum Command {
     TurntableGif,
     CastingSheet,
     PartingLine,
+    StoneMap,
     ToggleGhost,
     ToggleStones,
     ToggleAsCast,
@@ -395,6 +396,7 @@ impl Command {
         Command::TurntableGif,
         Command::CastingSheet,
         Command::PartingLine,
+        Command::StoneMap,
         Command::ToggleGhost,
         Command::ToggleStones,
         Command::ToggleAsCast,
@@ -421,6 +423,7 @@ impl Command {
             Command::TurntableGif => "Turntable GIF…",
             Command::CastingSheet => "Casting sheet…",
             Command::PartingLine => "Parting line SVG…",
+            Command::StoneMap => "Stone map SVG…",
             Command::ToggleGhost => "Toggle comparison ghost",
             Command::ToggleStones => "Toggle stone previews",
             Command::ToggleAsCast => "Toggle as-cast softening",
@@ -454,6 +457,7 @@ impl Command {
             Command::TurntableGif => export::export_turntable(app),
             Command::CastingSheet => export::export_spec(app),
             Command::PartingLine => export::export_parting(app),
+            Command::StoneMap => export::export_stone_map(app),
             Command::ToggleGhost => app.toggle_pin(),
             Command::ToggleStones => {
                 app.show_gems = !app.show_gems;
@@ -717,6 +721,14 @@ fn toolbar(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
                 .clicked()
             {
                 export::export_parting(app);
+                ui.close();
+            }
+            if ui
+                .button(format!("{} Stone map…", icon::DIAMOND))
+                .on_hover_text("Every stone to scale, plan and unrolled, with the tight gaps drawn: the setter's map.")
+                .clicked()
+            {
+                export::export_stone_map(app);
                 ui.close();
             }
             if ui

--- a/crates/ringdesign-mcp/src/tools.rs
+++ b/crates/ringdesign-mcp/src/tools.rs
@@ -2344,6 +2344,24 @@ impl RingDesignServer {
     }
 
     #[tool(
+        description = "Write the stone spacing map as a printable SVG: every stone the design sets to scale — plan view and the band unrolled, drawn 2:1 — with each stone's label and size and the census's tight gaps drawn in red between the pairs the setter has to watch. `path` is optional and defaults to a temp file named after the design. Fails when the design sets no stones."
+    )]
+    async fn export_stone_map(
+        &self,
+        Parameters(p): Parameters<ExportParams>,
+    ) -> Result<Json<ExportResult>, ErrorData> {
+        let mut e = self.engine.lock();
+        let path = p.path.unwrap_or_else(|| default_export_path(&e.design().name, "stones.svg"));
+        let field = e.field_report();
+        let report = ringdesign_core::stones::report(e.design(), field.parting_z_mm);
+        let bytes = ringdesign_core::stonemap::write_stone_map_svg(&path, e.design(), report.as_ref());
+        drop(e);
+        let bytes =
+            bytes.map_err(|err| ErrorData::internal_error(format!("write {path}: {err}"), None))?;
+        Ok(Json(ExportResult { path, bytes }))
+    }
+
+    #[tool(
         description = "Save the design to `path` as JSON: size, profile, shank, the whole layer stack, build resolution and casting settings. Alphas are referenced by name, not embedded, so a design file is small but needs the same library to rebuild identically. The conventional extension is .ring.json."
     )]
     async fn save_design(
@@ -3199,13 +3217,14 @@ mod tests {
             "export_obj",
             "export_3mf",
             "export_glb",
+            "export_stone_map",
             "save_design",
             "load_design",
             "apply_template",
         ] {
             assert!(names.contains(&expected), "missing tool {expected}: {names:?}");
         }
-        assert_eq!(names.len(), 32, "{names:?}");
+        assert_eq!(names.len(), 33, "{names:?}");
         for t in &tools {
             let d = t.description.as_ref().unwrap_or_else(|| panic!("{} has no description", t.name));
             assert!(d.len() > 120, "{} has a thin description", t.name);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -179,9 +179,11 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
   into the head's belly carried as `ShankMod::bore_lift_mm`; the bore is a vertical wall at any radius.
 - [x] Alpha granulometry (#90): `Alpha::min_feature_px` and `dfm::findings_in` — the measured
   finest stroke and gap of a texture at the layer's cell scale, against the sand floor.
-- Shelf: stone spacing map SVG; march instances along a guide path; blue-noise scatter
-  generator; mm-true mask morphology; nesting-depth stepped relief; honest rope rail;
-  `stones::probe_seat`; pearl stock; flat-edged seat plans.
+- [x] Stone spacing map SVG (#92): `stonemap::write_stone_map_svg` — plan and unrolled chart at 2:1
+  with every stone to scale and the census's tight gaps; File menu, MCP, CLI `stonemap`, phone Share.
+- Shelf: march instances along a guide path; blue-noise scatter generator; mm-true mask
+  morphology; nesting-depth stepped relief; honest rope rail; `stones::probe_seat`; pearl stock;
+  flat-edged seat plans.
 - [x] The graph editor in the comfyui-android look (#87): `ringdesign_graph_ui::style`, shared by the
   desktop pane and the phone tab.
 - Niceties: gate & sprue advisor; DPI true-scale; reference-mesh import + deviation report as a


### PR DESCRIPTION
Closes #92

- `stonemap::stone_map_svg` / `write_stone_map_svg`: plan view (each stone face-on at its position — a crest-set stone seen down the finger is an edge, which tells the setter nothing) and the band unrolled (each plan at its bearing), drawn 2:1 in mm, one label per family (a pad, a run, a group's seats) with count and size, the census's tight pairs as red lines with the deciding gap. Refuses a design without stones.
- `stones::StoneFrame` and `stone_frames` go public so the map reads the same girdle frames the crowding census measures.
- Wired: File > Stone map… (and the palette), MCP `export_stone_map` (router test now pins 33 tools), CLI `--formats stonemap` (`<slug>_size<N>_stones.svg` per size), phone Share > Stone map (EguiMobile `15ac634`).
- Looked at: the gypsy eternity and the bezel crescent showcase maps rendered through rsvg; the first cut drew plan stones as edges and sixteen colliding labels, both fixed before this PR.

Full guarded suite green (core 325, mcp 42); phone host tests and `cargo ndk check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)