### PR TITLE
The bolt ring, the cloud ring, and stamps measured for the sand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1018,7 +1018,13 @@ pins both directions. On top of that:
   distance field, 3×3-tiled so a seamless mask reads seamless, cached by
   content) at the layer's own mm-per-texel, after the layer's
   contrast/bias/invert shaping. Greek Key on 2.7 mm cells passes the
-  pitch check and measures 0.06 mm strokes — that is the finding. Run on
+  pitch check and measures 0.06 mm strokes — that is the finding. A
+  **stamp** is measured the same way at its own mm per texel, with the
+  alpha stretched by the section's own arc ratio at the stamp's station
+  first — the chart's `v` is that arc normalized, so on a lobe three
+  times the reference thickness a stamp stands that much taller than it
+  is wide — and the measurement replaces the footprint's 15%-of-size
+  guess, which called a 2.25 mm hook with a 0.45 mm stroke mush. Run on
   the shipped templates (`dfm::measured_tests::the_templates_measured`,
   `--nocapture`) it names three: Waves at 0.10 mm strokes on the waved
   hexagon signet's 11.8 × 1.8 mm cells, Chevron at 0.07 mm gaps on the
@@ -1354,6 +1360,24 @@ wedge against the crossing's edge that the wall sweep read as 0.67 mm,
 clean at 5.0; and **a seat's skirt is its finest DFM feature**, read at
 the chart's 0.85 metal scale, so a 0.4 mm skirt measures 0.34 against a
 0.35 floor. The hollow takes 11% out of a 12 mm clover signet.
+
+`examples/sketches.rs` is the same discipline on pencil sketches, built
+here and through CrossGems' own components for the side-by-side
+(`SKETCHES=A,N` runs only the named designs; `NOCT_*`, `BOLT_*`, `CLOUD_*`
+knobs probe one). What it measured: a **cast dot on a signet's table must
+ride the parting line** — a 0.2 mm dot 2 mm off it on the zero-draft
+table leaned 14° on its near flank, on the crest line it is clean; a
+plate wide across the band curls the loft's flank under it and the wall
+over the hole thinned to 0.62 mm where along the band it holds 1.30; a
+**collar across the whole outer surface** (a flat curve wire from bore
+edge to bore edge, eight round the ring on a beveled band) fields 0.000%
+— its flanks face round the ring, parallel to the pull; and a **cloud is
+a keyframed band** — five lobes lifting the crest and widening the plan
+with dips between, every section still one dome — whose curls go on the
+lobes' side faces as stamps, each drawn squashed by its lobe's own
+stretch (2.9 / 2.5 / 1.7) so it comes out round, centred and sized from
+the face the modulated section actually has (3.6 / 3.0 / 1.9 mm tall):
+raised onto the crown they leaned 12–19°, fitted to the face 0.007%.
 
 `examples/commissions.rs` is the same discipline applied to client sketches
 (half-wrap patterned crescents, a gem-set cross band, the Diamond and Cross

--- a/crates/ringdesign-core/examples/sketches.rs
+++ b/crates/ringdesign-core/examples/sketches.rs
@@ -7,7 +7,9 @@
 //   cargo run --release --example sketches [out_dir]
 use ringdesign_core::alpha::AlphaLibrary;
 use ringdesign_core::castability::{self, CastProcess, Verdict};
-use ringdesign_core::field::{Layer, LayerEntry, SeatPadLayer, SeatRunLayer, SeatStyle, SignetOutline, Window};
+use ringdesign_core::curve::{CurveLayer, WireProfile};
+use ringdesign_core::field::{Decal, DecalLayer, Layer, LayerEntry, SeatPadLayer, SeatRunLayer, SeatStyle, SignetOutline, Window};
+use ringdesign_core::svg::SvgAlpha;
 use ringdesign_core::gem::{Gem, GemCut};
 use ringdesign_core::mesh::{self, BuildParams};
 use ringdesign_core::profile::{ShankKey, ShankKind, SIGNET_MIN_SHANK_FRAC, TOP_DEG};
@@ -184,8 +186,11 @@ fn main() {
     // cast dot where each goes and the report carries the stones. The dots
     // ride the crest line: off it, on a zero-draft table, a dot's near flank
     // leans back (measured 14 deg with the face across the band).
-    let hw = 5.0 - 1.2;
-    let ay = 11.0 - 1.2 * std::f64::consts::SQRT_2;
+    // Then the whole face scaled so its width is the band's own 4.5 mm:
+    // 11.0 x 4.5, the dots scaled with it.
+    let scale = knob("NOCT_SCALE", 4.5 / (2.0 * (5.0 - 1.2)));
+    let hw = (5.0 - 1.2) * scale;
+    let ay = (11.0 - 1.2 * std::f64::consts::SQRT_2) * scale;
     let cy = ay - hw;
     let corners = [[-cy, -hw], [-ay, 0.0], [-cy, hw], [cy, hw], [ay, 0.0], [cy, -hw]];
     // Twelve stations an edge: the importer wants a polyline, not six corners.
@@ -222,7 +227,7 @@ fn main() {
     d.shank.head.loft_lateral_mm = 2.0;
     let ctx = d.field_context();
     let plane_r = d.inner_radius_mm() + d.profile.thickness_mm + d.shank.head.rise_mm;
-    for (i, dx) in [-6.6, -2.2, 2.2, 6.6].iter().enumerate() {
+    for (i, dx) in [-6.6 * scale, -2.2 * scale, 2.2 * scale, 6.6 * scale].iter().enumerate() {
         // A 1 mm dot, 0.2 proud, at the ring angle its station on the table
         // plane projects to. Its skirt is the finest feature and reads
         // 0.38 mm at the chart's metal scale, over the 0.35 mm floor.
@@ -233,6 +238,156 @@ fn main() {
         seat.elong = 1.0;
         d.layers.layers.push(LayerEntry::new(&format!("Amethyst {}", i + 1), Layer::SeatPad(seat)));
     }
-    finish(&dir, "N-nocturnal-face", "18.6 x 7.6 hexagon face along the band, flat, four cast dots for 2.5 mm amethysts", WHITE, d, &mut lib);
+    finish(&dir, "N-nocturnal-face", "11.0 x 4.5 hexagon face along the band, flat, four cast dots for 2.5 mm amethysts", WHITE, d, &mut lib);
+    }
+
+    if want("P") {
+    // --- P. Bolt ring: eight shafts and the collars between them ----------
+    // The sketch reads as bone; the brief says bolt, so the section is
+    // beveled with flat sides, each shaft waists only a little, and the
+    // collars are flat-topped wires run across the whole outer surface —
+    // their flanks face round the ring, parallel to the pull, and on the
+    // side faces they are relief where relief is always castable.
+    let mut d = RingDesign::default();
+    d.size = RingSize::new(7.0);
+    d.profile.apply_style(ProfileStyle::Beveled);
+    d.profile.width_mm = 4.0;
+    d.profile.thickness_mm = 2.2;
+    d.profile.flatten_sides();
+    d.shank.kind = ShankKind::Keyframes;
+    d.shank.amount = 1.0;
+    let waist = knob("BOLT_WAIST", 0.85);
+    d.shank.keys = (0..16)
+        .map(|k| {
+            let collar = k % 2 == 0;
+            ShankKey {
+                theta_deg: TOP_DEG + 22.5 * k as f64,
+                width_scale: if collar { 1.0 } else { waist },
+                thickness_scale: if collar { 1.0 } else { 0.5 + 0.5 * waist },
+                crown_scale: 1.0,
+            }
+        })
+        .collect();
+    let ctx = d.field_context();
+    let collar = CurveLayer {
+        points: vec![[0.5, 0.0], [0.5, ctx.band_v_len_mm]],
+        repeats_around: 8,
+        closed: false,
+        width_mm: knob("BOLT_COLLAR_W", 1.6),
+        height_mm: knob("BOLT_COLLAR_H", 0.45),
+        profile: WireProfile::Flat,
+        taper: 0.0,
+        mirror_v: false,
+    };
+    d.layers.layers.push(LayerEntry::new("Collars", Layer::Curve(collar)));
+    finish(&dir, "P-bolt-ring", "eight beveled shafts, flat collars across the band", WHITE, d, &mut lib);
+    }
+
+    if want("Q") {
+    // --- Q. Cloud ring: five lobes along the crest, swirls on the sides -----
+    // The cloud is the band itself: keyframed stations lift the crest and
+    // widen the plan at five lobes with dips between, so every section is
+    // still one dome and the valleys run along the ring, never across it.
+    // The curls are round wires on the side faces, the one place relief
+    // cannot undercut.
+    let mut d = RingDesign::default();
+    d.size = RingSize::new(7.0);
+    d.profile.apply_style(ProfileStyle::LowDome);
+    d.profile.width_mm = 3.2;
+    d.profile.thickness_mm = 2.0;
+    d.profile.flatten_sides();
+    d.shank.kind = ShankKind::Keyframes;
+    d.shank.amount = 1.0;
+    let lobe = knob("CLOUD_LOBE", 1.0);
+    // Lobes stand three band-thicknesses proud with flatter crowns, so
+    // each is a tall flat face with a rounded rim — the puff the sketch
+    // draws curls on; the dips between them make five clouds, not a ridge.
+    let station = |off: f64, w: f64, t: f64, c: f64| ShankKey { theta_deg: TOP_DEG + off, width_scale: 1.0 + (w - 1.0) * lobe, thickness_scale: 1.0 + (t - 1.0) * lobe, crown_scale: c };
+    d.shank.keys = vec![
+        station(0.0, 2.4, 2.9, 0.7),
+        station(11.0, 1.9, 1.9, 0.8),
+        station(-11.0, 1.9, 1.9, 0.8),
+        station(22.0, 2.1, 2.4, 0.7),
+        station(-22.0, 2.1, 2.4, 0.7),
+        station(33.0, 1.4, 1.4, 0.8),
+        station(-33.0, 1.4, 1.4, 0.8),
+        station(44.0, 1.5, 1.65, 0.75),
+        station(-44.0, 1.5, 1.65, 0.75),
+        station(60.0, 1.05, 1.05, 1.0),
+        station(-60.0, 1.05, 1.05, 1.0),
+        station(180.0, 1.0, 1.0, 1.0),
+    ];
+    let ctx = d.field_context();
+    // The curls: one hook of a turn and a tenth per lobe, on both side
+    // faces. The chart's v is the section's arc normalized, so a stamp
+    // stands taller than wide on a lobe by the lobe's own stretch; each
+    // lobe's art is drawn squashed by that factor and comes out round.
+    let inner_r = d.inner_radius_mm();
+    let crest_r = inner_r + d.profile.thickness_mm;
+    // Per lobe: the chart's stretch there, and the low side face's own run
+    // in metal — the surface points whose normal leans 80 degrees or more
+    // along the pull, walked from the low bore edge — so each hook is
+    // centred on its face and sized to it.
+    let face_of = |theta: f64| -> (f64, f64, f64) {
+        let m = d.modulation_at(theta, inner_r, crest_r);
+        let l = d.profile.sample_mod(inner_r, 192, &m);
+        let k = l.surface_len_mm / ctx.band_v_len_mm;
+        let steep = (80.0f64).to_radians().sin();
+        let (mut lo, mut hi) = (f64::MAX, f64::MIN);
+        for p in l.pts.iter().filter(|p| p.surface && p.v_mm < 0.5 * l.surface_len_mm) {
+            if p.nz.abs() >= steep {
+                lo = lo.min(p.v_mm);
+                hi = hi.max(p.v_mm);
+            } else if hi > lo {
+                break;
+            }
+        }
+        if hi <= lo { (k, 0.0, 0.0) } else { (k, lo, hi) }
+    };
+    let hook = |k: f64| -> String {
+        let pts: Vec<String> = (0..=120)
+            .map(|i| {
+                let t = i as f64 / 120.0;
+                let a = t * 1.05 * std::f64::consts::TAU;
+                let r = 6.0 + 41.0 * t;
+                format!("{:.1} {:.1}", 50.0 + r * a.cos(), 50.0 + r * a.sin() / k)
+            })
+            .collect();
+        format!(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M{}" fill="none" stroke="#000" stroke-width="20" stroke-linecap="round"/></svg>"##,
+            pts.join(" L")
+        )
+    };
+    // The low side face's run, said explicitly: `wider()` ties on a
+    // symmetric band and may hand back the high face.
+    let face = ctx.side_faces_std().and_then(|f| f.wider());
+    let vc_low = face.map_or(0.7, |(a, b)| {
+        let c = 0.5 * (a + b);
+        if c < ctx.crest_v_mm { c } else { ctx.band_v_len_mm - c }
+    });
+    let v_low = knob("CLOUD_CURL_V", 0.9).max(vc_low * 0.5);
+    let faces = [face_of(TOP_DEG), face_of(TOP_DEG + 22.0), face_of(TOP_DEG + 44.0)];
+    let mut layers = Vec::new();
+    for (n, (name, off)) in [("Cloud curl centre", 0.0), ("Cloud curl mid", 22.0), ("Cloud curl outer", 44.0)].into_iter().enumerate() {
+        let (k, lo, hi) = faces[n];
+        d.svgs.push(SvgAlpha { name: name.into(), svg: hook(k), invert: false });
+        // The hook fills 0.8 of the face's height, in metal; its stamp is
+        // that wide, and the stamp's centre is the face's, read back into
+        // the chart. Never under 2.2 mm, the size its stroke casts at.
+        let size = (0.8 * (hi - lo) * knob("CLOUD_CURL_S", 1.0)).max(2.2);
+        let v_face = if hi > lo { 0.5 * (lo + hi) / k } else { v_low };
+        let mut decals = Vec::new();
+        for sign in if off == 0.0 { vec![1.0] } else { vec![1.0, -1.0] } {
+            let theta = TOP_DEG + sign * off;
+            decals.push(Decal { theta_deg: theta, v_mm: v_face, size_mm: size, rotation_deg: 0.0, height_mm: 0.25, flip: false });
+            decals.push(Decal { theta_deg: theta, v_mm: ctx.band_v_len_mm - v_face, size_mm: size, rotation_deg: 0.0, height_mm: 0.25, flip: true });
+        }
+        println!("{:<22}   {name}: stretch {k:.2}, face {lo:.2}..{hi:.2} mm of metal, hook {size:.2} mm at chart v {v_face:.2}", "");
+        layers.push(DecalLayer { alpha: name.into(), decals, feather_mm: 0.25, invert: false });
+    }
+    for (n, l) in layers.into_iter().enumerate() {
+        d.layers.layers.push(LayerEntry::new(&format!("Curls {}", n + 1), Layer::Decals(l)));
+    }
+    finish(&dir, "Q-cloud-ring", "five lobes keyframed into the crest, curls on the side faces", WHITE, d, &mut lib);
     }
 }

--- a/crates/ringdesign-core/src/dfm.rs
+++ b/crates/ringdesign-core/src/dfm.rs
@@ -38,6 +38,63 @@ pub fn findings_in(design: &RingDesign, lib: &crate::AlphaLibrary) -> Vec<DfmFin
             }
         }
     }
+    // A stamp is a texture too: its footprint guesses 15% of the stamp,
+    // but the alpha can be measured at each stamp's own mm per texel, and
+    // the measurement replaces the guess either way.
+    for (i, entry) in design.layers.layers.iter().enumerate() {
+        let Layer::Decals(dl) = &entry.layer else { continue };
+        if !entry.enabled {
+            continue;
+        }
+        let Some(alpha) = lib.get(&dl.alpha) else { continue };
+        // The chart's v is the section's arc normalized, so on a station
+        // thicker than the reference a stamp stands taller than it is wide
+        // by that ratio: measure the alpha stretched the same way, and the
+        // metal's own features come out, squashed art included.
+        let inner_r = design.inner_radius_mm();
+        let crest_r = inner_r + design.profile.thickness_mm;
+        let mut finest_of: Option<(&str, f64)> = None;
+        for d in dl.decals.iter().take(crate::field::MAX_DECALS) {
+            let m = design.modulation_at(d.theta_deg, inner_r, crest_r);
+            let k = design.profile.sample_mod(inner_r, 96, &m).surface_len_mm / ctx.band_v_len_mm.max(1e-9);
+            let k = if k.is_finite() { k.clamp(0.25, 8.0) } else { 1.0 };
+            let (w, h) = (alpha.width.max(1), alpha.height.max(1));
+            let hs = ((h as f64 * k).round() as usize).clamp(1, 4096);
+            let stretched = if hs == h {
+                alpha.clone()
+            } else {
+                let mut data = Vec::with_capacity(w * hs);
+                for row in 0..hs {
+                    let src = ((row as f64 + 0.5) / hs as f64 * h as f64) as usize;
+                    data.extend_from_slice(&alpha.data[src.min(h - 1) * w..src.min(h - 1) * w + w]);
+                }
+                crate::alpha::Alpha::new(format!("{} x{k:.2}", alpha.name), w, hs, data)
+            };
+            let Some((ink_px, gap_px)) = stretched.min_feature_px() else { continue };
+            let scale = d.size_mm / w as f64 * ctx.arc_scale(d.v_mm);
+            if !(scale.is_finite() && scale > 0.0) {
+                continue;
+            }
+            let (ink, gap) = (ink_px * scale, gap_px * scale);
+            let (what, f) = if ink <= gap { ("strokes", ink) } else { ("gaps", gap) };
+            if finest_of.is_none_or(|(_, best)| f < best) {
+                finest_of = Some((what, f));
+            }
+        }
+        let Some((what, finest)) = finest_of else { continue };
+        out.retain(|f| f.layer != i);
+        if finest < min {
+            let smallest = dl.decals.iter().map(|d| d.size_mm).fold(f64::MAX, f64::min);
+            out.push(DfmFinding {
+                layer: i,
+                label: entry.name.clone(),
+                message: format!(
+                    "the {} stamp's finest {what} measure {finest:.2} mm at its smallest, {smallest:.1} mm, against the sand's {min:.2} mm floor — they will cast as mush. Enlarge the stamp, bolden the art, or accept the softness.",
+                    dl.alpha
+                ),
+            });
+        }
+    }
     for (i, entry) in design.layers.layers.iter().enumerate() {
         if !entry.enabled || out.iter().any(|f| f.layer == i) {
             continue;
@@ -187,6 +244,47 @@ mod measured_tests {
         assert!(measured[0].message.contains("Greek Key"), "{}", measured[0].message);
         d.draft.min_detail_mm = 0.0;
         assert!(findings_in(&d, &lib).is_empty(), "no floor, no finding");
+    }
+
+    /// A stamp is measured at its own mm per texel, on the section as
+    /// modulated at its station: a bold hook passes where the 15% guess
+    /// said mush, and the same art at half the size fails.
+    #[test]
+    fn a_stamp_is_measured_not_guessed() {
+        let hook: String = {
+            let pts: Vec<String> = (0..=120)
+                .map(|i| {
+                    let t = i as f64 / 120.0;
+                    let a = t * std::f64::consts::TAU;
+                    let r = 6.0 + 40.0 * t;
+                    format!("{:.1} {:.1}", 50.0 + r * a.cos(), 50.0 + r * a.sin())
+                })
+                .collect();
+            format!(
+                r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M{}" fill="none" stroke="#000" stroke-width="20" stroke-linecap="round"/></svg>"##,
+                pts.join(" L")
+            )
+        };
+        let mut lib = crate::AlphaLibrary::builtin();
+        let mut d = RingDesign::default();
+        d.profile.width_mm = 6.0;
+        d.profile.thickness_mm = 2.0;
+        d.profile.flatten_sides();
+        d.svgs.push(crate::svg::SvgAlpha { name: "Hook".into(), svg: hook, invert: false });
+        d.bake_all(&mut lib);
+        let ctx = d.field_context();
+        let stamp = |size: f64| crate::field::DecalLayer {
+            alpha: "Hook".into(),
+            decals: vec![crate::field::Decal { theta_deg: crate::profile::TOP_DEG, v_mm: ctx.crest_v_mm, size_mm: size, ..Default::default() }],
+            ..Default::default()
+        };
+        d.layers.layers.push(LayerEntry::new("Bold", Layer::Decals(stamp(2.25))));
+        assert!(!findings(&d).is_empty(), "the 15% guess calls a 2.25 mm stamp mush");
+        assert!(findings_in(&d, &lib).is_empty(), "measured, a 0.45 mm stroke and gap pass: {:?}", findings_in(&d, &lib));
+        d.layers.layers[0].layer = Layer::Decals(stamp(1.0));
+        let f = findings_in(&d, &lib);
+        assert_eq!(f.len(), 1, "{f:?}");
+        assert!(f[0].message.contains("measure") && f[0].message.contains("Hook"), "{}", f[0].message);
     }
 
     /// What the measure says about the shipped templates, printed under


### PR DESCRIPTION
Two more sketched rings as sand patterns in `examples/sketches.rs`, and the slimmed Nocturnal face (11.0 × 4.5 mm on a 4.5 mm band).

- **Bolt ring**: eight beveled shafts, flat collars run as curve wires across the whole outer surface — flanks face round the ring, parallel to the pull. 0.000 %, 1.25 mm wall.
- **Cloud ring**: a keyframed band — five flat-faced lobes lifting the crest and widening the plan, dips between — with a hook curl stamped on each lobe's side face, drawn squashed by that lobe's own chart stretch (2.9 / 2.5 / 1.7) and centred and sized from the face the modulated section actually has. Raised onto the crown the curls leaned 12–19°; fitted, 0.007 %.
- **DFM measures stamps**: the alpha is stretched by the section's arc ratio at the stamp's station and read by granulometry at its own mm per texel, replacing the 15 %-of-size footprint guess (which called a 2.25 mm hook with a 0.45 mm stroke mush). Pinned by `a_stamp_is_measured_not_guessed`; core suite green under the memory guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015z4xSoyNyNRaeYo7SUFmth