### PR TITLE
Three sketched rings, built in both engines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1397,7 +1397,10 @@ bezel collars, gypsy mounds, prong bumps. Three pieces keep that honest:
   crown reports its draft — and the warning keys on a *flat top's rim* on
   low draft, because that is the measured 8.6% hazard, while a fully-domed
   mound on the same base measures 0.000%), foot-to-band-edge clearance vs
-  `MIN_EDGE_MM`, metal available for the pavilion along the seat's normal
+  `MIN_EDGE_MM` — measured along the section **as modulated at that
+  station**, so a keyframed or signet top carries the seat its reference
+  band could not (read off the reference width it refused a 4 mm princess
+  on a 3 mm band widened to 7) — metal available for the pavilion along the seat's normal
   (to the bore wall on the crown, across the band on a side face) vs
   `gem.pavilion_mm()` + `MIN_WALL_MM`, run bridges vs `MIN_EDGE_MM`, and
   carat totals — plus the pairwise crowding census below. Analytic — it
@@ -1446,6 +1449,9 @@ overhung its own stock by 0.6 mm at each end.
   rim outward rather than as a fraction of the radius — normalizing instead
   would thin an authored 0.5 mm blend to 0.25 mm at a marquise's point,
   straight through `MIN_EDGE_MM`.
+- Prong bumps stand on the plan outline, on its axes for a round plan and
+  at its **corners** once `plan_pow` passes 2.5 — a princess is claw-set at
+  its corners, and the claws land where the girdle is.
 - `plan_pow` is floored at 1, which keeps the plan **convex**. Convex is
   star-shaped about the centre, so a mound on it is still a monotone drop
   from a single crest and releases wherever a round one does — measured

--- a/crates/ringdesign-core/examples/obj_render.rs
+++ b/crates/ringdesign-core/examples/obj_render.rs
@@ -1,6 +1,6 @@
 //! Render an OBJ mesh with the core software renderer.
 //!
-//! Single file:  obj_render <in.obj> <out.png> [--yaw DEG] [--pitch DEG] [--edge PX] [--cg] [--gif out.gif]
+//! Single file:  obj_render <in.obj> <out.png> [--yaw DEG] [--pitch DEG] [--edge PX] [--cg] [--gif out.gif] [--stones gems.obj]
 //! Batch:        obj_render --dir <root> [--cg] [--edge PX] [--force]
 //!
 //! `--cg` maps a CrossGems mesh (ring in XZ, finger axis Y, head at +Z)
@@ -22,6 +22,7 @@ struct Opts {
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let mut o = Opts { yaw: 0.55, pitch: 1.05, edge: 640, cg: false, gif: None, force: false };
+    let mut stones: Option<String> = None;
     let mut positional = Vec::new();
     let mut dir: Option<String> = None;
     let mut i = 1;
@@ -34,6 +35,7 @@ fn main() -> anyhow::Result<()> {
             "--force" => { o.force = true; i += 1; }
             "--gif" => { o.gif = Some(args[i + 1].clone()); i += 2; }
             "--dir" => { dir = Some(args[i + 1].clone()); i += 2; }
+            "--stones" => { stones = Some(args[i + 1].clone()); i += 2; }
             other => { positional.push(other.to_string()); i += 1; }
         }
     }
@@ -58,7 +60,13 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(2);
     }
     let mesh = read_obj(Path::new(&positional[0]), o.cg)?;
-    render::write_png(&positional[1], &mesh, o.yaw, o.pitch, o.edge, render::GOLD)?;
+    // A second mesh drawn as stones, for a ring exported with its gems.
+    let gems = stones.map(|p| read_obj(Path::new(&p), o.cg)).transpose()?;
+    let mut parts = vec![render::Part::metal(&mesh, render::GOLD)];
+    if let Some(g) = &gems {
+        parts.push(render::Part::stone(g));
+    }
+    render::write_png_parts(&positional[1], &parts, o.yaw, o.pitch, o.edge)?;
     if let Some(g) = o.gif {
         render::write_turntable_gif(g, &mesh, 36, 360, render::GOLD)?;
     }

--- a/crates/ringdesign-core/examples/sketches.rs
+++ b/crates/ringdesign-core/examples/sketches.rs
@@ -1,0 +1,154 @@
+// Three sketched rings — a heart signet, a half-eternity, a princess
+// solitaire — built here with the same numbers handed to CrossGems through
+// its Grasshopper components, so the two engines can be laid side by side
+// on the same brief. Each is field-checked, rendered with its stones,
+// exported as OBJ for the mesh comparison, and saved so it opens in the app.
+//
+//   cargo run --release --example sketches [out_dir]
+use ringdesign_core::alpha::AlphaLibrary;
+use ringdesign_core::castability::{self, CastProcess, Verdict};
+use ringdesign_core::field::{Layer, LayerEntry, SeatPadLayer, SeatRunLayer, SeatStyle, SignetOutline, Window};
+use ringdesign_core::gem::{Gem, GemCut};
+use ringdesign_core::mesh::{self, BuildParams};
+use ringdesign_core::profile::{ShankKey, ShankKind, SIGNET_MIN_SHANK_FRAC, TOP_DEG};
+use ringdesign_core::render::{self, Part};
+use ringdesign_core::{gems, library, stonemap, stones, ProfileStyle, RingDesign, RingSize};
+
+const YELLOW: [f32; 3] = [0.86, 0.70, 0.42];
+const WHITE: [f32; 3] = [0.83, 0.83, 0.80];
+
+/// Field-check, render with stones, sheet, map, OBJ, save.
+fn finish(dir: &str, slug: &str, blurb: &str, tint: [f32; 3], mut d: RingDesign, lib: &mut AlphaLibrary) {
+    d.name = slug.split_once('-').map(|(_, r)| r.replace('-', " ")).unwrap_or_else(|| slug.into());
+    d.bake_all(lib);
+    let field = castability::attributed_field_report(&d, lib, &d.draft, 256, 128);
+    println!("{slug:<22} {blurb}");
+    println!(
+        "{:<22} {} under {}: {:.3}% undercut, worst {:+.1} deg, thinnest wall {:.2} mm",
+        "",
+        field.verdict.label(),
+        d.draft.process.label(),
+        field.undercut_fraction() * 100.0,
+        field.worst_draft_deg,
+        field.thinnest_wall_mm
+    );
+    for n in &field.notes {
+        println!("{:<22}   note: {n}", "");
+    }
+    let dfm = ringdesign_core::dfm::findings_in(&d, lib);
+    for f in &dfm {
+        println!("{:<22}   dfm: {}: {}", "", f.label, f.message);
+    }
+    let report = stones::report(&d, field.parting_z_mm);
+    if let Some(s) = &report {
+        println!("{:<22}   stones: {} stones, {:.2} ct", "", s.stone_count, s.total_carats);
+        if let Some(p) = &s.closest {
+            println!("{:<22}   closest pair: {} / {} — {:.2} mm at the girdle, {:.2} mm at the culet", "", p.a, p.b, p.gap_mm, p.gap_deep_mm);
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for seat in &s.seats {
+            for w in &seat.warnings {
+                if seen.insert(w.clone()) {
+                    println!("{:<22}   stone warning: {w}", "");
+                }
+            }
+        }
+    }
+    assert_ne!(field.verdict, Verdict::NotCastable, "{slug} must not ship uncastable");
+
+    let out = mesh::build(&d, lib, BuildParams { theta_steps: 1600, profile_steps: 360, ..Default::default() });
+    assert!(out.report.validation.watertight, "{slug} not watertight");
+    println!("{:<22}   bore {:.2} mm, volume {:.1} mm3", "", out.report.inner_diameter_mm, out.report.volume_mm3);
+    for m in out.report.metals.iter().take(2) {
+        println!("{:<22}   {}: {:.2} g", "", m.metal, m.grams);
+    }
+    let stones_mesh = gems::preview_mesh(&d, lib);
+    let mut parts = vec![Part::metal(&out.mesh, tint)];
+    if let Some(g) = &stones_mesh {
+        parts.push(Part::stone(g));
+    }
+    render::write_png_parts(format!("{dir}/{slug}-hero.png"), &parts, 0.55, 1.05, 900).unwrap();
+    render::write_png_parts(format!("{dir}/{slug}-top.png"), &parts, 0.0, 1.55, 700).unwrap();
+    render::write_png_parts(format!("{dir}/{slug}-side.png"), &parts, 1.5708, 0.0, 700).unwrap();
+    ringdesign_core::stl::write_obj(format!("{dir}/{slug}.obj"), &out.mesh, &d.name).unwrap();
+    let sheet = ringdesign_core::spec::html(&d, &out.report, &field, report.as_ref(), &dfm, "sketches");
+    std::fs::write(format!("{dir}/{slug}-sheet.html"), sheet).unwrap();
+    if report.is_some() {
+        stonemap::write_stone_map_svg(format!("{dir}/{slug}-stones.svg"), &d, report.as_ref()).unwrap();
+    }
+    let designs = library::default_design_dir().join("sketches");
+    std::fs::create_dir_all(&designs).unwrap();
+    library::save_design(designs.join(format!("{slug}.ring.json")), &d).unwrap();
+    println!();
+}
+
+fn main() {
+    let dir = std::env::args().nth(1).unwrap_or_else(|| "/tmp".into());
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut lib = AlphaLibrary::builtin();
+
+    // --- A. Heart signet: the same numbers as CrossGems' Signet Ring ------
+    // (Table Length 12 across the finger, Width 11.4 along the ring, Table
+    // Height 3.0 over the bore, sides 4.5 x 1.5, Frontal/Lateral 2), through
+    // the same mapping cg_signet.rs uses for a decoded preset.
+    let mut d = RingDesign::default();
+    d.size = RingSize::new(7.0);
+    d.profile.apply_style(ProfileStyle::HalfRound);
+    d.profile.width_mm = 12.0;
+    d.profile.thickness_mm = 1.75;
+    d.profile.crown_mm = 1.49;
+    d.profile.edge_round_mm = 0.05;
+    d.shank.apply_signet(12.0);
+    let shank_frac = (4.5_f64 / 12.0).clamp(SIGNET_MIN_SHANK_FRAC, 1.0);
+    d.shank.amount = ((1.0 - shank_frac) / (1.0 - SIGNET_MIN_SHANK_FRAC)).clamp(0.0, 1.0);
+    d.shank.head.outline = SignetOutline::Heart;
+    d.shank.head.length_mm = 11.4;
+    d.shank.head.rise_mm = 3.0 - 1.5;
+    d.shank.head.rim_round_mm = 0.3;
+    d.shank.head.table_dome_mm = 0.0;
+    d.shank.head.loft_frontal_mm = 2.0;
+    d.shank.head.loft_lateral_mm = 2.0;
+    finish(&dir, "A-heart-signet", "lofted heart signet, 12 x 11.4 plate, flat table", YELLOW, d, &mut lib);
+
+    // --- B. Half-eternity: 2 mm rounds over 200 degrees --------------------
+    // CrossGems packs them 0.2 mm apart for shared prongs or a channel; in
+    // sand the seats are bosses drilled at the bench, the bridge is the
+    // 0.3 mm fill floor, and the count follows from that.
+    let mut d = RingDesign::default();
+    d.size = RingSize::new(7.0);
+    d.profile.apply_style(ProfileStyle::LowDome);
+    d.profile.width_mm = 3.8;
+    d.profile.thickness_mm = 2.2;
+    let ctx = d.field_context();
+    let seat = SeatPadLayer { v_mm: ctx.crest_v_mm, style: SeatStyle::Boss, height_mm: 0.45, crown: 0.9, blend_mm: 0.4, ..Default::default() };
+    let mut run = SeatRunLayer { seat, gem: Gem::calibrated(GemCut::Round, 2.0), bridge_mm: 0.3, ..Default::default() };
+    run.solve_spacing(&ctx);
+    let mut entry = LayerEntry::new("Half eternity", Layer::SeatRun(run));
+    entry.window = Window::around(TOP_DEG, 200.0);
+    d.layers.layers.push(entry);
+    finish(&dir, "B-half-eternity", "2 mm rounds over 200 degrees on a 3.8 x 2.2 band", WHITE, d, &mut lib);
+
+    // --- C. Princess solitaire: a 4 mm stone on a 3 x 2 band ---------------
+    // A prong head stands above the band and is lost-wax stock: here the
+    // band widens to carry a boss with four prong bumps, and the sheet is
+    // judged for lost wax, as CrossGems' head is.
+    let mut d = RingDesign::default();
+    d.size = RingSize::new(7.0);
+    d.profile.apply_style(ProfileStyle::LowDome);
+    d.profile.width_mm = 3.0;
+    d.profile.thickness_mm = 2.0;
+    d.shank.kind = ShankKind::Keyframes;
+    d.shank.amount = 1.0;
+    d.shank.keys = vec![
+        ShankKey { theta_deg: TOP_DEG, width_scale: 2.35, thickness_scale: 1.3, crown_scale: 0.6 },
+        ShankKey { theta_deg: TOP_DEG + 55.0, width_scale: 1.35, thickness_scale: 1.1, crown_scale: 1.0 },
+        ShankKey { theta_deg: TOP_DEG - 55.0, width_scale: 1.35, thickness_scale: 1.1, crown_scale: 1.0 },
+        ShankKey { theta_deg: TOP_DEG + 180.0, width_scale: 1.0, thickness_scale: 1.0, crown_scale: 1.0 },
+    ];
+    d.draft.process = CastProcess::LostWax;
+    let ctx = d.field_context();
+    let mut seat = SeatPadLayer { theta_deg: TOP_DEG, v_mm: ctx.crest_v_mm, style: SeatStyle::Boss, height_mm: 0.9, crown: 1.0, blend_mm: 0.45, prongs: 4, prong_mm: 0.55, ..Default::default() };
+    seat.fit_stone(Gem::calibrated(GemCut::Princess, 4.0));
+    d.layers.layers.push(LayerEntry::new("Princess", Layer::SeatPad(seat)));
+    finish(&dir, "C-princess-solitaire", "4 mm princess in a four-prong boss on a widened 3 x 2 band", WHITE, d, &mut lib);
+}

--- a/crates/ringdesign-core/examples/sketches.rs
+++ b/crates/ringdesign-core/examples/sketches.rs
@@ -70,7 +70,10 @@ fn finish(dir: &str, slug: &str, blurb: &str, tint: [f32; 3], mut d: RingDesign,
     render::write_png_parts(format!("{dir}/{slug}-hero.png"), &parts, 0.55, 1.05, 900).unwrap();
     render::write_png_parts(format!("{dir}/{slug}-top.png"), &parts, 0.0, 1.55, 700).unwrap();
     render::write_png_parts(format!("{dir}/{slug}-side.png"), &parts, 1.5708, 0.0, 700).unwrap();
-    ringdesign_core::stl::write_obj(format!("{dir}/{slug}.obj"), &out.mesh, &d.name).unwrap();
+    // The comparison mesh: dense enough to measure against, light enough to
+    // measure with.
+    let probe = mesh::build(&d, lib, BuildParams { theta_steps: 640, profile_steps: 160, ..Default::default() });
+    ringdesign_core::stl::write_obj(format!("{dir}/{slug}.obj"), &probe.mesh, &d.name).unwrap();
     let sheet = ringdesign_core::spec::html(&d, &out.report, &field, report.as_ref(), &dfm, "sketches");
     std::fs::write(format!("{dir}/{slug}-sheet.html"), sheet).unwrap();
     if report.is_some() {
@@ -103,7 +106,7 @@ fn main() {
     d.shank.amount = ((1.0 - shank_frac) / (1.0 - SIGNET_MIN_SHANK_FRAC)).clamp(0.0, 1.0);
     d.shank.head.outline = SignetOutline::Heart;
     d.shank.head.length_mm = 11.4;
-    d.shank.head.rise_mm = 3.0 - 1.5;
+    d.shank.head.rise_mm = 3.0 - 1.75;
     d.shank.head.rim_round_mm = 0.3;
     d.shank.head.table_dome_mm = 0.0;
     d.shank.head.loft_frontal_mm = 2.0;

--- a/crates/ringdesign-core/src/field.rs
+++ b/crates/ringdesign-core/src/field.rs
@@ -1397,9 +1397,11 @@ impl SeatPadLayer {
         // seat carries its claws where its girdle is.
         let prong_r = (0.28 * rb).clamp(0.35, 0.8);
         let step = std::f64::consts::TAU / n as f64;
+        // A square plan is claimed at its corners, a round one on its axes.
+        let phase = if self.plan_pow > 2.5 { 0.5 * step } else { 0.0 };
         let mut prong: f64 = 0.0;
         for k in 0..n {
-            let (sin, cos) = (k as f64 * step).sin_cos();
+            let (sin, cos) = (k as f64 * step + phase).sin_cos();
             let seat_r = (self.rim_mm(cos, sin) - prong_r * 0.6).max(0.2);
             let dp = ((a - seat_r * cos).powi(2) + (b - seat_r * sin).powi(2)).sqrt();
             let t = (dp / prong_r).clamp(0.0, 1.0);

--- a/crates/ringdesign-core/src/stones.rs
+++ b/crates/ringdesign-core/src/stones.rs
@@ -568,13 +568,14 @@ fn check_seat(
         let radial = [b.nr * theta.to_radians().cos(), b.nr * theta.to_radians().sin(), b.nz];
         worst_draft = worst_draft.min(draft_angle(radial, b.z, parting_z));
 
-        // Foot to the nearer band edge, in reference v like the layer itself.
+        // Foot to the nearer band edge, on the section as modulated at this
+        // station: a widened top carries a seat the reference band could not.
         // An elongated seat reaches across the band by its own `v` extent,
         // which is its length when the stone is turned to face the edges.
         let foot = seat.half_extents_mm().1 + seat.blend_mm.max(0.0);
         clearance = clearance
-            .min(v_here - foot)
-            .min(ctx.band_v_len_mm - v_here - foot);
+            .min(b.along - foot)
+            .min(b.surface_len - b.along - foot);
 
         // Metal along the seat's normal: to the bore wall on the crown, across
         // the band on a side face — the drill goes where the normal points.
@@ -659,6 +660,10 @@ struct BasePoint {
     nz: f64,
     /// Band width at this station, mm.
     width: f64,
+    /// Arc from the low band edge to this point along the station's own
+    /// section, and that section's whole surface arc, mm.
+    along: f64,
+    surface_len: f64,
 }
 
 /// The bare band under a point, from the modulated profile — the same
@@ -692,8 +697,8 @@ fn base_at(
         }
     }
     match best {
-        Some(p) => BasePoint { r: p.r, z: p.z, nr: p.nr, nz: p.nz, width: (hi - lo).max(0.0) },
-        None => BasePoint { r: inner_r, z: 0.0, nr: 1.0, nz: 0.0, width: 0.0 },
+        Some(p) => BasePoint { r: p.r, z: p.z, nr: p.nr, nz: p.nz, width: (hi - lo).max(0.0), along: target, surface_len: l.surface_len_mm },
+        None => BasePoint { r: inner_r, z: 0.0, nr: 1.0, nz: 0.0, width: 0.0, along: v_mm, surface_len: ctx.band_v_len_mm },
     }
 }
 


### PR DESCRIPTION
Closes #97

`examples/sketches.rs` builds a heart signet, a 200° half-eternity and a princess solitaire with the numbers handed to CrossGems for the same sketches, so the two can be laid side by side (the comparison page is an artifact; the CrossGems side was built headless through its Grasshopper components on the Rhino VM and measured mesh-to-mesh).

Core changes the solitaire turned up:
- prong bumps on a plan squarer than `plan_pow` 2.5 stand at its corners, not its axes;
- the seat-to-band-edge check reads the section as modulated at the seat's station (`base_at` carries the station's own arc), so a keyframed or signet top carries the seat its reference band could not — unchanged on an unmodulated band.

Also: `obj_render --stones <obj>`; the signet's rise from the cast thickness; a 640×160 probe mesh for the comparison. Core suite green under the memory guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015z4xSoyNyNRaeYo7SUFmth