### PR TITLE
Collection 3: what we have, measured

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1314,6 +1314,24 @@ opens in the app. Lessons it measured, kept in its comments:
   `compose()` and the showcase both derive it from the face the stamp landed
   on, because `wider()`'s tie on a symmetric band breaks on float noise.
 
+`examples/collection3.rs` is the same tour over one day's additions — a
+bypass solitaire, a diagonal princess band, a hollowed clover signet, a
+cabochon cigar band, a graded prong eternity judged for lost wax — each
+rendered with its stones, given its sheet and setter's map, and saved to
+`designs/collection3/`. What it measured, all of it from the verdicts
+rather than the renders: **a stone is sized to its face, not to its
+band** — a gypsy seat carries 1.8 mm of stock round its stone and a
+turned square reaches 1.19× further, so 2.5 mm princesses overhung a
+5 mm band's face by a millimetre (bosses carry 1.2 mm; 1.8 mm stones on
+a 5.5 mm band leave a quarter millimetre either side), and a 5 mm cab's
+bezel overhung a 4.5 mm band's face by 1.5 mm and leaned to −68° where a
+7.5 mm cigar band gives a 4 mm cab a 6.4 mm face; **a bypass crossing
+needs room under a stone** — on a 4.5 mm band the mound's skirt left a
+wedge against the crossing's edge that the wall sweep read as 0.67 mm,
+clean at 5.0; and **a seat's skirt is its finest DFM feature**, read at
+the chart's 0.85 metal scale, so a 0.4 mm skirt measures 0.34 against a
+0.35 floor. The hollow takes 11% out of a 12 mm clover signet.
+
 `examples/commissions.rs` is the same discipline applied to client sketches
 (half-wrap patterned crescents, a gem-set cross band, the Diamond and Cross
 `SignetOutline`s added for them). Its own measured lessons: a gem column

--- a/crates/ringdesign-core/examples/bypass_probe.rs
+++ b/crates/ringdesign-core/examples/bypass_probe.rs
@@ -24,7 +24,13 @@ fn main() {
             println!("{:+6.1}  {:.2}  {:+.2}  {:.2}", off, m.width_scale, m.z_center_frac, m.side_groove_mm);
         }
         let f = castability::analyze_field(&d, &lib, &d.draft, 384, 192);
-        println!("field: {:?} {:.4}% worst {:+.1} deg", f.verdict, f.undercut_fraction() * 100.0, f.worst_draft_deg);
+        println!("field: {:?} {:.4}% worst {:+.1} deg, thinnest wall {:.2} mm at {:.0} deg", f.verdict, f.undercut_fraction() * 100.0, f.worst_draft_deg, f.thinnest_wall_mm, f.thinnest_wall_theta_deg);
+        for off in [0.0, 30.0, 45.0, 60.0] {
+            let l = d.profile.sample_mod(ir, 192, &d.modulation_at(TOP_DEG + off, ir, base));
+            let (zmin, zmax) = l.pts.iter().fold((f64::MAX, f64::MIN), |(a, b), p| (a.min(p.z), b.max(p.z)));
+            let edge_r = l.pts.iter().filter(|p| p.surface && (p.z - zmin).abs() < 0.05).map(|p| p.r).fold(f64::MIN, f64::max);
+            println!("  off {off:+5.1}: z {zmin:+.2}..{zmax:+.2}, outer r at the low edge {edge_r:.2} vs bore {ir:.2} -> edge wall {:.2}", edge_r - ir);
+        }
         let built = mesh::build(&d, &lib, BuildParams { theta_steps: 768, profile_steps: 256, ..Default::default() });
         let m = &built.mesh;
         let dir = std::path::Path::new(&out);

--- a/crates/ringdesign-core/examples/collection3.rs
+++ b/crates/ringdesign-core/examples/collection3.rs
@@ -1,0 +1,209 @@
+// What we have: a collection built on the pieces that landed in one day —
+// the bypass shank, tilted runs, the bezel that stands on its stone, the
+// hollowed lofted signet, the measured DFM and the stone map. Every ring
+// is held to the field verdict, rendered with its stones, saved so it opens
+// in the app, and given its casting sheet and setter's map.
+//
+//   cargo run --release --example collection3 [out_dir]
+use ringdesign_core::alpha::AlphaLibrary;
+use ringdesign_core::castability::{self, CastProcess, Verdict};
+use ringdesign_core::field::{
+    Layer, LayerEntry, MilgrainLayer, SeatPadLayer, SeatRunLayer, SeatStyle, SideFacePick,
+    SignetOutline, VGate, Window, SIDE_FACE_MIN_DRAFT_DEG,
+};
+use ringdesign_core::gem::{Gem, GemCut};
+use ringdesign_core::mesh::{self, BuildParams};
+use ringdesign_core::profile::{ShankKind, TOP_DEG};
+use ringdesign_core::render::{self, Part};
+use ringdesign_core::tiling::TilingLayer;
+use ringdesign_core::{gems, library, stonemap, stones, ProfileStyle, RingDesign};
+
+const YELLOW: [f32; 3] = [0.86, 0.70, 0.42];
+const ROSE: [f32; 3] = [0.84, 0.60, 0.49];
+const WHITE: [f32; 3] = [0.83, 0.83, 0.80];
+const PLATINUM: [f32; 3] = [0.75, 0.76, 0.78];
+
+fn squared(width: f64, thickness: f64) -> RingDesign {
+    let mut d = RingDesign::default();
+    d.profile.apply_style(ProfileStyle::Flat);
+    d.profile.width_mm = width;
+    d.profile.thickness_mm = thickness;
+    d.profile.flatten_sides();
+    d
+}
+
+/// The wider side face's `v` run, and whether it is the low (-Z) face.
+fn wider_face(d: &RingDesign) -> ((f64, f64), bool) {
+    let ctx = d.field_context();
+    let run = ctx.side_faces_std().and_then(|f| f.wider()).expect("a squared band has side faces");
+    (run, 0.5 * (run.0 + run.1) < ctx.crest_v_mm)
+}
+
+/// Field-check, render with stones, sheet, map, save. Refuses to ship an
+/// uncastable ring.
+fn finish(dir: &str, slug: &str, blurb: &str, tint: [f32; 3], pitch: f64, gif: bool, mut d: RingDesign, lib: &mut AlphaLibrary) {
+    d.name = slug.split_once('-').map(|(_, r)| r.replace('-', " ")).unwrap_or_else(|| slug.into());
+    d.bake_all(lib);
+    let field = castability::attributed_field_report(&d, lib, &d.draft, 256, 128);
+    println!("{slug:<26} {blurb}");
+    println!(
+        "{:<26} {} under {}: {:.3}% undercut, worst {:+.1} deg, thinnest wall {:.2} mm",
+        "",
+        field.verdict.label(),
+        d.draft.process.label(),
+        field.undercut_fraction() * 100.0,
+        field.worst_draft_deg,
+        field.thinnest_wall_mm
+    );
+    for n in &field.notes {
+        println!("{:<26}   note: {n}", "");
+    }
+    let dfm = ringdesign_core::dfm::findings_in(&d, lib);
+    for f in &dfm {
+        println!("{:<26}   dfm: {}: {}", "", f.label, f.message);
+    }
+    let report = stones::report(&d, field.parting_z_mm);
+    if let Some(s) = &report {
+        println!("{:<26}   stones: {} stones, {:.2} ct", "", s.stone_count, s.total_carats);
+        if let Some(p) = &s.closest {
+            println!("{:<26}   closest pair: {} / {} — {:.2} mm at the girdle, {:.2} mm at the culet", "", p.a, p.b, p.gap_mm, p.gap_deep_mm);
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for seat in &s.seats {
+            for w in &seat.warnings {
+                if seen.insert(w.clone()) {
+                    println!("{:<26}   stone warning: {w}", "");
+                }
+            }
+        }
+    }
+    assert_ne!(field.verdict, Verdict::NotCastable, "{slug} must not ship uncastable");
+
+    let out = mesh::build(&d, lib, BuildParams { theta_steps: 1600, profile_steps: 360, ..Default::default() });
+    assert!(out.report.validation.watertight, "{slug} not watertight");
+    for m in out.report.metals.iter().take(2) {
+        println!("{:<26}   {}: {:.2} g", "", m.metal, m.grams);
+    }
+    let stones_mesh = gems::preview_mesh(&d, lib);
+    let mut parts = vec![Part::metal(&out.mesh, tint)];
+    if let Some(g) = &stones_mesh {
+        parts.push(Part::stone(g));
+    }
+    render::write_png_parts(format!("{dir}/{slug}-hero.png"), &parts, 0.55, pitch, 900).unwrap();
+    if gif {
+        render::write_turntable_gif(format!("{dir}/{slug}.gif"), &out.mesh, 36, 480, tint).unwrap();
+    }
+    let sheet = ringdesign_core::spec::html(&d, &out.report, &field, report.as_ref(), &dfm, "collection3");
+    std::fs::write(format!("{dir}/{slug}-sheet.html"), sheet).unwrap();
+    if report.is_some() {
+        stonemap::write_stone_map_svg(format!("{dir}/{slug}-stones.svg"), &d, report.as_ref()).unwrap();
+    }
+    let designs = library::default_design_dir().join("collection3");
+    std::fs::create_dir_all(&designs).unwrap();
+    library::save_design(designs.join(format!("{slug}.ring.json")), &d).unwrap();
+    println!();
+}
+
+fn main() {
+    let dir = std::env::args().nth(1).unwrap_or_else(|| "/tmp".into());
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut lib = AlphaLibrary::builtin();
+
+    // --- 01. Bypass solitaire: the two arms pass each other under a stone. --
+    let mut d = RingDesign::default();
+    d.profile.apply_style(ProfileStyle::LowDome);
+    // 5.0 wide: at 4.5 the crossing left the mound's skirt a wedge against
+    // the band edge that the wall sweep read as 0.67 mm.
+    d.profile.width_mm = 5.0;
+    d.profile.thickness_mm = 2.3;
+    d.shank.kind = ShankKind::Bypass;
+    d.shank.amount = 1.0;
+    let ctx = d.field_context();
+    // The crossing is 1.45 band widths wide; a 3.5 mm round's mound with its
+    // skirt just fits inside it, a 4 mm one spilled 0.06 mm past the edge.
+    // A 3.5 mm stone's foot still grazed the edge and the verdict read the
+    // feather it left as a 0.68 mm wall; 3.2 keeps a third of a millimetre.
+    // The skirt is the seat's finest feature for the DFM, read at the chart's
+    // 0.85 metal scale: 0.45 measures 0.38 against the 0.35 floor.
+    let mut seat = SeatPadLayer { theta_deg: TOP_DEG, v_mm: ctx.crest_v_mm, style: SeatStyle::GypsyMound, height_mm: 0.7, crown: 1.0, blend_mm: 0.45, ..Default::default() };
+    seat.fit_stone(Gem::calibrated(GemCut::Round, 3.2));
+    d.layers.layers.push(LayerEntry::new("Centre", Layer::SeatPad(seat)));
+    finish(&dir, "01-bypass-solitaire", "a 3.2 mm round in a gypsy mound where the two arms cross", YELLOW, 1.3, true, d, &mut lib);
+
+    // --- 02. Diagonal princess band: a tilted run on the side face, milgrain on the crest.
+    // A gypsy seat carries 1.8 mm of stock round its stone, and a turned
+    // square reaches 1.19x further: 2.5 mm princesses overhung a 5 mm band's
+    // face by a millimetre. Bosses carry 1.2 mm of stock; 1.8 mm stones on
+    // a 5.5 mm band leave a quarter millimetre of face either side.
+    let mut d = squared(7.0, 5.5);
+    let ((lo, hi), low_face) = wider_face(&d);
+    let ctx = d.field_context();
+    let mut run = SeatRunLayer { gem: Gem::calibrated(GemCut::Princess, 1.8), bridge_mm: 0.45, ..Default::default() };
+    run.seat.style = SeatStyle::Boss;
+    run.seat.crown = 0.3;
+    run.seat.blend_mm = 0.3;
+    run.seat.height_mm = 0.5;
+    run.seat.v_mm = 0.5 * (lo + hi);
+    run.tilt_deg = 45.0;
+    run.solve_spacing(&ctx);
+    let mut e = LayerEntry::new("Princess row", Layer::SeatRun(run));
+    e.window = Window::around(TOP_DEG, 200.0);
+    d.layers.layers.push(e);
+    d.layers.layers.push(LayerEntry::new("Milgrain", Layer::Milgrain(MilgrainLayer { v_mm: ctx.crest_v_mm, bead_diameter_mm: 0.5, beads_around: 96, height_mm: 0.2, ..Default::default() })));
+    // Pitch 1.12 tilts the +Z face to the viewer; ornament on the -Z face needs the mirrored attitude.
+    let pitch = if low_face { std::f64::consts::PI - 1.12 } else { 1.12 };
+    finish(&dir, "02-diagonal-princess", "1.8 mm princess cuts set on the diagonal along one face, a bead line on the crest", PLATINUM, pitch, false, d, &mut lib);
+
+    // --- 03. Hollow clover signet: a lofted head on a drawn plan, scooped from the finger.
+    let mut d = squared(12.0, 1.8);
+    d.shank.apply_signet(12.0);
+    let outline = library::list_outlines().into_iter().find(|o| o.name == "CG Clover").map(|o| d.shank.adopt_outline(o)).unwrap_or(SignetOutline::Hexagon);
+    d.shank.head.dome = d.shank.suggest_dome(outline);
+    d.shank.head.outline = outline;
+    d.shank.head.fit_length_to(12.0);
+    d.shank.head.table_dome_mm = 1.0;
+    let solid = mesh::build(&d, &lib, BuildParams { theta_steps: 384, profile_steps: 144, ..Default::default() }).report.volume_mm3;
+    d.shank.head.hollow_mm = 0.6;
+    let hollow = mesh::build(&d, &lib, BuildParams { theta_steps: 384, profile_steps: 144, ..Default::default() }).report.volume_mm3;
+    println!("{:<26} hollow saves {:.1} mm³ of {:.1} ({:.0}%)", "03-hollow-clover-signet", solid - hollow, solid, (solid - hollow) / solid * 100.0);
+    finish(&dir, "03-hollow-clover-signet", "a lofted clover head with a smooth table, 0.6 mm hollowed under the face", YELLOW, 1.12, true, d, &mut lib);
+
+    // --- 04. Cabochon bezel band: the collar stands on its stone; a trellis on the far side.
+    // A bezel is a side-face feature and its collar is the stone plus two
+    // walls, so the face has to be wider than the stone: a 5 mm cab on a
+    // 4.5 mm band overhung its face by 1.5 mm and leaned to -68 deg. A cigar
+    // band 7.5 mm thick gives a 4 mm oval cab a 6.4 mm face.
+    let mut d = squared(6.0, 7.5);
+    let ((lo, hi), low_face) = wider_face(&d);
+    let mut bezel = SeatPadLayer { theta_deg: TOP_DEG, v_mm: 0.5 * (lo + hi), style: SeatStyle::Bezel, recess_mm: 0.5, bezel_wall_mm: 0.6, blend_mm: 0.8, ..Default::default() };
+    bezel.fit_stone(Gem::cabochon(GemCut::Oval, 4.0));
+    d.layers.layers.push(LayerEntry::new("Cabochon", Layer::SeatPad(bezel)));
+    let ctx = d.field_context();
+    let mut t = TilingLayer::default_for("Trellis", &ctx);
+    t.height_mm = 0.3;
+    // Trellis carries four wires per tile: fourteen repeats measured 0.27 mm
+    // strokes against the 0.35 mm floor, eight read 0.47.
+    t.repeats_around = 8;
+    assert!(t.fit_to_side_faces(&ctx, SIDE_FACE_MIN_DRAFT_DEG));
+    let mut e = LayerEntry::new("Trellis", Layer::Tiling(t));
+    e.window = Window::except(TOP_DEG, 70.0);
+    e.window.v_gate = VGate::SideFaces(SideFacePick::Both);
+    d.layers.layers.push(e);
+    let pitch = if low_face { std::f64::consts::PI - 1.12 } else { 1.12 };
+    finish(&dir, "04-cabochon-bezel", "a 4 mm oval cab in a bezel whose collar height comes from the stone's dome; trellis round the rest of the cigar band", ROSE, pitch, false, d, &mut lib);
+
+    // --- 05. Graded prong eternity, for lost wax: the stock sand refuses. ---
+    let mut d = RingDesign::default();
+    d.profile.apply_style(ProfileStyle::LowDome);
+    d.profile.width_mm = 4.6;
+    d.profile.thickness_mm = 2.5;
+    d.draft.process = CastProcess::LostWax;
+    d.draft.min_section_mm = 0.5;
+    d.draft.min_detail_mm = 0.15;
+    let ctx = d.field_context();
+    let mut run = SeatRunLayer { gem: Gem::calibrated(GemCut::Round, 2.2), bridge_mm: 0.4, taper: 0.5, taper_theta_deg: TOP_DEG, shared_prong_mm: 0.25, ..Default::default() };
+    run.seat.v_mm = ctx.crest_v_mm;
+    run.solve_spacing(&ctx);
+    d.layers.layers.push(LayerEntry::new("Graded row", Layer::SeatRun(run)));
+    finish(&dir, "05-graded-prong-eternity", "a graduated row with shared prongs, judged for lost wax", WHITE, 1.12, false, d, &mut lib);
+}


### PR DESCRIPTION
`examples/collection3.rs`: a bypass solitaire, a diagonal princess band (tilted run on a side face, milgrain on the crest), a hollowed lofted clover signet with a smooth table, a cabochon cigar band with the bezel that stands on its stone and a trellis round the rest, and a graded shared-prong eternity judged for lost wax. Every piece is field-checked (the example refuses NotCastable), rendered with its stones through `write_png_parts`, given its casting sheet and stone map, and saved under `designs/collection3/`. A sixth piece was made from the shell through the graph runtime (`ringdesign graph eval --set Width=6.5 --set Thickness=2.4` → check → `export --shrink sterling`) and needed no code.

Three of the first drafts were wrong in ways only the verdicts said: stones sized to the band rather than the face (gypsy stock + the turned square's 1.19× reach; a bezel's collar), and a bypass crossing too narrow for its mound's skirt. The lessons are in CLAUDE.md. `bypass_probe` now prints the thinnest wall and the edge wall round the crossing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)