### PR TITLE
Uniform loft knots, measured against the loft itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -747,8 +747,8 @@ band**, crown 0.745·(T + 0.5). Not flat-topped; forcing it flat put the
 shank 0.35 mm off.
 
 `Tent` in `profile.rs` holds the five rows — resampled by arc length from
-the −y seam, which is the correspondence the whole shoulder hangs on; the
-knot averages the rows' own chord parameters — and reads, per ring angle:
+the −y seam, which is the correspondence the whole shoulder hangs on, and
+blended by a clamped cubic on **uniform** knots — and reads, per ring angle:
 the crest (the plane under the 0.98 row, else the first row down the loft
 the ray enters), the bore span, the face as a chord 12% of the bore-to-
 ridge drop below the ridge (never deeper than the ridge sits below the
@@ -801,6 +801,29 @@ Five defects on the way, each seen in a render and pinned by a number:
   round a hair outside both adjacent segments and find nothing, leaving a
   1e-6 spike that smoothing spread into a dip; it takes slack now, and a
   missed ray inherits its neighbours.
+
+**The loft, measured against the loft itself.** The Rhino side baked the
+head loft of presets 001, 005 and 016 as `.3dm` (rows and surface, in
+`batch6-8/from-rhino/brief01-loft/`), and a loose `Brep.CreateFromLoft` is
+exactly `S(u, v) = Σ Nᵢ(u)·rowᵢ(v)`: a clamped cubic across the rows on a
+**uniform** knot vector (one interior knot at the middle of the domain on
+every preset, however the rows are spaced), the rows paired by their own
+parameter from their own seam. A Python replica on that rule reproduces
+the 001 surface to 0.0000 mm; our chord-length-averaged knot (0.35) put
+the sheet 0.053 mm off on average and 0.32 at worst, uniform knots take
+that to 0.034 on 001 and to 0.017 / 0.003 on 005 / 016. Against the
+cached meshes the capped 005 head went 0.088 → 0.045 mm mean (p90 0.178 →
+0.064), 016 0.081 → 0.074, 001 unchanged. `the_loft_knots_are_uniform`
+pins the knots and the analytic (P₁ + 2P₂ + P₃)/4 read at the middle. What
+is left on 001 is the factory's own seam: its hand-drawn cushion starts
+2.4 mm off the −y axis and the equator rows are re-seamed to match, so
+the flank is twisted by a hundredth of the perimeter against our
+symmetric pairing — the 0.1 asymmetry `symmetrize` exists for, seen from
+the other side. The −y seam stays. Two more facts off the same files: the
+bore through the head is a four-row loft that dips **0.245 mm** inward at
+its middle (their comfort fit), and the row set of a Smooth-Table preset
+in that capture was still the flat five, so the apex loft remains pinned
+by the cached meshes alone.
 
 **The smooth table is the same loft from an apex.** `table_dome_mm` on a
 lofted head (0–3 mm, the "Cab dome" slider and MCP `head_table_dome_mm`) is
@@ -1695,6 +1718,16 @@ What the runtime settled while being built, each pinned by a test:
   express (a flange, a tiling warp, the draft settings) as `design.set`
   patches — so "Convert to graph" never loses a field, and the test that
   every template lifts back byte-for-byte also caps the patches at four.
+- **The list idioms follow Grasshopper where it was measured**
+  (`batch6-8/from-rhino/brief02-lists/`, Rhino 8.34): longest-list
+  matching repeats the last item; a negative Series count generates
+  nothing and warns rather than failing; Partition's size list cycles, a
+  zero size is an empty chunk, and the last chunk keeps what is left.
+  Polar Array only pinned that item 0 is the original and the step is
+  `angle / count` for a sweep past a full turn; the partial-arc law, and
+  Weave, Cull, List Item, Shift, Reverse and Sort, came back with panels
+  reading the inputs, so those keep their documented semantics (the
+  re-run list is in `SharedVM/answers/followup-brief02.txt`).
 
 ## Free mode: `crates/ringdesign-solid` and the Manifold kernel
 

--- a/crates/ringdesign-core/src/profile.rs
+++ b/crates/ringdesign-core/src/profile.rs
@@ -2985,9 +2985,7 @@ impl Tent {
         let hull = resample_row(hull);
         // A smooth table lofts from an apex point `cap_mm` over the plane,
         // through the outline scaled about its centroid at that height, to
-        // the outline at the plane — no rim row and no flat face. The apex
-        // row is the point repeated, which the chord-length gaps take as the
-        // mean radius of the row it leads to.
+        // the outline at the plane: no rim row and no flat face.
         let cap = cap_mm > 1e-6;
         let (rows, z): (Vec<Vec<[f64; 2]>>, Vec<f64>) = if cap {
             let apex = vec![c; LOFT_U];
@@ -3002,29 +3000,11 @@ impl Tent {
                 vec![plane, plane, plane - LOFT_BODY_DROP_MM, LOFT_EQUATOR_LIFT_MM, 0.0],
             )
         };
-        // Chord-length knots: each interior knot averages three of the rows'
-        // own parameters, as a clamped cubic fitted through them is.
+        // Uniform clamped cubic knots, as Rhino's loose loft.
         let n = rows.len();
-        let mut u = vec![0.0; n];
-        let mut total = 0.0;
-        for k in 0..n - 1 {
-            let dz = z[k + 1] - z[k];
-            let gap = (0..LOFT_U)
-                .map(|j| (dist(rows[k][j], rows[k + 1][j]).powi(2) + dz * dz).sqrt())
-                .sum::<f64>()
-                / LOFT_U as f64;
-            total += gap;
-            u[k + 1] = total;
-        }
-        let total = total.max(1e-9);
-        for x in u.iter_mut() {
-            *x /= total;
-        }
         let mut knots = vec![0.0; 4];
         for j in 1..=(n - 4) {
-            let k = ((u[j] + u[j + 1] + u[j + 2]) / 3.0).clamp(0.05, 0.95);
-            let prev = knots[knots.len() - 1];
-            knots.push(k.max(prev + 1e-3));
+            knots.push(j as f64 / (n - 3) as f64);
         }
         knots.extend([1.0, 1.0, 1.0, 1.0]);
         Tent { rows, z, knots, plane, cap }
@@ -5330,6 +5310,26 @@ mod tests {
         assert!(watertight);
         assert_eq!(rep.undercut, 0, "{:?}", rep.notes);
     }
+    #[test]
+    fn the_loft_knots_are_uniform() {
+        // A round table 20 across over a rectangular equator silhouette.
+        let circle = |s: f64| -> (f64, f64) {
+            let h = (1.0 - s * s).max(0.0).sqrt();
+            (-h, h)
+        };
+        let hull = [[-10.75, -3.0], [10.75, -3.0], [10.75, 3.0], [-10.75, 3.0]];
+        let flat = Tent::build(&circle, 10.0, 10.0, 12.5, 2.0, 2.0, &hull, 0.0);
+        assert_eq!(flat.knots, vec![0.0, 0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0]);
+        // At its one interior knot a clamped uniform cubic reads (P1 + 2 P2 + P3) / 4.
+        assert!((flat.z_at(0.5) - (12.5 + 2.0 * 9.5 + 3.0) / 4.0).abs() < 1e-9, "{}", flat.z_at(0.5));
+        let mut row = Vec::new();
+        flat.row_at(0.5, &mut row);
+        // The seam sample: the table at -10, the body at -11, the hull at -3.
+        assert!(row[0][0].abs() < 1e-6 && (row[0][1] - (-10.0 - 2.0 * 11.0 - 3.0) / 4.0).abs() < 1e-3, "{:?}", row[0]);
+        let capped = Tent::build(&circle, 10.0, 10.0, 12.5, 2.0, 2.0, &hull, 1.5);
+        let thirds = [0.0, 0.0, 0.0, 0.0, 1.0 / 3.0, 2.0 / 3.0, 1.0, 1.0, 1.0, 1.0];
+        assert!(capped.knots.len() == thirds.len() && capped.knots.iter().zip(&thirds).all(|(a, b)| (a - b).abs() < 1e-12), "{:?}", capped.knots);
+    }
 }
 
 #[cfg(test)]
@@ -5381,4 +5381,5 @@ mod hollow_tests {
         let deep = section(&d, TOP_DEG);
         assert!(bore_of(&deep) < crest_of(&deep) - MIN_EDGE_MM, "a wall survives the deepest scoop");
     }
+
 }

--- a/crates/ringdesign-graph/src/nodes/idiom.rs
+++ b/crates/ringdesign-graph/src/nodes/idiom.rs
@@ -100,15 +100,15 @@ fn cull_nth(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeEr
 fn partition(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError> {
     let items = i.list("items");
     let sizes = ints(i, "size")?;
-    if sizes.is_empty() || sizes.iter().any(|s| *s < 1) {
-        return Err(NodeError::input("size", "sizes must be positive"));
+    if sizes.is_empty() || sizes.iter().any(|s| *s < 0) || sizes.iter().all(|s| *s == 0) {
+        return Err(NodeError::input("size", "sizes must be non-negative, at least one of them positive"));
     }
-    // The size list repeats: {2, 3} partitions as 2, 3, 2, 3 …; the last
-    // chunk keeps whatever is left.
+    // The size list repeats: {2, 3} partitions as 2, 3, 2, 3 …; a zero is
+    // an empty chunk; the last chunk keeps whatever is left.
     let mut out = Vec::new();
     let mut at = 0usize;
     let mut k = 0usize;
-    while at < items.len() {
+    while at < items.len() && out.len() < MAX_LIST_ITEMS {
         let size = sizes[k % sizes.len()] as usize;
         let end = (at + size).min(items.len());
         out.push(Value::List(items[at..end].to_vec()));
@@ -427,9 +427,13 @@ mod tests {
         let cn = node(&mut g, "list.cull_nth", &[("items", texts(&["a", "b", "c", "d", "e", "f", "g"])), ("n", Literal::Int(2))]);
         let p1 = node(&mut g, "list.partition", &[("items", ints(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])), ("size", ints(&[3]))]);
         let p2 = node(&mut g, "list.partition", &[("items", ints(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])), ("size", ints(&[2, 3]))]);
+        let p3 = node(&mut g, "list.partition", &[("items", ints(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])), ("size", ints(&[3, 2, 0]))]);
+        let p0 = node(&mut g, "list.partition", &[("items", ints(&[0, 1, 2])), ("size", ints(&[0]))]);
         let d = node(&mut g, "list.dispatch", &[("items", texts(&["a", "b", "c", "d"])), ("pattern", bools(&[true, false]))]);
         let r = run(&g);
-        assert!(!r.any_failed() || r.status[&ci_strict].failed(), "{:?}", r.notes(&g));
+        for (id, st) in &r.status {
+            assert!(!st.failed() || *id == ci_strict || *id == p0, "{:?}", r.notes(&g));
+        }
         assert_eq!(as_texts(r.value(w, "out")), ["a", "x", "y", "b", "z", "c", "d", "e", "f"]);
         assert_eq!(as_texts(r.value(w2, "out")), ["a", "x", "b", "c"], "an exhausted stream's slots are skipped");
         match r.value(e, "out") {
@@ -447,6 +451,8 @@ mod tests {
         let chunks = |v: Option<&Value>| -> Vec<usize> { match v { Some(Value::List(c)) => c.iter().map(|x| x.as_list().map_or(0, |l| l.len())).collect(), _ => vec![] } };
         assert_eq!(chunks(r.value(p1, "out")), [3, 3, 3, 1]);
         assert_eq!(chunks(r.value(p2, "out")), [2, 3, 2, 3]);
+        assert_eq!(chunks(r.value(p3, "out")), [3, 2, 0, 3, 2], "a zero size is an empty chunk, as Grasshopper measured");
+        assert!(r.status[&p0].failed(), "all-zero sizes never advance");
         assert_eq!(as_texts(r.value(d, "a")), ["a", "c"]);
         assert_eq!(as_texts(r.value(d, "b")), ["b", "d"]);
     }

--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -137,7 +137,8 @@ mod acceptance {
         assert_eq!(list_of(r.value(one, "out")), vec![0.0]);
         assert_eq!(list_of(r.value(big, "out")).len(), MAX_LIST_ITEMS);
         assert!(r.status[&big].warnings[0].contains("clamped"));
-        assert!(r.status[&neg].errors[0].1.contains("negative"));
+        assert!(list_of(r.value(neg, "out")).is_empty(), "a negative count generates nothing");
+        assert!(r.status[&neg].warnings[0].contains("negative"));
     }
 
     #[test]

--- a/crates/ringdesign-graph/src/nodes/source.rs
+++ b/crates/ringdesign-graph/src/nodes/source.rs
@@ -25,7 +25,8 @@ fn text(_: &mut EvalCtx<'_>, _: &Node, i: &Inputs) -> Result<Outputs, NodeError>
 fn capped_count(ctx: &mut EvalCtx<'_>, i: &Inputs, pin: &str) -> Result<usize, NodeError> {
     let n = i.int(pin)?;
     if n < 0 {
-        return Err(NodeError::input(pin, format!("{n} is negative")));
+        ctx.warn(format!("{pin} {n} is negative: nothing generated"));
+        return Ok(0);
     }
     let n = n as usize;
     if n > MAX_LIST_ITEMS {
@@ -85,7 +86,7 @@ pub fn register(reg: &mut Registry) {
             .output(PinSpec::list("out", ValueKind::Number).doc("The numbers."))
             .eval(series),
         NodeSpec::new("range", "Range", Category::Source)
-            .doc("Count evenly spaced numbers from a start to an end, both included.")
+            .doc("Count evenly spaced numbers from a start to an end, both included. Grasshopper's Range counts steps, one fewer.")
             .input(PinSpec::item("start", ValueKind::Number).default(0.0).doc("The first number."))
             .input(PinSpec::item("end", ValueKind::Number).default(1.0).doc("The last number."))
             .input(PinSpec::item("count", ValueKind::Int).default(10i64).doc("How many; capped at the list limit. One gives the start alone."))

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,6 +49,9 @@ Order: M0.1 → M0.2 → M0.3 → M0.4 → M0.0.
   `cg_signet` maps the preset flags. Test: crest at the centre = plane + cap, crest height
   non-increasing off the centre, field verdict clean, thinnest wall > 1 mm. Accept: the two
   domed factory presets rebuild within 0.15 mm mean at the head; the flat one is unchanged.
+  Brief 01 (2026-08-26): the factory loft is a loose `CreateFromLoft` = a clamped cubic blend of
+  the row curves on **uniform** knots; ours moved from chord-length knots (0.053 mm mean off the
+  001 surface) to uniform (0.034; 005 head vs cached mesh 0.088 → 0.045).
 - [x] **M0.4 Loft as the default for new signets** (S + render review, #4). `apply_signet` sets
   `loft = 1.0` (every "new signet" path funnels through it); `SignetHead::lofted()` for extra
   heads; `Default`/serde default untouched so existing files keep the prism. MCP `set_shank`
@@ -130,6 +133,9 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 
 - [x] **M5.1 List idiom nodes** (M, #53). Weave, entwine, cull, partition, gate, polar array (integer
   lattice — never a relaxation), format, json, if.
+  Brief 02 (Rhino 8.34, 2026-08-26) re-pinned: negative Series count → empty + warning; Partition
+  size 0 → empty chunk. Polar Array's partial-arc law and the Weave/Cull/List Item cases came back
+  unusable (panels read inputs) — re-run list in `SharedVM/answers/followup-brief02.txt`.
 - [x] **M5.2 First hosted cluster** (M, #54). The signet construction as a user-dir cluster whose
   preset evaluates to the lofted head.
 - [x] **M5.3 Editor polish** (M, #55). Live value badges, subgraph navigation and collapse, arrange,


### PR DESCRIPTION
Closes #95

**The loft.** Three factory head lofts were baked as `.3dm` (rows and surface) on the Rhino side. A loose `Brep.CreateFromLoft` is a clamped cubic blend of the row curves on a **uniform** knot vector, paired by each row's own parameter from its own seam — a replica on that rule reproduces the 001 surface to 0.0000 mm. `Tent::build` used a chord-length-averaged knot (0.35): 0.053 mm mean / 0.32 max off the sheet. Uniform knots: 0.034 on 001 (the rest is the reference curve's own off-axis seam), 0.017 / 0.003 on 005 / 016; the capped 005 head against its cached mesh 0.088 → 0.045 mm mean (p90 0.178 → 0.064). `the_loft_knots_are_uniform` pins the knot vectors and the analytic (P₁ + 2P₂ + P₃)/4 mid-knot read.

**The idioms.** Measured Grasshopper 8.34: a negative Series count generates nothing and warns (was a node failure); Partition's size 0 is an empty chunk (was refused). The partial-arc Polar Array law and the Weave/Cull/List Item cases were not settled by this round and keep their documented semantics.

Docs: CLAUDE.md (lofted head, graph idioms), ROADMAP M0.3 / M5.1 notes. Workspace tests green under the memory guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015z4xSoyNyNRaeYo7SUFmth