### PR TITLE
The audit, and the roadmap it writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -990,6 +990,33 @@ The pattern therefore follows the band as it tapers instead of sliding across
 it. `mesh::build` and `castability::section_at` must do this identically — if
 they diverge, the section view lies about the solid.
 
+## Two things the model does not yet know
+
+Recorded here because they are doctrine-level, not tickets: a reader of this file will otherwise
+assume both are handled, since everything around them is. The 2026-08-30 audit
+(`docs/AUDIT-2026-08-30.md`, roadmap M10-M24) established them, and both are still open.
+
+**The verdict is radial and cannot see the axial web.** `thinnest_wall` walks bore points and
+interpolates the surface at the same `z`; `bore_span_wall` bins by `z` and subtracts bore radius
+from surface radius. Both measure outward from the finger hole. Nothing measures metal *across* the
+band — which is exactly where this file sends every deep carve. `OpenworkLayer::height` says so
+itself: the carve eats `depth * nr` of radial metal, so on a side face where `nr` is ~0 the cap
+opens up and `depth_mm` is the only limit left. A 1.8 mm band carved 0.8 mm from each face leaves a
+0.2 mm web and reports a healthy wall. Four independent audit dimensions found this, and it is a
+**fill** rule, not a draft one: a thin web does not lock the mould, it comes out of the flask as two
+halves. Until `min_local_thickness_mm` exists on `FieldReport` (M11.1), do not trust a wall figure
+on a design carrying opposing side-face relief.
+
+**The model has one stage where the trade has two.** Every entry in the `LayerStack` is cast
+geometry, judged by `analyze_field` against the sand's 0.30-0.40 mm detail floor. That is correct
+for cast relief and it is why the showcase records that the guilloche generators carry 7-24 periods
+per tile and fall under the floor at any tile size a band holds. But in the trade the fine work is
+not cast: bright-cut, wriggle, ramshorn scroll, Florentine line, true rose-engine guilloche, inside
+lettering and a signet's seal are cut into the cast blank afterwards, with a graver or a machine.
+There is no way to say "this line is cut at the bench", so such a feature is either refused as
+NotCastable or measured as mush. `LayerEntry::stage` (M14) is the fix, and it is the prerequisite
+for intaglio, monograms, crests, hallmarks and everything on the bore.
+
 ## Manufacturing analysis speaks in the sand's numbers
 
 `DraftSettings` carries the sand itself: `min_draft_deg`, `min_section_mm`

--- a/docs/AUDIT-2026-08-30.md
+++ b/docs/AUDIT-2026-08-30.md
@@ -1,0 +1,3730 @@
+# RingDesigner audit — 2026-08-30
+
+The evidence base for milestones M10-M24. Produced by a 26-agent audit: thirteen domain
+auditors reading the tree, each finding then checked by an adversarial verifier whose job was
+to stop a false "we are missing X" reaching the roadmap, followed by two independent
+sequencing passes. **243 findings**, none dropped as already-existing; 31 turned out to be the
+same thing found by two or more dimensions and are merged here.
+
+Read this the way `CLAUDE.md` is read: every claim carries the file and symbol it was read
+from, so a reader can audit the audit. Where a verifier sharpened or corrected the auditor,
+the corrected recommendation is what is printed.
+
+## The six-sentence summary
+
+1. **The pull is world-class; everything after the pull is missing.** `analyze_field` answers
+   "will it release" better than a person can. Nothing answers where to gate, how much to
+   melt, what polish eats, or whether the ring survives a week on a hand.
+2. **The verdict states numbers that are not true.** Switching Lost wax back to Sand leaves the
+   investment floors in place and the ring still reads Castable (F21); stone-to-stone metal is
+   judged against a hardcoded 0.3 mm while the sand's own floor is 0.7-0.8 (F58); the report
+   panel prints the *retired* mesh analyzer's numbers under the field verdict's banner (F123).
+   And there is no CI: 474 tests, no `.github` (F155).
+3. **The model has one stage: as cast.** So bright-cut, wriggle, guilloche, intaglio seals and
+   inside lettering - the fine work the trade actually sells - are judged NotCastable or
+   measured as mush (F93/F77). One missing concept blocks the largest family of ring variety.
+4. **Both wall measures are radial.** Four dimensions independently found that nothing measures
+   metal *across* the band (F115/F4/F226/F47), which is precisely where the doctrine sends
+   every deep carve.
+5. **Sizing is 54 lines, US-only, untested**, with no wide-band and no comfort-fit compensation
+   (F132/F133): the configurator gives a 14 mm signet the same bore as a 4 mm court band.
+6. **Lost wax is four lines and Free mode ships dark** (F20/F33): `ringdesign-gui` declares
+   `default = []`, so no UI can enter a whole documented, tested mode.
+
+## Where each finding went
+
+| Milestone | Effort | n | Findings |
+| --- | --- | --- | --- |
+| **M10** One verdict, spoken once | L | 47 | F5, F17, F19, F21, F22, F23, F25, F30, F58, F81, F83, F91, F105, F109, F110, F114, F123, F127, F128, F139, F143, F144, F147, F149, F150, F151, F152, F153, F154, F155, F156, F157, F158, F159, F160, F161, F162, F163, F164, F165, F166, F167, F172, F196, F197, F203, F223 |
+| **M11** The band has a thickness across it, too | L | 20 | F3, F4, F10, F11, F47, F66, F72, F115, F116, F118, F120, F121, F122, F126, F130, F136, F140, F141, F178, F226 |
+| **M12** Draw the plan, notch the band | M | 19 | F40, F45, F48, F49, F51, F55, F57, F99, F100, F101, F102, F103, F104, F112, F113, F148, F175, F187, F237 |
+| **M13** The first ten minutes | M | 10 | F56, F171, F173, F174, F176, F181, F184, F185, F239, F240 |
+| **M14** Cast is a stage; bench is the next one | L | 12 | F77, F79, F86, F89, F90, F93, F94, F95, F96, F97, F98, F108 |
+| **M15** The inside of the ring is a surface | L | 6 | F41, F78, F111, F135, F220, F224 |
+| **M16** Patterns get knobs and a seed | L | 14 | F75, F76, F80, F82, F84, F85, F87, F88, F177, F232, F233, F234, F235, F236 |
+| **M17** Many combinations, one grid | L | 7 | F168, F169, F170, F182, F183, F213, F214 |
+| **M18** The sand is a recipe, not three numbers | L | 17 | F6, F7, F8, F9, F12, F15, F20, F24, F26, F27, F31, F50, F117, F129, F192, F209, F217 |
+| **M19** Gate it, sprue it, ram it up | XL | 13 | F1, F2, F13, F14, F16, F18, F28, F29, F119, F124, F201, F221, F242 |
+| **M20** A stone is stock with a species | XL | 22 | F42, F43, F44, F52, F59, F60, F61, F63, F64, F65, F67, F68, F70, F71, F73, F74, F193, F211, F229, F230, F231, F243 |
+| **M21** A size is a fit, not a number | M | 11 | F132, F133, F134, F137, F138, F142, F145, F146, F215, F227, F228 |
+| **M22** More than one body | XL | 19 | F32, F33, F34, F35, F36, F37, F38, F39, F46, F53, F54, F62, F69, F92, F106, F107, F205, F225, F238 |
+| **M23** The shop floor: quote it, order it, catalogue it | XL | 15 | F125, F131, F179, F180, F198, F199, F206, F207, F208, F210, F212, F216, F218, F219, F222 |
+| **M24** File doors | L | 11 | F186, F188, F189, F190, F191, F194, F195, F200, F202, F204, F241 |
+
+Total: **243**. Every finding appears in exactly one milestone.
+
+## Ten things the 243 findings missed
+
+Added by a jeweller-perspective pass over the audit itself. Folded into the milestones above.
+
+**N1 — Nothing is ever shown at actual size** *(M13, M17)*  
+No life-size viewport lock, no DPI calibration, no scale reference or finger context in any render. A jeweller judges a 6 mm band by holding it.
+
+**N2 — No stock list or stretch-out** *(M19)*  
+Cut length is pi*(ID + t) and the app knows both exactly at every angle. "6.0 x 1.5 half-round sterling, 58.6 mm cut, 4.2 g" is the most-used calculation at a bench and appears nowhere. Also: the master's own weight in resin, so the bench can weigh the print before it commits.
+
+**N3 — The shrink ladder, not one shrink number** *(M18)*  
+A repeat-production master goes master -> rubber mould (-1.5 to -3%) -> wax (-0.4%) -> investment (+0.2%) -> metal (-1.3 to -1.9%), and those compound. `metal::pattern_scale` is one scalar. A shop that vulcanises one master for a size run needs the product; cutting the master at sand shrink puts the third-generation ring most of a size small.
+
+**N4 — The trade quotes in pennyweight** *(M23)*  
+Everything is grams. US shops and casters quote dwt (1.5552 g) and troy ounces, and spot is per troy ounce. And there is no melt/alloy calculator: customer brings 4.1 g of 14k scrap, you need 18 g of pour, how much fine gold and how much alloy.
+
+**N5 — The punch check** *(M15)*  
+You cannot strike a hallmark into a 1.0 mm shank without bellying the ring, and you need a flat land about 2.5 mm wide to land it. The app knows the wall thickness at every angle and never says it. No competitor makes that check.
+
+**N6 — Which way is up** *(M24)*  
+Nothing in the model declares wearer orientation, and every drawing, sheet, stone map and parting-line SVG leaves it out. On a contoured band, an asymmetric head or an inside inscription it is genuinely ambiguous. One arrow: "top toward fingertip", seam at TOP_DEG.
+
+**N7 — A reference-image underlay** *(M12)*  
+`examples/sketches.rs` proves this shop works from pencil sketches and customer photos, and there is no way to put a picture behind the unrolled canvas or the plan view and trace it with two-point mm calibration. It is the natural front door for a drawn head plan.
+
+**N8 — The alloy changes the floors** *(M18)*  
+`min_section_mm` is a property of the pair (sand, alloy, pour temperature): bronze fills sections sterling will not, and sterling in open sand needs a deoxidised alloy or the polish comes up grey with firescale. The fill floor should be a function, not a constant of the sand alone.
+
+**N9 — The inside edge break should be a default** *(M15)*  
+A sharp arris where the bore meets the side face is the most common complaint about a shop-made band, and the reference signet has 0.2 mm edge breaks. Every bore edge should get one unless the user takes it away.
+
+**N10 — Mirror the design** *(M12)*  
+A contoured band for the left hand is the mirror of the right, and a matched pair usually needs both. One boolean over the chart's u.
+
+## Eight more, from the concurrent core audit
+
+A second audit ran against this tree in parallel and filed its own tickets. Most of it
+restates findings above from the implementation side, and those are merged into the
+milestone epics as work items. These eight are things it saw and this audit did not.
+
+**C1 — A twelfth signet outline panics on first use** *(M12 (issue 104))*  
+`silhouette()` is backed by `static T: [OnceLock<Silhouette>; 11]` indexed by `SignetOutline::index()`, and `SignetOutline::ALL` has exactly 11 entries. Appending one panics on first use. This audit found no way to bring a drawn plan in and missed that adding a builtin is booby-trapped.
+
+**C2 — The builtin outline set is short of the trade's** *(M12 (issue 127))*  
+Square, Tonneau (antique barrel cushion), Pear, Kite, Coffin, Oxford, Lozenge, Quatrefoil, Star, Horseshoe and the heraldic escutcheons are all castable plans and none is offered. This audit asked for an import path and never counted what ships.
+
+**C3 — Sand has a pour ceiling, and nothing enforces it** *(M18 (issue 102))*  
+Roughly 1100 C for Delft clay and ~1200 C for Petrobond, non-ferrous only. Platinum (1768 C) and palladium are in `METALS` and the app will quote a sand pattern for either. This audit said `metal.rs` models weight and shrink; it did not notice the app offers a metal the process cannot pour.
+
+**C4 — A process must carry its own numbers without changing its serialised shape** *(M18 (issue 147))*  
+`CastProcess` is a unit-variant enum serialised as a bare string on every saved `DraftSettings`. Widening it to `LostWax { .. }` breaks every file. A `ProcessSpec` sibling is the way in - the shape of the fix, which this audit did not work out.
+
+**C5 — A rubber production mould is a third process** *(M18 (issue 151))*  
+Undercut becomes a depth limit rather than a verdict, wax fills thinner than metal (~0.4 mm), and rubber picks up finer detail than any sand (~0.05 mm). This audit treated the world as sand-or-investment; a shop that vulcanises a master has a third set of floors.
+
+**C6 — Luminance is not height** *(M16 (issue 153))*  
+`Alpha::from_bytes` reads an image and treats luminance as height, so a photograph's raking light becomes relief that is not there. `height_from_normals` is the conversion every image-to-relief path needs. This audit criticised the pipeline and missed the wrong assumption at its head.
+
+**C7 — A matrix needs a cartesian product and a filter** *(M17 (issues 123, 124))*  
+`list.cross` over up to four pins with an index and a label list, then `list.compact` and `list.filter_by` so a verdict gate can drop the failures. This audit asked for a variant explorer without naming the two list primitives it is built from.
+
+**C8 — Ornament should be transplantable between designs** *(M17 (issues 131, 132))*  
+`adopt_ornament` moves a layer stack and its referenced assets onto another band and refits each layer; a `.look.json` makes that bundle a shareable document. This audit wanted variation and never asked how a look moves from one ring to another.
+
+## Four the audit got wrong
+
+**F53 Open, adjustable and cuff rings.** Filed as structurally impossible. It is not a casting problem at all: a C-shaped band with a domed section pulls perfectly well. It is that `mesh::build` hard-wires a closed torus. A topology change in one module, and it also gets bangles and the whole wrap/snake family.
+
+**F227 Bangles.** Filed high/M alongside F53. It is an S: a range check on `RingSize` (`design.new` rejects outside 1-20; the sweep already works at 60-70 mm). Merging it with F53 buries a one-day win under a multi-week one.
+
+**F62 Bar setting.** The finding says so itself: provably castable in a two-part mould. Build it, do not refuse it.
+
+**F45 Cathedral.** A cathedral's void is under the head and over the finger, which is exactly what `SignetHead::hollow_mm` already casts through `ShankMod::bore_lift_mm` with the field verdict clean. A cathedral is a crest rise plus a bore lift plus a shoulder arc, using machinery that exists and is measured.
+
+## The honest no: a refusal registry
+
+The app already does this well in two places, and they are the template: the prong report says
+"cast flush and bead-set or judge for lost wax", and `pave::halo` builds a gypsy plate with
+zero-height markers rather than the proud melee ring it measured at 1.4% / -33 degrees.
+Generalise that into a registry (F73, M20) - reason, measurement, remedy - and populate it:
+
+- **Free-standing prong heads, baskets, peg heads, six-claw, tension (F54/F69)** — All four need a void under the girdle, and that void is a re-entrant no single +/-Z parting plane clears.  
+  *Say:* "A basket is open under the stone - a two-part sand mould cannot form that void. In sand I can give you a bezel, a gypsy plate or a flush seat here. For a real basket: switch to lost wax and I will build it, or cast the head separately and solder it."
+- **The pierced gallery / open back under a head (F107)** — Same geometry one level up. (The *hollow* under a head is different and already works, because a bore surface's normal is radial at any radius.)  
+  *Say:* "The gallery is a window through the flank under the table - it faces across the pull. Cast it solid and pierce it with a saw, or go lost wax."
+- **Piercing through metal (F32/F92/F225)** — Be precise instead of banning it: a hole whose axis is +/-Z, punched from one side face to the other, is parallel to the pull and casts; a hole through the band's thickness is a horizontal core and does not.  
+  *Say:* "I pierce along the pull only. This hole runs through the band's thickness - drill it at the bench (0.9 mm, from the outside, here) or go lost wax."
+- **Anything on the bore that is not a monotone widening (F41/F224/F78/F220)** — The sand column in the finger hole is one rigid piece pulled along Z, so any pocket or ridge in the bore wall locks it. Sizing beads are soldered, full stop.  
+  *Say:* "Nothing cast goes inside the ring. The bore is cored and reamed. Your inscription is a bench operation - here it is at 1:1, mirrored, 0.15 mm deep, with the wall you have left to cut into."
+- **Two-tone and mokume (F50)** — Two metals is not one pour. Mokume-gane is a diffusion-bonded billet that is forged, not poured - render the look if you like, never claim it casts.  
+  *Say:* "Two-tone is two castings and a solder joint. Name the regions and I will export two parts with a 0.05 mm running fit and print a joint plan."
+- **Inlay retention (F51)** — The channel casts; the undercut that holds the inlay is by definition an undercut.  
+  *Say:* "The channel casts as drawn. The retention undercut is cut with a graver after casting; you will need 0.11 cm3 of fill."
+- **Blind pockets high in the cope (F12)** — Warn, do not refuse.  
+  *Say:* "This pocket is blind and sits 6 mm above the parting plane in Delft, which is nearly impermeable. Vent it, or turn the ring in the flask so it sits in the drag."
+
+## The findings
+
+### M10 — One verdict, spoken once (L, 47 findings)
+
+**Done when:** CI green, a golden corpus pins verdict + volume for every template, Sand->LostWax->Sand restores 0.7/0.35 exactly, and no sink writes a file the field verdict refuses.
+
+#### F5 Drag drops the verdict to Marginal without a single word of explanation — `high` / `S` / sand-process
+
+**Problem.** A design whose marginal + vertical area exceeds 12% is downgraded to "Castable with care" while the notes say "the surface itself carries no undercut at this parting". The user is told the ring is worse and simultaneously told nothing is wrong. There is no note, no location, and no attribution — undercut attribution exists and deliberately ignores drag.
+
+**Evidence.** castability.rs:1136-1143: `else if (undercut_area > 0.0 && !noise) || drag_frac > DRAG_FRACTION { Verdict::Marginal }`. The note block immediately below (1146-1170) branches only on `lost_wax` / `undercut_area`, so the drag-only path falls into the `else` arm and pushes "Field-sampled: the surface itself carries no undercut at this parting." `field_undercuts` (castability.rs:1258) filters `classify(...) == FaceClass::Undercut`, so `attribute_undercuts` can never explain a drag region.
+
+**Do this.** Do not write a new drag message — lift the one that already exists. Move the marginal/vertical note text from `analyze` (castability.rs:537-548) into `analyze_field`'s note block so the authoritative verdict, the casting sheet and the CLI all carry it; that alone removes the contradiction and costs nothing new. Then generalize `field_undercuts` to take a `FaceClass` predicate so `attribute_undercuts` can cluster and blame drag arcs, which is the part with no existing implementation anywhere.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Push a note in the drag branch naming the number and the cause ("18% of the surface is under 3° of draft — mostly the flat outer wall between 0 and 360°; dome the profile or accept scuffing"), and generalize `field_undercuts` to take a `FaceClass` predicate so `attribute_undercuts` can cluster and blame drag arcs with the same muting pass. A `Flat` or `KnifeEdge` profile plus a squared side face is a legitimately draggy ring; the user deserves to know that is what they built.
+
+</details>
+
+**Castability.** n/a — reporting only, no geometry change.
+
+**Verified.** The verdict logic and the contradictory field note are exactly as described (castability.rs:1141-1143 and the `else` arm at 1181), and `field_undercuts` (castability.rs:1258) does filter `classify(...) == FaceClass::Undercut`, so `attribute_undercuts` genuinely cannot blame a drag arc. BUT the explanation is not absent: the mesh analyzer `analyze` already emits a drag note with a percentage, an area and a fix — castability.rs:537 "X% of the surface (N mm2) carries less than D deg of draft and will drag on the sand. Raise the crown or add side draft to steepen it." — plus a separate vertical-wall note at 544. Those `CastReport.notes` reach the GUI report panel (gui/panels/report.rs:231) and the MCP `castability` payload (mcp/tools.rs:1161). The GUI banner also computes a combined drag+undercut percentage (report.rs:294-296). What is genuinely missing: the field verdict's own notes contradict the drag it just judged on; `spec::html` takes only `field` (spec.rs:29-36) so the printed sheet the caster holds gets no drag note; the CLI `check` prints only `f.notes` (cli/src/main.rs:97); and nothing locates or attributes the drag.
+
+#### F17 The build's wall clamp is a constant divorced from the sand's fill floor — `medium` / `S` / sand-process *(also found as F30)*
+
+**Problem.** `mesh::build` silently floors the radial wall at a hardcoded 0.5 mm. The verdict then judges the *same* geometry against `min_section_mm`, which defaults to 0.7 and becomes 0.8 under Delft clay. So the builder deliberately manufactures a wall the chosen sand cannot fill, and the verdict catches it after the fact — but only through the thinnest-wall note, and only if the clamp actually bit at the thinnest point. Switching to Delft clay moves the floor the verdict wants and does not move the floor the geometry is built to.
+
+**Evidence.** mesh.rs:20 `pub const MIN_WALL_MM: f64 = 0.5;`; mesh.rs:240 `BuildParams::default` sets `min_wall_mm: MIN_WALL_MM`; mesh.rs:353 `r = r.max((inner_r + min_wall).min(p.r))`; refine.rs:308 the same. castability.rs:110 `DraftSettings::default` sets `min_section_mm: 0.7`, and `SandProcess::apply` (castability.rs:141) writes 0.8 for Delft clay. Nothing connects the two — grep shows `BuildParams::min_wall_mm` is never assigned from `DraftSettings`.
+
+**Do this.** Take the note, not the auto-derivation. Defaulting `BuildParams::min_wall_mm` from `min_section_mm` would silently change the geometry of every saved design the moment a user switches sand — a Petrobond-to-Delft click would move metal, which is exactly the kind of hidden coupling this codebase's provenance rules exist to prevent. Implement the second half only: have `analyze_field` detect that the thinnest wall sits at the build's clamp (it has both numbers) and say so — "the wall at 210 deg is at the build's 0.50 mm floor, which is under the 0.80 mm Delft clay fills; the geometry was clamped, not designed". If the constant is to move at all, raise `MIN_WALL_MM` once, deliberately, with a measurement.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Default `BuildParams::min_wall_mm` from `design.draft.min_section_mm` at build time (keeping the explicit field for callers who want to override), or at minimum have the field verdict note when the clamp is what produced the thinnest wall — "the wall at 210° is at the build's 0.50 mm floor, which is under the 0.80 mm Delft clay fills; the geometry was clamped, not designed." A silent clamp that produces an unfillable section is worse than a warning about a thin one.
+
+</details>
+
+**Castability.** Raising the clamp thickens walls only — it cannot introduce an undercut, and it moves the bore's inner corner outward, which the existing `.min(p.r)` guard already handles.
+
+**Verified.** Verified. `MIN_WALL_MM = 0.5` (mesh.rs:20) feeds `BuildParams::default` (mesh.rs:240) and is applied at mesh.rs:356, refine.rs:308 and castability.rs:818 (so the section view and the mesh agree with each other). `DraftSettings::default` sets `min_section_mm: 0.7` (castability.rs:110) and `SandProcess::apply` writes 0.8 for Delft clay (castability.rs:141). Confirmed the two are never connected: every assignment of `min_wall_mm` in the workspace is either `MIN_WALL_MM` or a literal 0.5 (configurator/src/main.rs:31 and :282 hard-write 0.5), and there is no GUI or MCP control for it at all — a grep of the frontends finds only reads of `Section::min_wall_mm`.
+
+#### F19 The size-run manifest reports nominal volume beside an oversize pattern file, with no weight column — `low` / `S` / sand-process
+
+**Problem.** When `--shrink` is used, the exported mesh is scaled by `pattern_scale` — about 1.94% linear for sterling, so 5.9% in volume — while the manifest's `volume_mm3` column comes from the unscaled build report. The CSV therefore describes a file that is not the file it names, with no column and no note distinguishing pattern volume from casting volume, and no grams at all. This is the export-regression diff as well as the caster's index, so the ambiguity propagates.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:174-181: `let built = build(...)`, then `let (mesh, name) = match scale { Some((m, k)) => (built.mesh.scaled(k), ...) }`. main.rs:216-228 writes the row with `built.report.volume_mm3` — the pre-scale figure — while `file` names the `_pattern-sterling` STL. main.rs:168 defines the header with no grams column.
+
+**Do this.** Split the column into `casting_volume_mm3` and `pattern_volume_mm3` (the latter = casting × k³, present only when scaling), add `casting_g` for the shrink metal when one is given, and add a summary line after the loop with the run's total pour weight. Since the manifest doubles as the regression diff, this also makes a shrink-setting change visible in the diff rather than invisible.
+
+**Castability.** n/a.
+
+#### F21 CastProcess::apply never restores the sand floors, so a sand design silently keeps investment numbers — `high` / `S` / lost-wax *(also found as F114)*
+
+**Problem.** `CastProcess::apply` sets `d.process = self` and then writes `min_section_mm = 0.5` and `min_detail_mm = 0.15` only when the process is LostWax. Switching back to Sand (two-part) leaves both at the investment figures. The GUI toggle calls `p.apply(d)` for both arms, so a jeweller who tries lost wax and changes their mind is left judging a Delft-clay ring against a 0.5 mm fill floor and a 0.15 mm detail floor. Delft clay wants 0.8 and 0.30. The verdict then passes walls that will not fill and the DFM chips stop firing on strokes that will cast as mush.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:92-96 — `if self == CastProcess::LostWax { d.min_section_mm = 0.5; d.min_detail_mm = 0.15; }` with no else. crates/ringdesign-gui/src/panels/design.rs:1237-1240 calls `p.apply(d)` unconditionally on any process click. `SandProcess::apply` (castability.rs:138-148) writes the correct sand triple but must be clicked separately, and its picker only appears after the process is already back on Sand.
+
+**Do this.** Make `apply` a total match: LostWax writes (0.5, 0.15); SandTwoPart writes `SandProcess::DelftClay`'s triple (3.0 draft, 0.8 section, 0.30 detail) via `SandProcess::DelftClay.apply(d)` so there is one source for the sand numbers. Better still, remember the last sand preset on the design and restore it. Pin it with a round-trip test asserting min_section_mm >= 0.6 and min_detail_mm >= 0.25 after LostWax → SandTwoPart.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `CastProcess::apply` a total match: LostWax writes (0.5, 0.15) and SandTwoPart writes `SandProcess::DelftClay`'s triple (3.0, 0.8, 0.30) — better, remember the sand preset the design was on and restore it. Add a test that round-trips LostWax → SandTwoPart and asserts `min_section_mm >= 0.6`.
+
+</details>
+
+**Castability.** Directly attacks the sand guarantee: it is the one place where the lost-wax path can make a sand ring read castable when it is not.
+
+**Verified.** Verified verbatim at castability.rs:90-96: `pub fn apply(self, d: &mut DraftSettings) { d.process = self; if self == CastProcess::LostWax { d.min_section_mm = 0.5; d.min_detail_mm = 0.15; } }` — no else arm. crates/ringdesign-gui/src/panels/design.rs:1233-1237 calls `p.apply(d)` on any process click, both arms. The Sand-preset row (design.rs:1242-1256) is gated behind `if d.process == CastProcess::SandTwoPart`, so it does reappear after switching back — the loss is recoverable but silent, which is exactly the complaint. Worth noting the neutral default is min_section 0.7 / min_detail 0.35 (castability.rs:104-112), so LostWax→Sand leaves the design *below* even the untouched default.
+
+#### F22 The field banner tells a lost-wax design it "clears a two-part pull" while its own note says the opposite — `high` / `S` / lost-wax
+
+**Problem.** Under LostWax `analyze_field` returns `Verdict::Castable` unconditionally (fill aside), and the GUI's field banner renders the Castable arm's fixed string "The surface itself clears a two-part pull." — even when the same report's first note reads "Lost wax: 4.2% of the surface would undercut a two-part pull ... this pattern cannot move to sand as-is." The headline and the note contradict each other, and the headline is the part in green, large, at the top of the panel.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:1145-1147 (`let mut verdict = if lost_wax { Verdict::Castable }`) and :1156-1166 (the contradicting note). crates/ringdesign-gui/src/panels/report.rs:286 — `Verdict::Castable => "The surface itself clears a two-part pull.".to_string()`. Nothing in `field_banner` reads the process.
+
+**Do this.** Add a `process: CastProcess` field to `FieldReport`, set in `analyze_field` (it already has `settings.process` in scope at line 1142), and branch the Castable arm in `report.rs::field_banner`: sand keeps today's string; lost wax reads "Investment: fills and releases. N% would lock a two-part sand mould." Same branch for `spec.rs`'s verdict pill and the phone's banner. This is the cheapest of the twenty items and removes an outright false statement from the UI.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Pass the process into `field_banner` (or add a `FieldReport::process` field set by `analyze_field`) and give the Castable arm two texts: sand keeps today's, lost wax says "Investment: fills and releases. N% would lock a two-part sand mould." Do the same for the sheet's verdict pill in spec.rs.
+
+</details>
+
+**Castability.** Encourages moving a lost-wax pattern to sand on the strength of a headline that measured the opposite.
+
+**Verified.** Both halves verified. castability.rs:1144-1147: `let mut verdict = if lost_wax { Verdict::Castable }`. castability.rs:1156-1162 pushes the contradicting note. report.rs:286: `Verdict::Castable => "The surface itself clears a two-part pull.".to_string()`, and `field_banner` (report.rs:278) takes only `&FieldReport` — it has no access to the process, and `FieldReport` has no `process` field (struct returned at castability.rs:1196-1210). The banner renders only `detail`; the notes appear elsewhere in the panel, so the green headline and the note are visually separated, which makes the contradiction worse rather than better.
+
+#### F23 castability::analyze is process-blind and speaks sand out loud — `medium` / `S` / lost-wax
+
+**Problem.** The mesh-face analyzer — which paints the viewport's draft colours, feeds `sink.mesh_verdict` and is the Free-mode verdict — never reads `settings.process`. Under LostWax it still returns `NotCastable` above 1% undercut and still emits notes like "will drag on the sand", "the finger hole ... cores in the sand" and "move that pattern onto the side faces". A lost-wax design is painted red in the Draft shade mode, and every piece of advice it gives is the wrong advice for the pour that is actually happening.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:428 `pub fn analyze(mesh, settings, bore_radius_mm)` — the only `process` read in the file is at :1142, inside `analyze_field`. Verdict at :510-516 has no lost-wax arm. Sand-worded notes at :528-533, :537-541, :558-562. Consumed by crates/ringdesign-gui/src/panels/report.rs:5 and crates/ringdesign-graph/src/nodes/sink.rs `mesh_verdict`.
+
+**Do this.** Give `analyze` the same lost-wax arm as `analyze_field` (never gate on undercut) and switch the note vocabulary. The highest-value part is `sink.mesh_verdict`: it is free_only, so it is guaranteed to be judging a lost-wax piece, and it currently reports pull statistics as the verdict. Relabel the Draft shade legend under lost wax as "pull, for reference" so red reads as information.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `analyze` the same lost-wax arm as `analyze_field`: the verdict never gates on undercut, and every note switches vocabulary ("the investment burns out of this" / "this pattern will not move to sand"). Relabel the Draft shade legend under lost wax as "pull, for reference" so the red reads as information rather than failure.
+
+</details>
+
+**Castability.** None — the sand path is untouched. It removes a false alarm, not a real one.
+
+**Verified.** Verified. `pub fn analyze(mesh, settings: &DraftSettings, bore_radius_mm)` at castability.rs:428 receives the settings but the only `settings.process` read in the whole file is at :1142 inside `analyze_field`. The verdict at :510-517 has no lost-wax arm. Sand-worded notes confirmed verbatim: "...or move that pattern onto the side faces, which pull straight out" (:534), "...will drag on the sand" (:541), "...cores in the sand or gets reamed at the bench" (:562). Consumers: report.rs's `verdict_banner` (its Castable string at :355 is "Every face clears a two-part pull."), the Draft shade mode (viewport.rs:840), and `sink.mesh_verdict` (sink.rs:342) — which is the *only* verdict a Free-mode graph can reach.
+
+#### F25 min_detail_mm never gates anything, but the UI says it does — `medium` / `M` / lost-wax
+
+**Problem.** The lost-wax tooltip promises "Fill and detail still do [gate]". `analyze_field` reads `min_section_mm` and never reads `min_detail_mm` — the detail floor only produces advisory `DfmFinding`s on layer rows and in the sheet. The app's stated second gate does not exist in either process. Under investment this matters more than under sand, because investment's selling point is the detail it holds, and a design whose value is a 0.12 mm filigree line has no check saying whether the chosen process can reproduce it.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs — `min_detail_mm` appears only at :54-55 (field), :94 (apply), :99 (default), :110, :146; it is absent from `analyze_field`'s body (:1050-1210). crates/ringdesign-gui/src/panels/design.rs:1227-1231 tooltip text. crates/ringdesign-core/src/dfm.rs:27 reads it purely to build advisory findings.
+
+**Do this.** Make it gate, and reuse what exists: `attributed_field_report` is already the call every surface makes, and `dfm::findings_in` already returns measured feature sizes. Drop the verdict to `Marginal` when a measured feature is under, say, half the detail floor, and cite the finding in the note. This matters most under investment, where the detail *is* the reason for choosing the process. If gating is rejected, correct the tooltip and the sheet to say detail is reported, not enforced.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Either make it gate — a `DfmFinding` whose measured feature is under half the detail floor drops the verdict to Marginal, which is exactly what `Verdict::Marginal` means — or correct the tooltip and the sheet to say detail is reported, not enforced. Gating is the better answer: `dfm::findings_in` already returns the measured numbers and `attributed_field_report` is already the call every surface makes.
+
+</details>
+
+**Castability.** None to geometry; it tightens the verdict in both processes, which is the safe direction.
+
+**Verified.** Verified. Full grep of `min_detail_mm`: castability.rs:55 (field), :94 (apply), :110 (default), :146 (SandProcess) — it never appears in `analyze_field`'s body. Its real consumers are dfm.rs:27 and :128 (advisory `DfmFinding`s), spec.rs:84 (printed on the sheet), stones.rs:262 (a skirt warning), and app.rs:530 (`params.soften_mm` for the as-cast preview). The GUI tooltip at design.rs:1228-1231 does say "Fill and detail still do" gate. So the tooltip is a false statement about both processes. One nuance the auditor missed and worth keeping: `dfm::fit_to_floor` already exists (dfm.rs:203/213, used by examples/patternbands.rs) — the machinery to reason about the floor is there, only the verdict link is absent.
+
+#### F58 Judge stone-to-stone metal against the process fill floor, not a hardcoded 0.3 mm — `critical` / `S` / stone-setting
+
+**Problem.** The pairwise census and the seat-run bridge check both judge the metal between stones against constants (0.3 mm and MIN_EDGE_MM 0.2 mm) that are unrelated to the sand the ring is actually cast in. Delft clay's own fill floor is 0.8 mm and Petrobond's 0.6 mm (SandProcess::apply), and the DraftSettings default is 0.7. So the report tells a jeweller a 0.35 mm bridge is merely "tight" when Delft clay physically cannot fill it — the unsafe direction, on the check whose own doc comment says it is "said in the min_section_mm voice". The stone map then prints the contradiction out loud: its legend says red lines are "gaps under the sand's 0.80 mm fill floor" while the lines it draws are only those under 0.30.
+
+**Evidence.** crates/ringdesign-core/src/stones.rs:138 `pub const CROWD_TIGHT_MM: f64 = 0.3;` and its doc at :136; the run bridge warnings at stones.rs:235-243 (`bridge < MIN_EDGE_MM` then the literal `else if bridge < 0.3`); the census's own justification comment at stones.rs:328-332 ("this is a fill rule ... said in the min_section_mm voice"); crates/ringdesign-core/src/castability.rs:107-110 (default min_section_mm 0.7) and :141-142 (DelftClay 0.8, Petrobond 0.6); crates/ringdesign-core/src/stonemap.rs:137-141 prints `design.draft.min_section_mm` in the legend for lines drawn at CROWD_TIGHT_MM.
+
+**Do this.** Delete `CROWD_TIGHT_MM` and read `design.draft.min_section_mm` at all five sites: the two early-outs in `crowding` (stones.rs:360, :381), `StonesReport::crowding_note` (:122), the SeatRun literal `else if bridge < 0.3` (:242), and spec.rs:176's heading. Two named thresholds: under `min_section_mm` is "will not fill" (a red finding), under `min_section_mm * 1.5` is "tight". Note that `crowding()` cannot take the design's floor without also fixing spec.rs and stonemap.rs in the same change, or the sheet and the map still disagree. Pin the coupling by asserting in `the_census_measures_metal_between_stones_no_layer_can_see` that switching the design to Petrobond (0.6) and DelftClay (0.8) changes `tight_pairs` on the same geometry.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Delete CROWD_TIGHT_MM and read `design.draft.min_section_mm` in `stones::crowding`, `StonesReport::crowding_note` and the SeatRun bridge branch in `stones::walk`. Keep two thresholds with real names: below `min_section_mm` is "will not fill" (a finding), below `min_section_mm + a margin` is "tight". Pass the settings into `crowding()` (it already takes `design`). The stone map's legend then matches the lines it draws. Update `the_census_measures_metal_between_stones_no_layer_can_see` to assert against the design's own floor so the coupling is pinned.
+
+</details>
+
+**Castability.** None — it tightens a report threshold and touches no geometry. It will newly flag existing designs (the default eternity's bridge is 0.4 mm against Delft's 0.8), which is the point; the field verdict is unchanged.
+
+**Verified.** Every claim verified. `pub const CROWD_TIGHT_MM: f64 = 0.3;` is at crates/ringdesign-core/src/stones.rs:138 with the doc "Metal between two stones the sand still fills" at :136. It is the *only* threshold the census uses: the early-out at stones.rs:360 (`floor > CROWD_TIGHT_MM`), the tight-pair filter at stones.rs:381 (`if pair.worst_mm() >= CROWD_TIGHT_MM { continue; }`), and `crowding_note` at stones.rs:122. The SeatRun branch in `walk` (stones.rs:235-243) is worse than described — the second branch is a bare literal `else if bridge < 0.3` with the message "0.3 mm is safer", and the first is `MIN_EDGE_MM`, neither reading `design.draft`. `DraftSettings::default` is min_section_mm 0.7 (castability.rs:107); `SandProcess::apply` writes 0.8 for DelftClay and 0.6 for Petrobond (castability.rs:141-142). The contradiction is real in two places, not one: stonemap.rs:137-141 prints `design.draft.min_section_mm` in the legend for lines drawn only for pairs under 0.30, and spec.rs:176 prints the heading "N pairs under {CROWD_TIGHT_MM}" — so the casting sheet and the setter's map disagree with each other about what the floor is. `crowding()` already takes `&RingDesign` (stones.rs:339) so the settings are in hand at zero cost.
+
+#### F81 `Alpha::make_seamless` is dead code, and CLAUDE.md claims it is the import mechanism — `medium` / `S` / ornament
+
+**Problem.** CLAUDE.md states "`Alpha::make_seamless` cross-fades imported images" as the seamlessness mechanism for imports. Nothing in the app calls it — the only references outside its own definition are its own unit tests and the doctrine sentence. The alpha editor instead offers `mirror_tile`, which is a different operation with a different look: it folds the motif against itself, halving the design and imposing bilateral symmetry. For an imported ZBrush alpha or a scanned rubbing that is often exactly wrong.
+
+**Evidence.** `grep -rn 'make_seamless' .` outside target/: /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/CLAUDE.md l.981; /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/alpha.rs l.282 (definition) and l.1860-1877, 2094, 2128 (its own tests). No caller in ringdesign-gui, -cli, -mcp, -graph or -configurator. The editor's op chain is fixed at `crop -> auto_trim -> rotate -> flip -> mirror_tile -> edge_fade -> levels -> resize` (/home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/alpha_editor.rs module doc l.1-9, `Ops` l.50-62).
+
+**Do this.** Add a three-way seam control to `Ops` — None / Mirror (`mirror_tile`) / Cross-fade (`make_seamless(blend)`) — placed where `mirror` is today, with the existing `seam_error` readout beside it so the user gets a measured answer instead of a guess about which one worked on this particular image. Mirror is the wrong default for a scanned rubbing or an asymmetric ZBrush alpha: it halves the motif and imposes bilateral symmetry. Fix CLAUDE.md l.981 in the same commit — as written it asserts a mechanism the app does not use.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Put `make_seamless(blend)` in the editor's op chain as an alternative to `mirror_tile` — a three-way choice (None / Mirror / Cross-fade) with the existing `seam_error` readout already beside it to show which one actually worked on this image. The editor already displays seam error with good/warn thresholds, so the user gets an immediate measured answer rather than a guess. Then either the doctrine sentence becomes true or it should be corrected.
+
+</details>
+
+**Castability.** None — a mask operation, upstream of the height field. A cross-faded seam is if anything gentler than a mirrored one, since it cannot create the doubled ridge a fold produces at the join.
+
+**Verified.** Verified. `grep -rn make_seamless crates/ CLAUDE.md docs/ graphs/ tools/` returns: the definition at alpha.rs l.282, its own tests at l.1860/1864/1874/1876/2094/2128, and CLAUDE.md l.981. Zero callers in ringdesign-gui, -cli, -mcp, -graph, -configurator or any example. The editor's chain is fixed at `crop -> auto_trim -> rotate -> flip -> mirror_tile -> edge_fade -> levels -> resize` (alpha_editor.rs module doc l.1-9; `Ops` l.49-61 has `mirror: Option<Axis>` and no seamless field). The seam readout it should sit beside is real — `SEAM_GOOD = 0.02` / `SEAM_WARN = 0.08` at alpha_editor.rs l.32-34.
+
+#### F83 The Flutes DFM footprint is transposed, so reeding evades the arc-scale correction and its land is never measured — `high` / `S` / ornament
+
+**Problem.** Two defects in one footprint. (1) `Layer::Flutes` reports `FeatureFootprint::across(l.width_mm, ...)`, setting `feature_u_mm = INFINITY` and `feature_v_mm = width_mm` — documented as "a rail, a flute, a milgrain line: it runs the whole way round, so u does not limit it". True only when `along == true`. With `along == false`, the DEFAULT and the coin-edge/reeding case, the flutes repeat AROUND the ring and `width_mm` is a `u` measure. Because `metal_feature_mm` computes `(feature_u_mm * k).min(feature_v_mm)`, the infinity swallows the arc-scale factor and the finest feature is reported at chart size, not metal size. On a squared side face k is 0.80–0.85, so a 0.40 mm reed is 0.34 mm of metal against the 0.35 mm default floor — and it passes. Optimistic, on exactly the surface the doctrine sends all ornament to. (2) The land between reeds is never measured at all. `FlutesLayer::height` clamps `half = (width_mm.min(cell_mm)) * 0.5`, so as `count` rises the flutes butt and the land goes to zero, while the footprint keeps reporting `width_mm` and the checker stays silent. A 200-count coin edge on a 55 mm circumference has a 0.275 mm cell and no land whatever, and the report says it is fine.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/field.rs — `Layer::feature_footprints`, Flutes arm (l.620-624); `FeatureFootprint::across` (l.709-712) with its doc; `metal_feature_mm` (l.720-724). `FlutesLayer::height` (l.1681-1699), the `width_mm.min(cell_mm)` clamp at l.1693. Arc-scale figures for side faces are the measured table in CLAUDE.md (`k` 0.796–0.859).
+
+**Do this.** In the Flutes arm of `feature_footprints`, branch on `along`: when `along == false` emit `FeatureFootprint { feature_u_mm: width_mm, feature_v_mm: f64::INFINITY, .. }`; when `along == true` keep `across`. Then emit a SECOND footprint for the land, `(circumference/count - width_mm).max(0.0)` on the same axis, so a merged reeding flags. `dfm::findings`' `Layer::Flutes => "the flutes"` label should become two messages — "the reeds" and "the land between reeds" — because they are different bench facts and only one of them is fixed by widening the flute.
+
+**Castability.** Does not change any geometry, so no pull guarantee moves. It corrects a manufacturing report that is currently wrong in the unsafe direction on side faces — the same class of error `arc_scale` was introduced to fix everywhere else.
+
+#### F91 `edge_mm` silently discards contrast and bias, and its mm-per-texel is an axis average — `medium` / `S` / ornament
+
+**Problem.** Three problems in `TilingLayer::height_at`'s crisp-edge branch. (1) When `edge_mm > 0` the layer samples the distance field and applies only `invert` as a sign flip — `contrast` and `bias` are never applied. A user who shapes a texture with contrast and then turns on the crisp edge loses that shaping with no indication anywhere in the UI. (2) `mm_per_px = 0.5 * (cw / sdf.width + ch / sdf.height)` averages the two axes, so the bevel is only mm-true when the cell's aspect matches the alpha's; on a stretched cell — the normal case whenever `repeats_around` is chosen for coverage rather than by `repeats_for_square_cells` — the bevel width is wrong on both axes at once. (3) There is exactly one bevel shape, a linear chamfer, where a bench has three: chamfer, round-over and cove.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/tiling.rs `height_at`, the SDF branch (l.358-380): `let d_mm = d_px * mm_per_px * if self.invert { -1.0 } else { 1.0 }; (d_mm / edge).clamp(0.0, 1.0) * self.height_mm` — no `alpha.shaped(...)` call, unlike the brightness branch immediately below at l.379-384 which does apply `shaped(raw, self.contrast, self.bias, self.invert)`. `mm_per_px` at l.371-372.
+
+**Do this.** (1) Grey out the contrast and bias sliders in the tiling panel while `edge_mm > 0`, with a tooltip saying the crisp edge reads the distance field — applying them to a distance is meaningless, so hiding the loss is worse than disabling the control. (2) Carry the two pitches separately and take the distance in the anisotropic metric; at minimum warn in the panel when `cw/alpha.width` and `ch/alpha.height` differ by more than a few percent, because that is the common case whenever `repeats_around` was chosen for coverage rather than by `repeats_for_square_cells`, and it silently falsifies the module's headline guarantee. (3) `edge_profile: EdgeProfile { Chamfer, Round, Cove }` is a one-line remap of `(d_mm / edge)` and gives three real bench reads for nearly nothing.
+
+<details><summary>The auditor's original recommendation</summary>
+
+For (1): either apply `contrast`/`bias` to the SDF result before scaling, or — better, since they mean something different on a distance field — grey out the two controls in the panel while `edge_mm > 0` and say why, so the loss is visible rather than silent. For (2): carry the two scales separately and take the distance in the anisotropic metric, or at minimum warn in the panel when `cw/alpha.width` and `ch/alpha.height` differ by more than a few percent, since the whole selling point of `edge_mm` is that the bevel "holds its width in mm at any tile size" and that claim is false on a stretched cell. For (3): add `edge_profile: EdgeProfile { Chamfer, Round, Cove }`, a one-line remap of `(d_mm / edge)`.
+
+</details>
+
+**Castability.** Real but bounded. The bevel width IS the wall angle: `height_mm / edge_mm` is the slope of every raised feature's flank, so a bevel narrower in metal than the panel says is a steeper wall than the user believes. On a side face that is harmless (walls there are parallel to the pull by construction) but on a crown it is exactly the case `Alpha::draft_limited` exists to prevent. Cove is the one to gate: a concave edge profile leans back at its foot and should be restricted to side faces or checked by the field verdict.
+
+**Verified.** All three sub-claims verified at tiling.rs l.360-386. The SDF branch computes `d_mm = d_px * mm_per_px * if self.invert { -1.0 } else { 1.0 }` then `(d_mm / edge).clamp(0.0, 1.0) * self.height_mm` — `self.contrast` and `self.bias` appear nowhere in it, while the brightness branch immediately below (l.383) does call `alpha.shaped(raw, self.contrast, self.bias, self.invert)`. `mm_per_px = 0.5 * (cw / sdf.width + ch / sdf.height)` (l.374-375) is a scalar average of two genuinely different pitches. And the ramp is a single linear `clamp(0,1)` — one bevel shape, no chamfer/round/cove choice. The mm-true claim in CLAUDE.md ("the bevel holds its width in mm at any tile size, to within half a texel") is therefore true only when the cell aspect matches the alpha aspect.
+
+#### F105 A default new signet leaves a flat, square-edged shank — and a code comment contradicts the measured doctrine — `high` / `S` / signet-heads
+
+**Problem.** `apply_signet` now sets `loft = 1.0`, and the shank's rounding term is multiplied by `(1 - loft_k)`, so on every new signet `shank_crown` collapses to 1.0 — the shank keeps the head's own section, scaled narrow. `templates::signet` starts from `squared()` = `ProfileStyle::Flat` + `flatten_sides()`, so the shipped Heart, Waved-hexagon, Shouldered-cushion and Toi-et-moi signets all carry a flat-topped, square-edged ribbon at the back of the finger. The code comment justifying this says the factory presets' shank is flat-topped; CLAUDE.md's own measurement says the opposite.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:2651-2653: `let shank_crown = 1.0 + SIGNET_SHANK_ROUNDING * k * (1.0 - w) * (1.0 - loft_k);` with the comment "The lofted head's shank stays the band's own flat-topped section all the way round, as the factory presets' do." CLAUDE.md, the lofted-head section: "the shank is cast **T + 0.25** thick, and its section is the top of a tall ellipse — the unit profile curve stretched 4:1.33 — **3.0 × 1.49 mm on a 6 × 1.75 band**, crown 0.745·(T + 0.5). **Not flat-topped; forcing it flat put the shank 0.35 mm off.**" crates/ringdesign-core/examples/cg_signet.rs:73-77 does it correctly by hand: `apply_style(HalfRound)`, `crown_mm = (0.745 * (side_t + 0.25)).min(side_t - 0.25)`, `edge_round_mm = 0.05`. crates/ringdesign-core/src/templates.rs:39-45,48-54 — `squared()` then `apply_signet`, no crown.
+
+**Do this.** Narrow it and keep it. The real defect is in `templates.rs`, not in `apply_signet`: `squared()` is deliberate and necessary for the two ornamented templates (Waved hexagon and Shouldered cushion put tiling on side faces, which needs `flatten_sides`), but Heart signet and Toi et moi have blank tables and no side-face ornament, so they ship a flat square ribbon at the back of the finger for no reason. Give those two the cg_signet section — `HalfRound`, `crown_mm = 0.745 * (t + 0.25)`, `edge_round_mm = 0.05` — or better, land finding F14's `shank_profile` so the choice stops being all-or-nothing. Separately, fix the profile.rs:2652 comment to say what the code does ("the shank keeps the band's own crown; the loft adds no rounding of its own") rather than asserting the factory shank is flat-topped, which CLAUDE.md's own measurement contradicts.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Either make `apply_signet(band_width, thickness)` set the shank's crown the way `cg_signet.rs` does — `crown_mm = 0.745 * (t + 0.25)`, a small `edge_round_mm` — or, better, add `ShankStyle::shank_profile: Option<BandProfile>` so the head's section and the shank's are genuinely independent and the `(1 - loft_k)` term becomes unnecessary. Fix the comment either way, and add a test asserting the shank section behind a default signet is crowned rather than flat.
+
+</details>
+
+**Castability.** None — a crowned shank is a more domed profile, strictly further inside the superellipse guarantee than the flat one it replaces.
+
+**Verified.** The mechanism is verified but the blast radius is overstated. Confirmed: `let shank_crown = 1.0 + SIGNET_SHANK_ROUNDING * k * (1.0 - w) * (1.0 - loft_k);` at profile.rs:2651-2652 with the comment "The lofted head's shank stays the band's own flat-topped section all the way round, as the factory presets' do", and `SIGNET_SHANK_ROUNDING = 9.0` (profile.rs:1439). Confirmed: `templates::signet` -> `squared()` = `apply_style(Flat)` + `flatten_sides()` (templates.rs:38-54), so the four shipped signet templates carry a flat-topped, square-edged shank. WRONG in two places: (a) `apply_signet` (profile.rs:1774-1779) does not touch the profile at all, and the GUI kind switch (panels/design.rs:731-736) calls only `apply_signet`, so a signet made from a default band keeps `BandProfile::default()` = HalfRound with crown 1.8 on 2.0 — domed, not flat. (b) the code's behaviour is right and only the wording is loose: with `loft_k = 1` the term collapses to 1.0, meaning "defer to the band's own crown", which is exactly what examples/cg_signet.rs:73-77 relies on when it sets `apply_style(HalfRound)` and `crown_mm = (0.745 * (side_t + 0.25)).min(side_t - 0.25)`.
+
+#### F109 Tiling DFM ignores the shank modulation, and the shipped shouldered signet is the case — `high` / `M` / signet-heads
+
+**Problem.** `dfm::findings_in` measures a *decal's* alpha at the station it actually sits on — it reads `design.modulation_at(d.theta_deg, ...)` and stretches the raster by that section's own arc ratio before granulometry. Tilings get no such treatment: `tiling_finest_mm(t, lib, &ctx)` reads only the reference `FieldContext`. On a signet the band behind the head is `1 - (1 - 0.16) × 0.85 ≈ 0.29` of the head's width, so a pattern windowed onto the shoulders is measured roughly 3.5× larger than the metal it will actually be cast in — in the unsafe direction, on the surface the doctrine sends all ornament to.
+
+**Evidence.** crates/ringdesign-core/src/dfm.rs:43-92 (the decal path: `modulation_at` → `sample_mod(...).surface_len_mm / ctx.band_v_len_mm` → stretched alpha → `min_feature_px`); 96-118 (the tiling path: `tiling_finest_mm(t, lib, &ctx)`, reference ctx only, plus `t.cell_size(&ctx)` for the message). The shipped case: crates/ringdesign-core/src/templates.rs:99-113 — "Shouldered cushion signet", a Chevron tiling with `e.window = Window::except(TOP_DEG, 120.0)`, i.e. entirely on the tapered shoulders. CLAUDE.md's own measured-templates run already names it at "0.07 mm gaps on the shouldered cushion's shoulders"; the true figure is nearer 0.02 mm. Constants: `SIGNET_TAPER = 0.85`, `SIGNET_MIN_SHANK_FRAC = 0.16` (crates/ringdesign-core/src/profile.rs:1436,1424).
+
+**Do this.** Unchanged, and it is the highest-confidence bug in this set — a shipped template is measurably mis-reported by ~3.5x in the optimistic direction, on the surface the doctrine sends all ornament to. Reuse the decal path verbatim (dfm.rs:53-79 is already a working stretch-then-granulometry routine); the only new part is choosing stations, and the window's own centre plus both `outer_half_deg` edges is enough — take the worst. Report the offending station in the message, since "0.02 mm on the shoulders" is actionable and "0.07 mm" is not. Extend to `FlutesLayer` and `BorderLayer` widths, which have the same reference-ctx assumption.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give the tiling path the decal path's treatment: sample the layer's own window (centre and both edges, or a handful of stations across `Window::outer_half_deg`) through `modulation_at`, take the *worst* section's arc ratio, and stretch the mask by it before `min_feature_px` — then report the finest feature and the station it occurs at. The same correction applies to `FlutesLayer` and `BorderLayer` widths on a modulated band.
+
+</details>
+
+**Castability.** None to geometry; it corrects a *reported* number. It will make some currently-quiet designs report findings, which is the point.
+
+**Verified.** Verified precisely. In dfm.rs the decal path (43-92) does `design.modulation_at(d.theta_deg, inner_r, crest_r)` -> `sample_mod(...).surface_len_mm / ctx.band_v_len_mm` -> stretches the raster -> `min_feature_px` -> scales by `ctx.arc_scale(d.v_mm)`. The tiling path (96-118) is `tiling_finest_mm(t, lib, &ctx)` and `t.cell_size(&ctx)` against the reference `FieldContext` only, with no station sampling anywhere. The shipped case is real: templates.rs:99-113, "Shouldered cushion signet", a Chevron `side_tiling` with `e.window = Window::except(TOP_DEG, 120.0)` — entirely on the tapered arc. Constants check out: `SIGNET_TAPER = 0.85` (profile.rs:1466), `SIGNET_MIN_SHANK_FRAC = 0.16` (profile.rs:1437), so `1 - 0.84*0.85 = 0.286`. Direction of error confirmed unsafe: layers are parameterized against the reference section, so the pattern shrinks with the band and the real metal feature is ~0.29x the reported one.
+
+#### F110 A toi et moi's second head is judged by the primary's construction — `medium` / `S` / signet-heads
+
+**Problem.** `ShankStyle::modulation`'s Signet arm calls `pick_dominant` to choose which head's `HeadAt` governs this angle, then reads the construction weights from `self.head` unconditionally: `let (loft_k, dome_k) = self.head.mix();` and `let table_crown = 1.0 - self.head.table_flat...`. So a second head with a different `dome`, `loft` or `table_flat` is built with the primary's crest blend and crown law. The GUI compounds it: the second-head editor exposes only outline, face length, position and rise — no body fairing, rim round, cut dome, loft, cab dome or hollow — and its outline combo lists only `SignetOutline::ALL`, so a custom plan can never be the second head.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:2629-2657 — `let a = pick_dominant(&reads);` then `let (loft_k, dome_k) = self.head.mix();`, `let crest = blend_span(a.face, span, dome_k);`, `let table_crown = 1.0 - self.head.table_flat.clamp(0.0, 1.0);`. `head_at_for` (1903-2110) correctly uses the *specific* head's `mix()`, so the two disagree. crates/ringdesign-core/src/profile.rs:2212-2221 (`pick_dominant`). crates/ringdesign-gui/src/panels/design.rs:1134-1170 — the second-head UI, four controls, `SignetOutline::ALL` only.
+
+**Do this.** Keep, with the MCP correction: the custom-outline gap is GUI-only (MCP already adopts customs for head two), while the missing dome/loft/table_flat/rim/hollow controls are missing on *both* surfaces. Fix the geometry bug first — carry `loft_k`, `dome_k` and `table_flat` on `HeadAt` so profile.rs:2635 cannot reach past `pick_dominant` — because it is a silent wrong-geometry bug, not a UI gap. Then factor the GUI slider block into a `head_controls(ui, &mut SignetHead)` used for both heads and add the same fields to MCP's second-head set. Test: a cut-dome second head on a prism primary must field clean and report its own crown.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Take `loft_k`, `dome_k` and `table_flat` from the head `pick_dominant` chose — return the head reference alongside the `HeadAt`, or carry the three weights on `HeadAt` itself so the outer code cannot reach past it. Then give the second head the same editor as the first (factor the slider block into a `head_controls(ui, &mut SignetHead)` used twice) including the custom-outline picker, and add a test asserting a toi et moi with a cut-dome second head on a prism primary fields clean and reports the second head's own crown.
+
+</details>
+
+**Castability.** The bug can only produce a *wrong* crown, and a mismatched crest blend on a lobed second head is exactly the corrugated-flank failure `suggest_dome` exists to prevent. Fixing it is a castability improvement, not a risk; pin it with a field check over mixed-construction pairs.
+
+**Verified.** Verified at both sites. profile.rs:2629-2657: `let a = pick_dominant(&reads);` then `let (loft_k, dome_k) = self.head.mix();`, `let crest = blend_span(a.face, span, dome_k);`, `let table_crown = 1.0 - self.head.table_flat.clamp(0.0, 1.0);` — all three read the *primary* head unconditionally. By contrast `head_at_for` correctly uses the specific head: profile.rs:1916 `let (loft_k, dome_k) = head.mix();`. So the two genuinely disagree. GUI confirmed: panels/design.rs:1134-1170 gives the second head exactly four controls (outline, Face length, Around, Rise) and the combo iterates `SignetOutline::ALL` only. CORRECTION: MCP is not as limited on outlines — tools.rs:1613-1630 runs the second head's outline through `resolve_signet_outline`, so a custom plan *can* be the second head via MCP; but MCP exposes only `second_head_outline`/`second_head_length_mm`/`second_head_theta_deg` (tools.rs:463-467, 1631-1634), so dome, loft, table_flat, rim_round and hollow are unreachable on a second head from any surface.
+
+#### F123 The report panel prints the retired mesh verdict's numbers under the field verdict's banner — `medium` / `S` / dfm-verdict *(also found as F166)*
+
+**Problem.** The panel draws the field-sampled banner, then immediately below it draws the *mesh* report's class bar, four class counts and a bold "Worst draft" figure — the exact numbers the doctrine retired as phantoms. On a signet the user sees a green or amber banner over "Worst draft −15.3°" and a red undercut segment in the bar. Two of the app's own numbers disagree on screen with nothing saying which is authoritative. Worse, `class_areas` fabricates the Good and Vertical mm² by splitting the leftover area in proportion to face *count* and prints the result as mm² in the legend and the tooltip.
+
+**Evidence.** crates/ringdesign-gui/src/panels/report.rs:107-110 (field banner) then :162-229 — `class_areas(cast)`, `class_bar(ui, cast, &areas)`, the class grid over `cast.good/marginal/vertical/undercut`, and the "Worst draft" row reading `cast.worst_draft_deg`, all from the mesh `CastReport`. `class_areas` at report.rs:384-400: `(rest * cast.good as f64 / n, rest * cast.vertical as f64 / n)` where n is a face count. The mesh phantom is documented in CLAUDE.md and in the doc comment on `analyze_field` (castability.rs:1010-1032).
+
+**Do this.** Unchanged, and this is the cheapest high-value item on the list — it is a UI wiring change with no new geometry. `FieldReport` already carries `undercut_area_mm2`, `marginal_area_mm2`, `vertical_area_mm2`, `total_area_mm2` and `worst_draft_deg` as true mm² and a true angle, so `class_areas` can be deleted outright when a field report is present (Good = total − the other three, no face-count apportioning). Keep the mesh row only under a collapsed "per-facet, for the coloured view" header tied to `ShadeMode::Draft`, and change its hover text to say it is a build artefact.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Drive the banner, the class bar, the worst-draft row and the tooltip from `FieldReport` — it already carries `undercut_area_mm2`, `marginal_area_mm2`, `vertical_area_mm2`, `total_area_mm2` and `worst_draft_deg` as true mm² and a true angle, with Good as the remainder. Keep the mesh `CastReport` for what it is honestly for — painting `ShadeMode::Draft` faces in the viewport — and label its row "per-facet, for the coloured view" in a collapsed section, so the phantom is visible as a build artefact rather than as a competing verdict.
+
+</details>
+
+**Castability.** None — reporting only, and it removes an area figure that is currently an estimate presented as a measurement.
+
+**Verified.** Read crates/ringdesign-gui/src/panels/report.rs. `castability()` does `match field { Some(f) => field_banner(ui, f), None => verdict_banner(ui, cast) }`, then unconditionally `let areas = class_areas(cast); class_bar(ui, cast, &areas);`, then the four-row grid over `[cast.good, cast.marginal, cast.vertical, cast.undercut]`, then a bold "Worst draft" row reading `cast.worst_draft_deg` with the hover text "Most negative draft on the mesh." — all from the mesh `CastReport` regardless of whether a field report exists. `class_areas` (report.rs:384-400) is exactly as claimed: `let rest = (total - marginal - undercut).max(0.0); let n = (cast.good + cast.vertical) as f64; (rest * cast.good as f64 / n, rest * cast.vertical as f64 / n)` — face *counts* apportioning mm², printed in the legend as "{:.1} mm2". Only the thinnest-wall row and the trailing notes come from the field. On a signet the doctrine's documented 0.10-0.18% / −15° mesh phantom therefore prints in bold under a green banner.
+
+#### F127 The headline castability guarantees are pinned by the retired mesh analyzer, not by the field verdict — `high` / `M` / dfm-verdict
+
+**Problem.** The doctrine's central claim is "nothing needs judging from any build now — the verdict comes from `analyze_field`". But the three guarantees the whole design rests on are still asserted against `castability::analyze`, the facet-normal measure whose phantoms the doctrine documents. So the superellipse family, the side-face guarantee and the signet outline family are all pinned by a measure the app itself no longer trusts, and the side-face table in CLAUDE.md (0.000% at relief 0.15 / 0.30 / 0.50 / 0.80 / 1.60) has no test behind it — the one test that exists checks a single 0.5 mm Rope tiling.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:1712-1721 `every_profile_style_is_free_of_undercuts` — `analyze(&out.mesh, ...)`. castability.rs:1615-1665 `relief_holds_on_a_squared_side_face_where_it_ruins_the_crest` — `analyze(&b.mesh, ...)`, one height, one alpha. crates/ringdesign-core/src/mesh.rs:913-1050 `scratch_signet_head_undercuts` — every assertion is on `castability::analyze`, including the crest-line locality check that the doctrine credits with catching the −19.4° regression. Against these, `the_field_verdict_does_not_depend_on_resolution` (castability.rs:1441-1512) is the only field-based guarantee test.
+
+**Do this.** Narrow to the two that are genuinely unpinned and drop the third. Port `every_profile_style_is_free_of_undercuts` to `analyze_field` (the superellipse drop is a property of the surface, so the field is the right measure and it should assert exactly 0.0). Leave `scratch_signet_head_undercuts` on `analyze` — its subject is the phantom and the crest-line locality check that caught the −19.4°, which has no field analogue; the field side of the signet family is already covered by `cut_dome_heads_field_clean_and_never_pinch` and the seven profile.rs field tests. Then add the missing sweep, which is the real hole: walk the CLAUDE.md relief column (0.15, 0.30, 0.50, 0.80, 1.60) on a squared side face across two or three profile styles and assert `undercut_area_mm2 == 0.0` exactly — the table is stated in the doctrine as a construction guarantee and today rests on one 0.5 mm Rope build.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Port each of the three to `analyze_field` and keep the mesh assertions only where the subject *is* the mesh. Then add the missing sweep: a test that walks the CLAUDE.md relief column (0.15, 0.30, 0.50, 0.80, 1.60) on a squared side face across two or three profile styles and asserts `undercut_area_mm2 == 0.0` exactly — the table is stated as a guarantee of the same kind as the superellipse drop, so it should be asserted as one.
+
+</details>
+
+**Castability.** None — it strengthens the evidence behind the existing guarantees rather than changing them.
+
+**Verified.** Two of the three claims hold; the signet claim is too broad. Confirmed mesh-only: `every_profile_style_is_free_of_undercuts` (castability.rs:1712-1721) calls `analyze(&out.mesh, ...)` — the superellipse guarantee; and `relief_holds_on_a_squared_side_face_where_it_ruins_the_crest` (castability.rs:1616-1657) calls `analyze(&b.mesh, ...)` at one height (0.5 mm) with one alpha (Rope) on one style — the side-face guarantee, and the CLAUDE.md relief column 0.15/0.30/0.50/0.80/1.60 has no test behind it, confirmed. But the signet outline family IS field-pinned elsewhere, which the auditor missed: profile.rs carries `a_new_signet_is_lofted_and_fields_clean` (:3980), `a_lofted_head_follows_the_factory_recipe_and_still_pulls` (:4037), `a_smooth_table_is_an_apex_loft_and_still_pulls` (:4066), `two_heads_share_a_band_and_still_release` (:4272), `a_bypass_shank_...` (:4319), `a_split_shank_...` (:4361), `keyframes_interpolate_periodically_and_still_release` (:4851) — all `analyze_field`; and mesh.rs:883 `cut_dome_heads_field_clean_and_never_pinch` sweeps `SignetOutline::ALL` through `analyze_field`. `scratch_signet_head_undercuts` (mesh.rs:913-1050) is mesh-based, but its declared subject is the mesh phantom and its crest-line locality — that assertion is only meaningful on facets, so it is correctly a mesh test.
+
+#### F128 No golden corpus: a silent verdict or volume regression would fail nothing — `high` / `M` / dfm-verdict
+
+**Problem.** The templates test asserts only `verdict != NotCastable`. A change that takes every template from Castable to Marginal, or that shifts `volume_mm3` — and therefore every weight, every price and every shrink-scaled pattern — by five percent, passes green. The CLI manifest is documented as "the export-regression harness: the manifest diffs", but nothing in CI ever produces a manifest to diff against, and the one CLI test checks a single graph template's verdict string. The showcase, collection and sketches corpora — the thirteen finished designs the doctrine's measured lessons come from — are examples run by hand.
+
+**Evidence.** crates/ringdesign-core/src/templates.rs:218-237 — `assert_ne!(field.verdict, Verdict::NotCastable)` and a watertight check, nothing more. crates/ringdesign-cli/src/main.rs:4-8 (the harness claim) and :168-234 (the manifest is written to disk and never compared). crates/ringdesign-cli/tests/cli.rs — one test, one graph, one `contains("Castable")`. `volume_is_close_to_the_analytic_torus` (mesh.rs:675) covers only a plain band.
+
+**Do this.** Unchanged, with the precedent named exactly: copy the `RD_WRITE_TEMPLATE_GRAPHS` pattern from crates/ringdesign-graph/src/templates.rs:507-579 — committed artefact, env-var regeneration, byte/tolerance diff in the test. Commit one CSV per template plus the showcase/collection/sketches designs under designs/*/ (verdict exact, undercut fraction to 4 places, thinnest wall, volume within 0.5%, triangle count, worst quality angle) and rebuild at a fixed resolution. Doing this *before* findings 1, 2, 4 and 8 land is worth the ordering: each of those deliberately moves numbers, and a golden diff is how you see what moved and by how much rather than trusting that nothing else did.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Commit a golden CSV per template and per showcase design — verdict, undercut fraction to four places, thinnest wall, volume, triangle count, worst quality angle — and a test that rebuilds each at a fixed resolution and diffs against it with a stated tolerance (exact on verdict, 0.5% on volume). Regenerate behind an env var, the way `RD_WRITE_TEMPLATE_GRAPHS=1` already works for the graph goldens. Add the showcase designs under `designs/showcase/*.ring.json` to the same sweep so the measured lessons stay measured.
+
+</details>
+
+**Castability.** None — it locks in whatever the guarantees currently are and makes any future change to them deliberate.
+
+**Verified.** Verified all three legs. `every_template_builds_watertight_and_none_is_uncastable` (templates.rs:214-237) asserts a unique name, `d.name == t.name`, `watertight`, and `assert_ne!(field.verdict, Verdict::NotCastable)` — nothing numeric, so a corpus-wide slide to Marginal or a 5% volume shift passes. The CLI does claim the harness role in its module doc (cli/src/main.rs:6-7: "Doubles as the export-regression harness: the manifest diffs") and writes the manifest CSV, but crates/ringdesign-cli/tests/cli.rs holds exactly one test — one bundled Court band graph, asserting `text.starts_with("Court band: Castable")`, one `--set`, one error path — and nothing ever produces or compares a manifest in CI. The precedent the recommendation wants already exists and works: `RD_WRITE_TEMPLATE_GRAPHS=1` regenerates committed graph goldens and `templates.rs:579` diffs the committed file against its builder byte for byte.
+
+#### F139 The size run's per-size gate is the field verdict alone — stones and DFM are never checked — `high` / `S` / sizing-fit
+
+**Problem.** `ringdesign export --sizes` runs `analyze_field` per size and writes the verdict into the manifest, then writes every file regardless. It never runs `stones::report` (except incidentally when `stonemap` is one of the requested formats, and even then the warnings are discarded), and never runs `dfm::findings_in`. But both are size-dependent: seat edge clearance is measured against the modulated section, bridges scale with circumference, and a tiling's cell pitch is `circumference / repeats_around`, so a texture that measures 0.36 mm strokes at size 5 measures 0.43 at size 9 — or the other way round for the gaps. The manifest's `verdict` column can read `Castable` on a size whose stones no longer fit the band.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:172-227 (`analyze_field` only; `stones::report` at 206-209 lives inside the `"stonemap"` arm and its `warnings` are dropped; no `dfm` call anywhere in the crate); manifest header at main.rs:166-168 (`verdict, undercut_pct, thinnest_wall_mm, volume_mm3`); compare `check` at main.rs:79-107, which *does* print stone warnings for one size.
+
+**Do this.** Unchanged, plus one addition the auditor missed: `check` (main.rs:81-107) prints stone warnings but ALSO never runs `dfm::findings_in`, so even the single-design command under-reports. Hoist both into a shared helper and call it from `check` and from the export loop. Add `stone_warnings` and `dfm_findings` columns to the manifest header at main.rs:168 and print the warning text under each size line the way check does at main.rs:101-105. Add `--fail-on {undercut,marginal,any}` so a flask is refused before it is poured. Note that `dfm::findings_in` reads tiling and openwork masks by granulometry at the layer's own mm-per-texel, so it genuinely re-measures per size rather than echoing a constant.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Hoist `stones::report` and `dfm::findings_in` out of the format arm and run both per size in the export loop. Add `stone_warnings` and `dfm_findings` count columns to the manifest CSV, print the warning text under each size line the way `check` does, and add `--fail-on {undercut,marginal,any}` so a flask can be refused before it is poured. This also makes the manifest a genuine export-regression diff for stone and detail work, which is what its module doc already claims it is.
+
+</details>
+
+**Castability.** None; it adds two existing analytic passes per size. Both are cheap (`stones::report` reads layers and the modulated bare profile, never the mesh).
+
+**Verified.** Verified line by line. `crates/ringdesign-cli/src/main.rs:175` calls `analyze_field` and nothing else per size. Grepping the whole CLI crate for `dfm` returns ZERO hits — the module is never imported. `stones::report` appears twice: main.rs:99 inside `check` (which does print `seat.warnings`) and main.rs:207 inside the `"stonemap"` format arm, where the result is bound to `stones` and passed to `write_stone_map_svg` with `stones.warnings` discarded. The manifest header at main.rs:168 is `size,file,format,bytes,triangles,watertight,verdict,undercut_pct,thinnest_wall_mm,volume_mm3` — no stone or detail column. Size-dependence confirmed: `TilingLayer::repeats_around` is an integer so cell pitch = circumference/repeats, and `stones::seat_check` (stones.rs:600-625) measures clearance and depth against the modulated section at that size.
+
+#### F143 RingSize::display() can print "US 7.", and the quarter-size rounding is bypassed on every non-GUI path — `medium` / `S` / sizing-fit
+
+**Problem.** `display()` formats to two decimals then trims trailing zeros without trimming the decimal point: a size of 7.000000000000001 renders as "US 7.". That value is reachable — `RingSize::new` rounds to the quarter, but every path outside the GUI builds the tuple directly, and the CLI generates its run as `a + i*step`, where `5.0 + 20*0.1` is not 7.0. The same bypass means `--sizes 5:9:0.3` produces sizes 5.3, 5.6, 5.9 — sizes no mandrel has and no shop can order. The CLI's own `fmt_size` helper trims the dot, so the author already knew about this class of bug in the filename path but not in the label path. The label lands in the manifest CSV, the 3MF package metadata, the casting sheet header a client sees, and the graph's `band.size` label output.
+
+**Evidence.** crates/ringdesign-core/src/sizing.rs:10-12 (`new` rounds) and 30-36 (`display`, `.trim_end_matches('0')` with no `.trim_end_matches('.')`); crates/ringdesign-cli/src/main.rs:173 (`d.size = RingSize(size)`), 251 (`a + i as f64 * step`), 214 (`&d.size.display()` into `write_3mf`), 226 (into the manifest), 234-238 (`fmt_size`, which *does* trim the dot); crates/ringdesign-graph/src/nodes/band.rs:21 and 36 (`RingSize(...)`); crates/ringdesign-core/src/spec.rs:63.
+
+**Do this.** Keep it, but lead with the half that actually bites a shop rather than the cosmetic one. The real problem is that `--sizes 5:9:0.3` cheerfully produces 5.3, 5.6, 5.9 — sizes no mandrel carries and no shop can order — and those land in filenames, the manifest CSV, the 3MF metadata and the casting-sheet header. Route `parse_sizes` (main.rs:246), `design.new` (nodes/band.rs:21), `band.size` (nodes/band.rs:36) and `ringdesign_py::Design::set_size` (lib.rs:243) through `RingSize::new`, and if free-decimal sizes are ever wanted, make that an explicit `RingSize::exact` whose name says so. The `US 7.` formatting bug is a one-character fix (chain `.trim_end_matches('.')` at sizing.rs:34) worth doing in the same commit, but drop the `5.0 + 20*0.1` justification — it does not reproduce.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Chain `.trim_end_matches('.')` in `display()`, and route every construction through `RingSize::new` — the CLI's `parse_sizes`, `design.new`, `band.size`, `band.size.fit` — so the app cannot name a size that does not exist. If free-decimal sizes are wanted deliberately, make that an explicit `RingSize::exact` with a name that says so.
+
+</details>
+
+**Castability.** None — labelling and rounding.
+
+**Verified.** The bug is real but the auditor's reachability example is WRONG. I checked in floating point: `5.0 + 20*0.1` is exactly 7.0, and across every plausible `(start, step)` pair (steps 0.05-1.1 from starts 1-7) NO value lands near-integer-but-not-integer, so `--sizes 5:9:0.1` never triggers it. It IS reachable with awkward steps — a random search found `3.99:15:0.131` producing 7.003 and `5.25:15:0.456` producing 13.002, both of which format as `US 13.` via `sizing.rs:33-34` (`format!("US {:.2}")` then `.trim_end_matches('0')` with no `.trim_end_matches('.')`). Everything else in the finding is fully confirmed: `parse_sizes` (main.rs:257) generates `a + i*step` with no rounding; `main.rs:174` `d.size = RingSize(size)` bypasses `new`; so do `nodes/band.rs:21` (design.new) and `:36` (band.size), and `ringdesign-py/src/lib.rs:243`. `fmt_size` (main.rs:239-241) does chain `.trim_end_matches('.')`, so the filename path is already fixed and the label path is not. MCP `set_ring` correctly uses `RingSize::new` (tools.rs:1482), as does the configurator (compose.rs:198).
+
+#### F144 Pattern-scaled exports carry the nominal size label, not the size they are cut at — `medium` / `S` / sizing-fit
+
+**Problem.** When `--shrink sterling` is given, the mesh is scaled by `pattern_scale(1.9) = 1.0194` — including the bore — but the 3MF's size metadata is still `d.size.display()`, the nominal. A size-7 sterling pattern's bore is 17.63 mm, which measures US 7.4 on a mandrel. The filename and the mesh name both say "pattern", so the intent is not lost, but a caster who checks the pattern on a mandrel against the size field will read a mismatch and has nothing telling them it is correct. The GUI export path renames the same way and passes the size through unchanged.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:166 (`scale = shrink.map(...)`), 176-181 (mesh scaled, name annotated), 214 (`threemf::write_3mf(&file, &mesh, &name, &d.size.display())`); crates/ringdesign-gui/src/export.rs:33-42; crates/ringdesign-core/src/metal.rs:46-49 (`pattern_scale`); crates/ringdesign-core/src/threemf.rs:173-182.
+
+**Do this.** Unchanged, and it is a small, high-value change because it costs nothing to compute. Compose the label at both call sites when `scale` is `Some`: "US 7 — pattern cut at 17.63 mm (US 7.4), casts to US 7 in Silver 925". Add an `as_cut_bore_mm` column to the manifest CSV header (main.rs:168) so a size run is self-describing on paper. Put the same string in the `spec.rs` sheet header (line 61) whenever the sheet accompanies a pattern. Worth pairing with finding 12's `RingSize::new` routing, since the as-cut size is exactly the kind of non-quarter value that would otherwise print as "US 7.4" from a raw tuple.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Pass a composed label when a shrink scale is in play: "US 7 — pattern cut at 17.63 mm (US 7.4), casts to US 7 in Silver 925". Same string on the casting sheet's header when the sheet accompanies a pattern, and add the as-cut bore diameter to the manifest CSV so the run is self-describing.
+
+</details>
+
+**Castability.** None — labelling. The scaling itself is correct: uniform shrink means the bore shrinks with everything else and lands on nominal.
+
+**Verified.** Verified in both export paths. CLI `main.rs:166` `let scale = shrink.map(|m| (m, metal::pattern_scale(m.shrink_pct)))`, `:177` `built.mesh.scaled(k)` with the NAME annotated `[pattern +1.9% for Silver 925]`, then `:214` `threemf::write_3mf(&file, &mesh, &name, &d.size.display())` — the size label is the nominal, unscaled. GUI is identical: `export.rs:33-45` `pattern()` scales the mesh and annotates the name only, and `export.rs:153-155` `let size = job.design.size.display(); threemf::write_3mf(&path, &mesh, &name, &size)`. `metal::pattern_scale(1.9) = 1.0194` (metal.rs:46-49) applies to the whole mesh including the bore, so a size-7 sterling pattern's bore is 17.63 mm, which mandrels at about US 7.4. `threemf.rs:172-180` passes `size_label` straight into the package metadata.
+
+#### F147 The reported inside diameter is declared, never measured — `medium` / `S` / sizing-fit
+
+**Problem.** `Report::inner_diameter_mm` is set to `design.size.inner_diameter_mm()` in both the swept and refined build paths — it is the nominal figure echoed back, not anything read off the geometry. That is safe today because the bore is built from `inner_r` and only ever widens (comfort dome, `bore_lift_mm`), and the min-wall clamp touches surface points only. But it means the casting sheet's Dimensions block cannot catch a construction that ever changes the true hole, it never reports the *narrowest* bore or the width of the contact band a comfort-fit ring actually rides on, and it silently reports nominal even when a hollow has reshaped the bore under the head.
+
+**Evidence.** crates/ringdesign-core/src/mesh.rs:410 and 449 (`inner_diameter_mm: design.size.inner_diameter_mm()` in `build` and `build_refined`); mesh.rs:352-356 (the clamp is `if p.surface { r = r.max((inner_r + min_wall).min(p.r)) }` — bore rows untouched); crates/ringdesign-core/src/profile.rs:831-832 (`lift` and `comfort` both widen); crates/ringdesign-core/src/spec.rs:97-106 (the sheet prints it as "Inside dia").
+
+**Do this.** Sharpened by reusing what exists. `castability::Section::min_r` (castability.rs:611) already gives the minimum radius per slice and the field pass already walks every section, so `bore_min_mm` and `bore_max_mm` are a fold over the existing scan rather than a new traversal — take them off `analyze_field`'s section walk and carry them on the field report, not off the mesh. Add `contact_band_mm` — the axial run where the bore sits within ~0.05 mm of its minimum — which on a comfort-fit ring is THE number that explains the fit and is exactly what finding 3's radius-based comfort dome changes. Print all three under "Inside dia" at spec.rs:99 with the nominal beside them. The immediate payoff is the hollowed signet: `SignetHead::hollow_mm` reshapes the bore under the head via `bore_lift_mm` and the sheet currently reports nominal regardless.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Measure it: take the minimum bore radius over the built sections (or over `castability::section_at`'s non-surface points, which the field pass already walks) and report `bore_min_mm`, `bore_max_mm` and `contact_band_mm` — the axial run where the bore is within, say, 0.05 mm of its minimum. Print all three on the sheet under "Inside dia", with the nominal beside them. On a comfort-fit ring the contact band is the number that explains the fit.
+
+</details>
+
+**Castability.** None — a read over sections the field verdict already samples.
+
+**Verified.** Verified in both build paths: `mesh.rs:410` (swept `build`) and `mesh.rs:449` (`build_refined`) both set `inner_diameter_mm: design.size.inner_diameter_mm()` — the nominal echoed back, never read off geometry. The auditor's safety argument checks out: `mesh.rs:352-354` clamps only surface rows (`if p.surface { r = r.max(...) }`), and both bore-widening terms at `profile.rs:831-832` (`lift` and `comfort`) only add, so today the true bore is never smaller than nominal. `spec.rs:99` prints it as "Inside dia". One thing the auditor missed that makes the fix cheaper: `castability::Section` already carries `min_r` (castability.rs:611) per slice, so the measurement machinery exists and is simply not plumbed into `Report`.
+
+#### F149 Sanitize the swept build's height the way the other three consumers already do — `critical` / `S` / code-architecture
+
+**Problem.** Four production sites independently displace a sampled profile point by h(u,v). Three of them zero a non-finite height; `mesh::build` — the one whose output is exported — does not. `LayerEntry::opacity` is an unvalidated `f64` read straight from `.ring.json` and multiplied into the height, so a NaN or inf there propagates to vertex coordinates. `stl::to_stl_binary`, `write_obj` and `write_ply` write those coordinates through unfiltered, while `threemf.rs` and `gltf.rs` both explicitly drop non-finite vertices. The result is a binary STL full of NaN floats handed to a caster's slicer, with the section view and the refined build both showing a clean ring.
+
+**Evidence.** crates/ringdesign-core/src/mesh.rs:338-348 (`let h = ... soft_height(...) * p.weight;` then `let mut r = p.r + h * p.nr;` — no finite guard). Compare crates/ringdesign-core/src/castability.rs:806-808 (`if !h.is_finite() { h = 0.0; }`) and crates/ringdesign-core/src/refine.rs:296-301 (`if h.is_finite() { h } else { 0.0 }`). crates/ringdesign-core/src/field.rs:732 `pub opacity: f64` and field.rs:815 `* e.opacity * w`, with no clamp anywhere (grep for `opacity` in field.rs returns 815 and 830 only). crates/ringdesign-core/src/stl.rs:30-70 and 100+ write `mesh.vertices[i]` directly; crates/ringdesign-core/src/threemf.rs:123,139 and gltf.rs:22,30 filter with `Vec3::is_finite`. `Vec3::is_finite` exists at mesh.rs:47 and is never called from stl.rs.
+
+**Do this.** Keep, but re-argue it as consistency-of-the-export-path rather than a file-borne NaN. Add `if h.is_finite() { h } else { 0.0 }` at crates/ringdesign-core/src/mesh.rs:344 so the fourth consumer matches refine.rs:299 and castability.rs:810. Make `stl::whole_faces` also require `mesh.vertices[i].is_finite()` — that one change fixes `to_stl_binary`, `to_stl_ascii`, `write_obj` and `write_ply` at once and brings STL/OBJ/PLY in line with the 3MF and GLB writers. Skip the opacity clamp as a headline (MCP and both UIs already bound it); instead pin the invariant with a test that builds a design carrying an overflowing `height_mm` (1e308) and asserts the exported STL contains no non-finite f32 — the realistic route in.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add the same `if h.is_finite() { h } else { 0.0 }` guard in `mesh::build`'s slice loop; clamp `LayerEntry::opacity` to `0.0..=1.0` (and non-finite to 0) at read time in `LayerStack::height_d`; and make `stl::to_stl_binary`, `write_obj` and `write_ply` skip a face whose vertices are not all finite, exactly as `whole_faces` already skips out-of-range indices. Assert in a test that a design with `opacity: NaN` exports an STL with no NaN floats.
+
+</details>
+
+**Castability.** None — a pure output-sanitation change. It cannot alter any surface the field verdict reads, and the swept mesh stays watertight by construction because faces are dropped only when their vertices are already meaningless.
+
+**Verified.** The core defect is real and I confirmed it line by line. crates/ringdesign-core/src/mesh.rs:338-348 computes `soft_height(...) * p.weight` and displaces with NO finite guard, while crates/ringdesign-core/src/refine.rs:299-300 (`if h.is_finite() { h } else { 0.0 }`) and crates/ringdesign-core/src/castability.rs:810-812 (`if !h.is_finite() { h = 0.0; }`) both guard. Exporter asymmetry is real: threemf.rs:123,139 and gltf.rs:22,30,43 filter with `Vec3::is_finite`, while stl.rs `to_stl_binary` (:41-45), `to_stl_ascii` (:63-66), `write_obj` and `write_ply` write `mesh.vertices[i]` straight through — `whole_faces` (stl.rs:23-27) filters only out-of-range indices. BUT the stated trigger is wrong on two counts. (a) A NaN cannot arrive from a `.ring.json`: JSON has no NaN/Infinity token and serde_json rejects them, so `opacity: NaN` is unparseable. (b) opacity IS validated on the two authoring paths — crates/ringdesign-mcp/src/tools.rs:1962 `put_range(&mut entry.opacity, ..., 0.0, 8.0, ...)`, and crates/ringdesign-gui/src/panels/layers.rs:565 is a 0..=1 slider; the graph pin (nodes/layer.rs:403) is a 0..1 slider widget. Note also tiling.rs:394 already ends `if h.is_finite() { h } else { 0.0 }` per tiling layer, so the surviving inflow is arithmetic overflow (a huge legal literal such as `height_mm: 1e308` times anything, or a future division), not a NaN literal.
+
+#### F150 Give the four displacement copies one function, and pin refine against the sweep — `high` / `M` / code-architecture
+
+**Problem.** The doctrine's own "three copies of a station formula" warning applies here and is not honoured. `mesh::build`, `refine::point`, `castability::section_at_spaced` and the table probe in mesh.rs's tests each re-implement the same twelve lines — v-mapping through `surface_len_mm`, `layers.height`, `* p.weight`, the `r.max((inner_r + min_wall).min(p.r))` bore clamp — with comments saying "exactly as mesh::build does". They have already drifted (the finite guard). Only `section_at` is pinned against `mesh::build`, and only at theta = 0 on one design. `refine::point`, which is the *export* path, is pinned against nothing: refine.rs's thirteen tests check watertightness, convergence and cost, never that the refined surface is the same surface the preview showed.
+
+**Evidence.** crates/ringdesign-core/src/mesh.rs:338-358; crates/ringdesign-core/src/refine.rs:289-311; crates/ringdesign-core/src/castability.rs:798-820. The only cross-check is crates/ringdesign-core/src/castability.rs:1843 `the_section_matches_the_mesh_it_slices`, which slices one `undercutting_design()` at theta = 0. refine.rs test names (lines 33-324 of its test module) contain no comparison against `mesh::build`.
+
+**Do this.** Extract the shared body, but note two real differences the signature must carry, or the extraction will silently change behaviour: mesh::build calls `soft_height` (the as-cast 9-tap blur, preview only) while refine and section_at call `layers.height` — so the function needs a `soften_mm` parameter defaulting to 0; and refine evaluates at a fractional `s` through `Column::at` interpolation rather than at `sample_spaced` rows, so a vertex-exact equality test is impossible. Write the new test as `a_refined_build_lands_on_the_swept_surface`: build an ornamented design both ways and assert each refined vertex lies within `tolerance_mm` of the swept surface at its own (u, s). Extend `the_section_matches_the_mesh_it_slices` beyond theta=0 — a Signet, a Keyframes band and a Wave band at several angles, since reference-snapped row layout under modulation is precisely where the three copies could diverge.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Extract `pub fn displaced_point(p: &ProfileSample, loop_: &ProfileLoop, u: f64, ctx: &FieldContext, layers: &LayerStack, lib: &AlphaLibrary, inner_r: f64, min_wall: f64, soften_mm: f64) -> (f64, f64)` into `mesh.rs` and call it from all three. Then add `a_refined_build_lands_on_the_swept_surface`: build the same ornamented design both ways and assert every refined vertex is within `tolerance_mm` of the swept surface evaluated at its own (u, s) — and extend `the_section_matches_the_mesh_it_slices` over a signet, a Keyframes band and a Wave band at several angles, since reference-snapping under modulation is where divergence would actually appear.
+
+</details>
+
+**Castability.** Directly protective. A divergence between the refined export and the field verdict is precisely a ring that was judged castable and then cast from different geometry; a test on that pair is the cheapest insurance the two-part pull guarantee has.
+
+**Verified.** Verified. Three production copies of the same twelve lines: mesh.rs:338-358, refine.rs:296-310 (`fn point`, whose doc literally says "Displaced and clamped exactly as `mesh::build` does, or the two disagree about the same design"), castability.rs:800-820 (whose comment says "Displace, exactly as mesh::build does" and "Identical to the clamp in `mesh::build`"). They have already drifted on the finite guard, exactly as claimed. Cross-checks: the only one is castability.rs:1843 `the_section_matches_the_mesh_it_slices`, which slices `undercutting_design()` at theta = 0 alone. I listed every test in refine.rs (lines 950-1241): presets_run_at_the_benchmarked_depth, seeding_captures_a_feature_the_probes_would_miss, a_depth_limited_tree_says_so, a_refined_plain_band_is_watertight, an_ornamented_band_stays_watertight_at_every_tolerance, every_profile_and_shank_style_refines_watertight, faces_wind_outward, a_tighter_tolerance_costs_cells..., refinement_beats_a_uniform_grid..., refinement_cost_grows_slower..., refinement_converges_on_the_tolerance_it_was_given, slope_refinement_keeps_phantom_undercuts_small, the_leaf_cap_holds_at_an_absurd_tolerance — none compares refine's surface to mesh::build's. `refine::grid_error_mm` (refine.rs:712) measures a notional swept grid using refine's OWN `Lattice::point`, so it is self-referential and cannot catch a divergence.
+
+#### F151 Re-bake the distance field when a layer's `edge_mm` changes — `high` / `S` / code-architecture
+
+**Problem.** `TilingLayer::height` looks up `alpha##sdf` when `edge_mm > 0` and silently falls back to `alpha.shaped(raw, contrast, bias, invert)` when it is missing — a completely different height law, not an error. The SDFs are baked only by `RingDesign::bake_sdfs` inside `bake_all`, which runs on file open and app start. Nothing re-bakes on edit. So the general "Crisp edge" DragValue on any tiling layer, and the same control on Openwork, produce no mm-true bevel at all until the design is saved and reopened. The graph path is worse: `evaluate_design` only bakes when the design carries drawn/text/svg/recipe sources, so a graph that sets `edge_mm` on a builtin alpha never gets an SDF.
+
+**Evidence.** crates/ringdesign-core/src/tiling.rs:360-386 (the `_ =>` fallback arm). crates/ringdesign-core/src/lib.rs `bake_sdfs` is only reached via `bake_all`; grep for `bake_all` finds it at crates/ringdesign-gui/src/app.rs:252 (startup) and crates/ringdesign-gui/src/export.rs:384 (file open) — and nowhere in `mark_dirty` (app.rs:~470). The two add-menu presets bake their own SDF by hand (crates/ringdesign-gui/src/panels/layers.rs:177 and :706), which is the workaround that hides the general bug; the DragValues at layers.rs:1055 and :330 do not. crates/ringdesign-graph/src/eval.rs:506-511 gates `bake_all` on `has_sources`.
+
+**Do this.** Call `design.bake_sdfs(app.library_mut())` from `RingDesignerApp::mark_dirty` when any enabled tiling or openwork layer has `edge_mm > 1e-9` and its `alpha##sdf` is absent (the cheap membership test, not an unconditional rebake), and drop the `has_sources` gate in `eval.rs` in favour of the same absence test. Then delete the two hand-baked calls in layers.rs, which exist only to paper over this. Consider making the missing-SDF arm log a warning instead of silently changing the law.
+
+**Castability.** Fixing it changes wall angles inside textured relief, so re-run the templates and showcase field checks after: an SDF bevel is generally *more* castable than brightness-as-height (it has a defined wall angle), but the numbers should be re-measured rather than assumed.
+
+#### F152 Cap what a design file can rasterize into the alpha library at load — `high` / `S` / code-architecture
+
+**Problem.** `AlphaLibrary::insert` — the path taken by `bake_drawn`, `bake_texts`, `bake_svgs`, `bake_recipes`, `bake_sdfs` and `unpack_embedded` — has no entry cap and no byte accounting. `MAX_LIBRARY_ENTRIES` is enforced only inside `load_dir`. `RingDesign::drawn`, `.texts`, `.svgs` and `.recipes` are unbounded `Vec`s deserialized straight from the file, and every one is rasterized at load. `DrawnAlpha::rasterize` clamps each raster to `MAX_DRAWN_EDGE` = 4096, which is 4096 × 4096 × 4 bytes = 67 MB *per drawn alpha*, with no limit on how many. Fifty of them in one file is 3.3 GB allocated at open time on a machine the doctrine says has no swap.
+
+**Evidence.** crates/ringdesign-core/src/alpha.rs `insert` (no cap) vs alpha.rs:1542 (`if self.entries.len() >= MAX_LIBRARY_ENTRIES` inside `load_dir` only). crates/ringdesign-core/src/drawn.rs:24 `MAX_DRAWN_EDGE: u32 = 4096` and `rasterize_at`'s `vec![0.0f32; w * h]`. crates/ringdesign-core/src/lib.rs `bake_drawn`/`bake_texts`/`bake_svgs`/`bake_recipes` all iterate the full Vec with no count limit. CLAUDE.md's own rule — "Anything sized by a u32/usize struct field rather than a constant needs an explicit cap" — is the rule this violates.
+
+**Do this.** Unchanged, with the framing sharpened: the per-alpha caps are already right, so the fix is purely aggregate. Add `MAX_SOURCE_ALPHAS` (64) applied per Vec in `RingDesign::bake_all` (lib.rs:201) and a running texel budget (~64 M texels) that stops and logs which entries were skipped, mirroring `load_dir`'s `skipped` warning at alpha.rs:1555. Make `insert` honour `MAX_LIBRARY_ENTRIES` for a NEW name while always allowing replacement of an existing one — otherwise the `bake_*` overwrite path breaks. Refuse in `library::load_design_str` (library.rs:84) rather than truncating silently, so a file that cannot be honoured says so before it allocates.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a `MAX_SOURCE_ALPHAS` (say 64) applied per source Vec in `bake_all`, and a running texel budget (say 64 M texels ≈ 256 MB) that stops baking and logs which entries were skipped, mirroring `load_dir`'s `skipped` warning. Also make `insert` respect `MAX_LIBRARY_ENTRIES` — replacing an existing name should always succeed, adding a new one past the cap should not. Reject in `load_design_str` rather than silently truncating, so a file that cannot be honoured says so.
+
+</details>
+
+**Castability.** n/a — a resource guard, no geometry change. Skipped alphas must produce a visible refusal rather than a silently blank layer, or a ring could be judged on relief it does not have.
+
+**Verified.** Verified. `AlphaLibrary::insert` (alpha.rs:1464-1472) has no cap at all — it replaces by name or pushes. `MAX_LIBRARY_ENTRIES` (alpha.rs:67, 1024) is enforced only inside `load_dir` (alpha.rs:1542), and the test `load_dir_stops_at_the_entry_ceiling` (alpha.rs:2199) proves that by filling the library past the cap through `insert` itself. `bake_drawn`/`bake_texts`/`bake_svgs`/`bake_recipes` (lib.rs:~130-195) iterate the full Vec with no count limit. Per-item caps DO exist and the auditor undersold them: MAX_DRAWN_EDGE 4096 (drawn.rs:24), MAX_STROKES 4096 (:26), MAX_STROKE_POINTS 8192 (:28), MAX_SVG_BYTES 4 MiB (svg.rs:20), MAX_TEXT_CHARS 64 (text.rs:16). What is missing is exactly the count and the aggregate: nothing bounds how many 4096x4096 drawn alphas one file declares, and 4096*4096*4 bytes = 67 MB each is correct. On a machine the doctrine says has no swap, this is the `TilingLayer::cells()` 67 GB lesson repeated at the file boundary.
+
+#### F153 Unpack embedded alphas on session restore, not only on File > Open — `high` / `S` / code-architecture
+
+**Problem.** `open_design_path` calls `unpack_embedded` then `bake_all`. The session-restore path in `RingDesignerApp::new` calls only `bake_all`. So a design opened from someone else's `.ring.json` (whose imported art lives in the file's `embedded` PNGs and was never written to this machine's alpha directory) loses that art on the next app start: the layer references a name the library does not have, and a missing alpha contributes nothing, silently. The file is intact; the app just renders a different ring than it did before the restart.
+
+**Evidence.** crates/ringdesign-gui/src/app.rs:246-252 — `serde_json::from_str::<RingDesign>` from `DESIGN_STORAGE_KEY` then `design.bake_all(&mut lib);` with no `unpack_embedded`. Compare crates/ringdesign-gui/src/export.rs:381-383, which calls both. `RingDesign::unpack_embedded` (crates/ringdesign-core/src/lib.rs) is the only consumer of `self.embedded`. drawn.rs's own module doc states the consequence: "a missing alpha contributes nothing, silently, with no error."
+
+**Do this.** Fold `unpack_embedded` into `bake_all` at crates/ringdesign-core/src/lib.rs:201 — the doc comment there already states the rule ("adding a bake means adding it here, not at six sites") and eight of the nine call sites currently write the pair by hand, which is the smell. That single change fixes app.rs:252 and eval.rs:507 together. Guard it against finding 15's collision semantics first, since folding it in makes the skip-on-collision rule run at every bake. Separately, surface a referenced-but-missing alpha as a layer-row warning badge using `LayerStack::referenced_alphas` (already used by `embed_alphas` at lib.rs:211) — today a missing alpha contributes zero height with no error anywhere.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Fold `unpack_embedded` into `bake_all` (it is derived-data restoration exactly like the other bakes, and the doctrine already says "adding a bake means adding it here, not at six sites"), or add the call at app.rs:252. While there, make a referenced-but-missing alpha surface as a layer-row warning badge rather than rendering as zero — `LayerStack::referenced_alphas` already enumerates exactly what to check against the library.
+
+</details>
+
+**Castability.** Real: the field verdict is computed on whatever the library holds, so a design whose relief silently vanished reads 0.000% undercut and would be sent to the flask as a plain band.
+
+**Verified.** Verified exactly, and it is worse than stated because the autosave carries the PNGs. crates/ringdesign-gui/src/app.rs:246-252 deserializes the design from DESIGN_STORAGE_KEY and calls `design.bake_all(&mut lib)` with no `unpack_embedded`. Compare export.rs:382-383 (open path) and engine.rs:196-197 (`DesignEngine::load_design`), both of which call `unpack_embedded` then `bake_all`. `RingDesign::embedded` is `#[serde(default)] pub embedded: Vec<EmbeddedAlpha>` (lib.rs:84-85) with no skip-serializing, and main.rs:28-31 autosaves `serde_json::to_string(&self.design)` verbatim — so the restored design HAS the PNG payload sitting in `embedded` and simply never decodes it. Every other consumer pairs the two calls: cli/main.rs:66-67, py/lib.rs:151-152, graph/nodes/sink.rs:39-40, graph/nodes/solid.rs:149-150, examples/render_design.rs:22-23. The graph evaluator is the one exception on the bake side too (eval.rs:507 bakes but never unpacks).
+
+#### F154 Write the design file atomically, and keep one backup — `high` / `S` / code-architecture
+
+**Problem.** `library::save_design` is `std::fs::write(path, design_json(design)?)`. A design carrying embedded 16-bit PNGs and hand-drawn strokes is a large single write; if it is interrupted (crash, full disk, power) the user's `.ring.json` is left truncated and the work is gone. There is no temp-and-rename, no `.bak`, and no verification that the bytes written parse back. The same is true of `save_profile_in` and `save_outline_in`.
+
+**Evidence.** crates/ringdesign-core/src/library.rs:62-65 (`save_design`), :203-206 (`save_outline_in`), :229-233 (`save_profile_in`). No `NamedTempFile`, no `.persist`, no `rename` anywhere in the crate. The GUI's autosave to eframe storage (crates/ringdesign-gui/src/main.rs:28-31) is a partial safety net, but it serializes without `embed_alphas`, so it is not a substitute.
+
+**Do this.** Unchanged. Write to `<path>.tmp` in the same directory, `File::sync_all`, then `std::fs::rename` over the target; rename `<path>` to `<path>.bak` first if it exists. Do it once inside `save_design` (library.rs:62) and reuse the same helper from `save_profile_in` and `save_outline_in` so all three benefit. Note that `save_design_embedded` clones the design and calls `embed_alphas` before `save_design`, so a design with imported art is genuinely a multi-megabyte single write — that is the case worth naming in the commit. Add a test that a `.tmp` left behind by an interrupted save leaves the original file readable and parseable.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Write to `<path>.tmp` in the same directory, `sync_all`, then `std::fs::rename` over the target — rename within a directory is atomic on every platform this ships to. If a file already exists at `path`, rename it to `<path>.bak` first. Add a test that a save interrupted after the temp write leaves the original readable.
+
+</details>
+
+**Verified.** Verified. crates/ringdesign-core/src/library.rs:62-65 `save_design` is a bare `std::fs::write`; :204 `save_outline_in` and :229-232 `save_profile_in` likewise. A grep for `tempfile`, `persist(`, `fs::rename` and `.bak` across crates/ringdesign-core/src and crates/ringdesign-gui/src returns nothing (the only hits were the substring `bak` inside `bake_*`). Nothing verifies the written bytes parse back. The eframe autosave (gui/src/main.rs:28-31) is not a substitute as claimed — confirmed, it serializes `&self.design` directly without `design_json`, so it carries no `format_version` key and is not written through `embed_alphas`. Nothing on docs/ROADMAP.md's Shelf or Niceties list covers this (I grepped for CI/atomic/backup/autosave).
+
+#### F155 Stand up CI — there is none — `high` / `M` / code-architecture
+
+**Problem.** There is no `.github` directory and no CI configuration of any kind. 474 tests, a wasm target, a `parallel`/serial feature split, an optional C++ kernel behind `kernel-manifold`, three vendored egui forks, a Python module and an Android sibling all depend on a human remembering to run the right command. The local run is additionally constrained by the machine having no swap, which is exactly the constraint a CI runner does not have.
+
+**Evidence.** `ls -R .github` → no such directory. Workspace has eleven member crates (Cargo.toml). Feature matrix that must keep working per CLAUDE.md: `--no-default-features --target wasm32-unknown-unknown` for core and configurator, `--features kernel-manifold` for graph/solid, `--features shot` for graph-ui, plus `cargo ndk -t arm64-v8a check` in the sibling EguiMobile workspace.
+
+**Do this.** Unchanged, with two additions worth building in from day one because they are the checks this audit found teeth in: make the test job also run `cargo test -p ringdesign-graph write_template_graphs` style golden checks (the byte-for-byte template pins already exist and are the model), and add `cargo test -p ringdesign-core --no-default-features` so the serial path of every `#[cfg(feature = "parallel")]` split is actually exercised rather than only type-checked by the wasm `cargo check`. Note the local `systemd-run --scope -p MemoryMax=4G` guard exists because this machine has no swap; a hosted runner does not need it, but keep the guard documented in CONTRIBUTING so the local rule is not lost when CI makes it look unnecessary.
+
+<details><summary>The auditor's original recommendation</summary>
+
+One GitHub Actions workflow on push and PR: (1) `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`; (2) `cargo test --workspace` — a hosted runner has 16 GB and swap, so the `systemd-run --scope -p MemoryMax=4G` guard is a local-machine measure and is not needed there; (3) `cargo check -p ringdesign-core -p ringdesign-configurator --no-default-features --target wasm32-unknown-unknown`; (4) a separate, cached job for `--features kernel-manifold` since it builds Manifold from source. Skip the Android leg for now (it lives in another workspace). This is one afternoon and it pays for itself the first time a wasm-hostile call or a feature-gated compile error lands.
+
+</details>
+
+**Castability.** Protective: the field-verdict tests (`templates.rs`, `mesh::tests::scratch_signet_head_undercuts`, `castability` tests) are the ones that would go stale first, and those are exactly the ones encoding the two-part pull guarantee.
+
+**Verified.** Verified. `ls -a` at the repo root shows no `.github` directory (assets, batch6-8, Cargo.lock, Cargo.toml, .claude, CLAUDE.md, crates, docs, .git, .gitignore, graphs, patches, target, tools). `find . -maxdepth 3 -name '*.yml' -o -name '*.yaml'` outside target returns nothing. The feature matrix the auditor lists is the one CLAUDE.md documents and it is real. Nothing on docs/ROADMAP.md mentions CI (grepped).
+
+#### F156 Gate the GUI export on the verdict and the achieved tolerance — `high` / `S` / code-architecture
+
+**Problem.** `export.rs` builds and writes the file, then reports the outcome. Nothing checks the field verdict, nothing checks `RefineStats::hit_cap` or `saturated_leaves`, and the only quality signal in the status line is "NOT watertight" — after the file is already on disk. So a jeweller can File > Export STL on a design whose own banner says NotCastable, and the resulting file carries no mark distinguishing it from a clean one. Meanwhile the graph crate's `sink.export` refuses a `NotCastable` ring outright and the CLI field-checks every size, so the primary tool is the least careful of the three.
+
+**Evidence.** crates/ringdesign-gui/src/export.rs:92-113 (STL), :116-137 (OBJ), :140-163 (3MF) — each is `job.build()` then `write_*` then a status string; no reference to `field`, `verdict`, `hit_cap` or `saturated_leaves`. `RefineStats::hit_cap` is set at crates/ringdesign-core/src/refine.rs:581 and :651 and `saturated_leaves` at :678; a workspace grep finds no reader outside core. The GUI status line reads only `s.worst_error_mm` (crates/ringdesign-gui/src/app.rs:439-442), and that is the *preview* build's number, not the export's. Compare crates/ringdesign-graph/src/nodes/sink.rs:40 and crates/ringdesign-cli/src/main.rs:174-176.
+
+**Do this.** Unchanged and worth promoting — this is the finding with the most direct bench consequence, since the STL is the thing that reaches the caster. Reuse `ExportJob`'s existing snapshot: export.rs:286 already shows the pattern for computing `attributed_field_report` inside a spawned job, so lift that into `spawn_export` ahead of the write. Prefer (a) refuse-with-override for NotCastable, since the CLI and the graph sink both already refuse and the GUI should not be the lax one. Whichever is chosen, stamp the verdict into the STL's 80-byte header (stl.rs `binary_header` already carries generator, name and UNITS=mm — there is room) and into the 3MF metadata, so an exported file carries its own judgement. Surface `hit_cap` and `saturated_leaves` in the status line too: today a depth-limited refine reports a worst error of 0.0 that means nothing, and no UI reads the flag that says so.
+
+<details><summary>The auditor's original recommendation</summary>
+
+In `spawn_export`, run `attributed_field_report` on the snapshotted design before writing and either (a) refuse with the verdict and its notes, offering "export anyway", or (b) at minimum append the verdict, `worst_error_mm`, and `hit_cap`/`saturated_leaves` to the status line and stamp the verdict into the STL's 80-byte header (which already carries generator, name and UNITS=mm). Same for the 3MF metadata.
+
+</details>
+
+**Castability.** Directly addresses it: this is the last gate before metal, and it is currently open.
+
+**Verified.** Verified, and the asymmetry against the other two frontends is real. crates/ringdesign-gui/src/export.rs:83-113 (STL), :116-138 (OBJ), :141-164 (3MF) are each `job.build()` then `write_*` then a status string; the only quality signal is `out.report.validation.watertight` on the STL path, printed after the file is on disk. No reference to the field verdict in any of the three. `RefineStats::hit_cap` (refine.rs:150, set at :582 and :657) and `saturated_leaves` (:163, set at :678) have no reader outside refine.rs and its own tests — I grepped the whole workspace. Meanwhile crates/ringdesign-cli/src/main.rs:174 runs `analyze_field(&d, lib, &d.draft, 192, 128)` per size and prints the verdict into the manifest, and crates/ringdesign-graph/src/nodes/sink.rs:54-60 `judge()` refuses a NotCastable ring in SandRing mode. The GUI's own sheet export DOES compute the field (export.rs:286 `attributed_field_report`), which makes the mesh exports' silence a within-file inconsistency, not just a cross-crate one.
+
+#### F157 Stop cloning the whole design per layer inside undercut attribution — `medium` / `S` / code-architecture
+
+**Problem.** `castability::attribute_undercuts` clones the entire `RingDesign` once per enabled layer — including the base64 `embedded` PNGs, the drawn strokes, the texts and the SVG source — and re-runs a full 160×112 field sweep for each. On a twenty-layer design that is twenty full design clones (potentially megabytes each) and 358,400 extra field samples per settled build. It runs only when there *is* undercut, which means it fires exactly while the jeweller is iterating to remove one — the worst possible moment for the preview to slow down.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:1362-1367: `for &i in &enabled { let mut d = design.clone(); d.layers.layers[i].enabled = false; masked.push((i, field_undercuts(&d, lib, min_draft, parting_z, T, P))); }` with `const T: usize = 160; const P: usize = 112;` at :1322-1323. Called unconditionally from `attributed_field_report`, which the GUI worker runs on every settled build (crates/ringdesign-gui/src/app.rs:987).
+
+**Do this.** Unchanged; both halves are contained. Give `field_undercuts` a `mute: Option<usize>` threaded into `LayerStack::height_d` (field.rs:815, which already skips on `!e.enabled || e.opacity <= 0.0` at :830 — one more predicate, no allocation). Then prune candidates before sweeping: `Layer::feature_footprints` already names each layer's u-range, so a layer whose footprint does not overlap the clustered arc cannot explain it. Add a cheap third win: the arcs are already clustered, so the muted sweep only needs the theta range of the region rather than the full 160 columns.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Make `field_undercuts` take a `mute: Option<usize>` and skip that index inside `LayerStack::height_d` rather than cloning the design — no allocation at all. Then restrict the sweep: a layer whose `feature_footprints` u-range does not overlap the region's arc cannot explain it, so skip it. Both are contained changes and together they take the worst case from O(layers) full sweeps to one plus a handful.
+
+</details>
+
+**Castability.** None if the mute is implemented as a skip in `height_d`, which is exactly equivalent to `enabled = false`. Pin it with a test that the muted-index path and the cloned-design path return identical sample sets.
+
+**Verified.** Verified. crates/ringdesign-core/src/castability.rs:1319-1367: `const T: usize = 160; const P: usize = 112;`, then `for &i in &enabled { let mut d = design.clone(); d.layers.layers[i].enabled = false; masked.push((i, field_undercuts(&d, lib, min_draft, parting_z, T, P))); }`. `RingDesign` clone cost is real — it carries `embedded: Vec<EmbeddedAlpha>` of base64 PNG strings (lib.rs:84), `drawn`, `texts`, `svgs` and `recipes`. The early-out at :1325-1328 (`if base.is_empty() { return Vec::new(); }`) is real, which confirms the auditor's own point that it fires exactly while the jeweller is iterating to clear an undercut. Called from `attributed_field_report`, which the GUI worker runs on every settled build (app.rs:987).
+
+#### F158 Resolve each layer's alpha once per build instead of once per sample — `medium` / `M` / code-architecture
+
+**Problem.** `TilingLayer::height` does `lib.get(&self.alpha)` — a `HashMap<String, usize>` lookup with a full SipHash of the name — on every sample. So does the SDF lookup, and `LayerEntry::mask_at` does a third for a painted mask. At a 384×144 preview with eight layers that is on the order of ten million string hashes per build, and the same field is evaluated four more times per settled build (mesh, `attributed_field_report` at 192×128, `modulus_scan`, `section_at`, plus `stones::report`).
+
+**Evidence.** crates/ringdesign-core/src/tiling.rs:286 (`let Some(alpha) = lib.get(&self.alpha) else`), tiling.rs:362 (`lib.get(&crate::alpha::sdf_name(&self.alpha))` — this one also *allocates a String* per sample via `format!`), crates/ringdesign-core/src/field.rs:776 (mask). `AlphaLibrary::get` is `self.index.get(name).and_then(|&i| self.entries.get(i))`. The per-sample `sdf_name` allocation is the sharpest edge — a heap allocation and free inside the innermost loop of every bevelled tiling.
+
+**Do this.** Sharpen to the cheapest-first order, since the two halves are very different in cost to implement. (1) Kill the per-sample allocation first: cache the SDF name on `TilingLayer` as a `#[serde(skip)]` derived field, or better, cache the resolved index via the existing `AlphaLibrary::position` so the hot path becomes `get_index`. That is a contained change and removes a malloc/free from the innermost loop of every bevelled tiling. (2) Then the `ResolvedStack<'a>` built once per build. Measure before and after with an ornamented design at 384x144 — the field is evaluated at least five times per settled build (mesh, `attributed_field_report` at 192x128, `modulus_scan`, `section_at`, `stones::report`), so the multiplier is real.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Introduce a `ResolvedStack<'a>` built once per build: walk the stack, look up each layer's alpha, SDF and mask by name once, and hand `height` a struct of `&'a Alpha` references. If that is too invasive, the minimum win is caching the `sdf_name` String on `TilingLayer` (a `#[serde(skip)]` derived field, exactly like the outline silhouette table) — that alone removes an allocation per sample. This is the clearest next 2x on the interactive loop and it touches no geometry.
+
+</details>
+
+**Castability.** None — pure lookup caching. `h(u,v)` is bit-identical, so every measured 0.000% stays 0.000%.
+
+**Verified.** Verified, and the sharpest edge is confirmed. crates/ringdesign-core/src/tiling.rs:362 is `lib.get(&crate::alpha::sdf_name(&self.alpha))` and `alpha::sdf_name` (alpha.rs:553-555) is `format!("{name}##sdf")` — a heap allocation and free per sample. It is gated by `(edge > 1e-9).then(...)`, so only bevelled tilings pay it, which the auditor did not say but which narrows rather than kills the finding (edge_mm is exactly the feature finding 3 wants working). The other two lookups are as described: tiling.rs:286 `let Some(alpha) = lib.get(&self.alpha)` in `height_at`, and field.rs:779-781 `if let Some(name) = &self.mask && let Some(a) = lib.get(name)` in `LayerEntry::mask_at`. `AlphaLibrary::get` (alpha.rs:1488) is a `HashMap<String, usize>` probe, i.e. a full SipHash of the name each time. No resolved/cached form exists — I grepped for a ResolvedStack or any index-based fast path and found only `get_index`/`position` (alpha.rs:1492-1498), which nothing on the sampling path uses.
+
+#### F159 Cut `outline.rs` out of `field.rs` and `signet.rs` out of `profile.rs` — `medium` / `L` / code-architecture
+
+**Problem.** `field.rs` is 4,787 lines and `profile.rs` 5,385, and in both cases roughly a fifth of the file is a coherent subsystem that has nothing to do with the file's stated subject. `field.rs` — the height-field module — carries `SignetOutline`, `PolarOutline`, `Silhouette` and `CustomOutline` (lines 2046-2985, ~940 lines of *plan* geometry consumed almost entirely by `profile.rs`'s head construction, not by any layer). `profile.rs` carries `sample_spaced` at 508 lines and `ShankStyle::modulation` at 337 in one impl block alongside `SignetHead`, `HeadAt`, `Tent`, `WallShape` and ~30 head constants. The cohesion inside each subsystem is real; the cohesion *between* them is not.
+
+**Evidence.** `wc -l crates/ringdesign-core/src/{field,profile}.rs` → 4787 / 5385. Structure scan: field.rs types at lines 14-2044 are chart + layers, 2046-2985 are outline/plan geometry, 2986+ is `SignetLayer`. profile.rs: 18-1204 is `BandProfile`/`DropCurve`/`ProfileLoop`, 1206-2270 is signet head types and constants, 2272-2748 is `ShankMod`/`modulation`, 2749-3500 is the loft (`Tent`, `WallShape`, `LOFT_*`, `RIDGE_TABLE`). Largest functions: `sample_spaced` 508 lines (profile.rs:632), `modulation` 337 (profile.rs:2392), `head_at_for` 193 (profile.rs:1904).
+
+**Do this.** Two cuts, both mechanical and both worth it. (1) New top-level `outline.rs`: move `SignetOutline`, `PolarOutline`, `Silhouette`, `CustomOutline`, `BODY_FAIR_R`, `heart_table` and friends out of `field.rs`; re-export from `field` for compatibility. This inverts a dependency that is currently backwards — head construction should depend on plan geometry, not on the layer-stack module. (2) New `profile/signet.rs`: move `SignetHead`, `HeadAt`, `Tent`, `TentAt`, `WallShape`, `head_at_for`, `tent_for` and the ~30 `HEAD_*`/`LOFT_*`/`SIGNET_*` constants, leaving `profile.rs` as `BandProfile` + `ProfileLoop` + `sample_spaced` + `ShankStyle::modulation`. Do NOT split `sample_spaced` itself — its length is the price of building one section from two spans with every clamp visible in one place, and the interleaving of the crest/bore/wall solves is exactly the thing the comments say must not be separated. Splitting the *files* is worth it; splitting that function is not.
+
+**Castability.** n/a if done as pure moves with no logic edits — verify with `cargo test` before and after and a byte-identical STL from a template design.
+
+#### F160 `sizing.rs` has zero tests and no range guard on the one number a customer gives you — `medium` / `S` / code-architecture
+
+**Problem.** `crates/ringdesign-core/src/sizing.rs` is 54 lines and contains no `#[cfg(test)]` module at all — it is the only core module with none. `RingSize` is a public tuple struct, so `RingSize(x)` accepts any `f64` including 0, negative and NaN, and that is the constructor used by serde, by `nodes/band.rs:21`, by the CLI's `--sizes`, and by MCP. A negative size gives a negative inner circumference, hence a negative bore radius and a negative `circumference_mm` in the `FieldContext` — every chart coordinate and every integer-count generator then works in a mirrored space, with no error anywhere.
+
+**Evidence.** crates/ringdesign-core/src/sizing.rs (whole file, no test module; `inner_circumference_mm` = `36.5 + self.0 * 2.55` unguarded). `RingSize::new` rounds to a quarter but nothing forces its use: crates/ringdesign-graph/src/nodes/band.rs:21 `d.size = RingSize(size);` and crates/ringdesign-cli/src/main.rs:174 `d.size = RingSize(size);` both take the raw number. `crates/ringdesign-core/src/lib.rs` `inner_radius_mm` = `self.size.inner_diameter_mm() * 0.5` with no floor.
+
+**Do this.** Add a `sizing::tests` module pinning the formula against published US inside diameters (size 3 = 14.07 mm, 5 = 15.70, 7 = 17.35, 9 = 19.00, 13 = 22.20), round-tripping `from_diameter_mm`/`from_circumference_mm`, and checking `display()` for whole, half and quarter sizes. Then clamp construction: make `RingSize::new` the only public constructor (or add `#[serde(deserialize_with)]` clamping to a physical 0.5..=20.0 and rejecting non-finite), and have `RingDesign::inner_radius_mm` floor at something a finger could wear.
+
+**Castability.** A degenerate size produces a chart with negative circumference; every integer-count seamlessness guarantee and every arc-scale correction is then meaningless, and the field verdict would report on geometry that is not a ring.
+
+#### F161 CLAUDE.md's head-draft numbers contradict the code and themselves — `medium` / `S` / code-architecture
+
+**Problem.** The doctrine document is load-bearing — it is what a future maintainer (or agent) reads to know why a constant has the value it has — and two of its head numbers no longer match the source. It states that `HEAD_FACE_DRAFT` "drafts the head's flanks by 9%", while the constant is 0.02 and the *same document* records fifty lines earlier that it "was 0.09 ... Now 0.02, a token draft rather than a look." It also describes the swell as running "over an arc two and a half times as long" where `HEAD_SWELL_RATIO` is 2.4. Sampling the other numeric claims found them accurate, which is what makes the two stale ones dangerous: the document has earned enough trust to be believed.
+
+**Evidence.** CLAUDE.md:565 ("`HEAD_FACE_DRAFT` uses it to draft the head's flanks by 9%") vs crates/ringdesign-core/src/profile.rs:1452 `pub const HEAD_FACE_DRAFT: f64 = 0.02;` and CLAUDE.md:403 ("`HEAD_FACE_DRAFT` was 0.09 ... Now 0.02"). CLAUDE.md:320 ("two and a half times as long") vs crates/ringdesign-core/src/profile.rs:1430 `pub const HEAD_SWELL_RATIO: f64 = 2.4;`. Verified accurate in the same pass: `SIDE_FACE_MIN_DRAFT_DEG` 80.0 (field.rs:142), `BODY_FAIR_R` 0.75 (field.rs:2516), `HEAD_RISE_MM` 0.3, `HEAD_SHOULDER_DEG` 43.0, `HEAD_DOME_INSET` 0.90, `HEAD_EDGE_BREAK` 0.45, `head_aspect(Heart)` 1.05 (field.rs:2390), `MIN_EDGE_MM` 0.2, `MIN_WALL_MM` 0.5, `CABOCHON_MAX_ASPECT` 1.25, `BED_CLEARANCE_MM` 0.1, `MAX_RELIEF_MM` 1.6, `taper` clamp 0..0.85, `MAX_SEATS` 240.
+
+**Do this.** Unchanged, and the durable half is the valuable half. Fix CLAUDE.md:565 to 2% and CLAUDE.md:320 to "2.4 times". While fixing :565, check the clause that follows it — "which is what the reference does (16.0 mm body, 14.7 mm table)" — because 14.7/16.0 is an 8% inset and that belongs to the body/face fairing (`BODY_FAIR_R`, the morphological closing), not to `HEAD_FACE_DRAFT`; that mis-attached justification is almost certainly why the stale 9% survived a reading. Then add the drift test: a `#[test]` that parses the constants named in CLAUDE.md out of the prose and asserts each against its `pub const`, modelled on the byte-for-byte golden test the graph templates already have (`RD_WRITE_TEMPLATE_GRAPHS=1 cargo test -p ringdesign-graph write_template_graphs`).
+
+<details><summary>The auditor's original recommendation</summary>
+
+Fix line 565 to say 2% (and check that the "16.0 mm body, 14.7 mm table" justification in the same sentence belongs to the *fairing*, not to `HEAD_FACE_DRAFT` — 14.7/16.0 is an 8% inset, which is what makes the stale 9% look plausible). Fix line 320 to "2.4 times". Longer term, the durable fix is a test that greps the constants named in CLAUDE.md and asserts their values, so prose and code cannot drift again — the same discipline the graph templates already get from their byte-for-byte golden test.
+
+</details>
+
+**Castability.** Indirect but real: `HEAD_FACE_DRAFT` is the draft on the head's flanks, and someone restoring it to 0.09 on the strength of line 565 would change the one surface a two-part mould has to slide off.
+
+**Verified.** Both errors verified verbatim. CLAUDE.md:565 reads "`HEAD_FACE_DRAFT` uses it to draft the head's flanks by 9%" while crates/ringdesign-core/src/profile.rs:1452 is `pub const HEAD_FACE_DRAFT: f64 = 0.02;` and profile.rs:2198 applies it as `let k = 1.0 - HEAD_FACE_DRAFT;` — and CLAUDE.md:403 in the same document says "**`HEAD_FACE_DRAFT` was 0.09.** ... Now 0.02, a token draft rather than a look." CLAUDE.md:320 reads "over an arc two and a half times as long" while profile.rs:1430 is `pub const HEAD_SWELL_RATIO: f64 = 2.4;` (used at profile.rs:1551 as `face_half_deg * HEAD_SWELL_RATIO`). The auditor's control sample also holds up — the other constants they list match.
+
+#### F162 Track the harvest tooling — the evidence for the doctrine is untracked — `high` / `S` / code-architecture
+
+**Problem.** `tools/harvest/` is explicitly gitignored: 42 Python files, 3,685 lines, comprising `cluster_recipe.py` (the GH chunk parser whose type table settled the loft), `cgpreset.py` (the 448-preset unpacker), `outline_export.py` (the 19 factory signet plans), `cluster_curves.py` (the 23 profile sections), `signet_tent.py`, `deviation.py` and `dihedral.py` (the exact point-to-surface and crease measures that every deviation number in CLAUDE.md is quoted from). The archive it reads lives outside the repo too. So the calibration chain behind the lofted head, the wall table, the ridge table, the outline library and the imported profiles cannot be re-derived or re-verified from a clone — only the conclusions survive, as prose.
+
+**Evidence.** .gitignore contains `/tools/harvest/`; `git ls-files tools` returns nothing. `find tools/harvest -name '*.py' | wc -l` → 42; total 3,685 lines. CLAUDE.md cites these by name as the source of load-bearing numbers at many points (`tools/harvest/cluster_recipe.py`, `tools/signet_tent.py`, `tools/harvest/deviation.py`, `tools/harvest/outline_export.py`, `tools/harvest/cluster_curves.py`), and records that the archive "stays in ../PostLoad/PostLoad". CLAUDE.md's roadmap-adjacent "Niceties" list already wants the deviation report promoted to a core feature, which is the same tooling.
+
+**Do this.** Un-ignore `tools/harvest/*.py`, `requirements.txt` and its README while keeping `__pycache__/`, `reports/` and `tools/venv/` ignored — replace the blanket `/tools/harvest/` line with those narrower rules. That is roughly a megabyte of text against a correctly-ignored 221 MB `assets/decoded`. Then promote `deviation.py` (exact point-to-surface) and `dihedral.py` (the crease census) into `ringdesign-core` as examples or behind a dev feature, which is already on the ROADMAP Niceties list — say so when proposing it, and note the payoff CI makes possible: with finding 7's workflow in place, the deviation measures the doctrine quotes become a regression gate instead of a one-off run in an untracked venv.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Un-ignore `tools/harvest/*.py`, `requirements.txt` and `README.md` while keeping `__pycache__`, `reports/` and the venv ignored — that is ~1 MB of text against a 221 MB `assets/decoded` that correctly stays out. The decoded *outputs* can stay untracked; the scripts that produce them must not be. Separately, promote `deviation.py` and `dihedral.py` into `ringdesign-core` (behind a dev feature or as examples) so the mesh-comparison measures the doctrine quotes become runnable in CI rather than in an untracked venv.
+
+</details>
+
+**Castability.** n/a directly, but every castability number quoted for the lofted head family traces back to these scripts.
+
+**Verified.** Verified. .gitignore contains `/tools/harvest/` and `/tools/venv/`; `git ls-files tools` returns nothing at all; `find tools/harvest -name '*.py' | wc -l` is 42. So `cluster_recipe.py`, `cgpreset.py`, `outline_export.py`, `cluster_curves.py`, `signet_tent.py`, `deviation.py` and `dihedral.py` — every script CLAUDE.md cites as the source of a load-bearing number — are absent from a clone. Worth adding to the finding: `.gitignore` also ignores `assets/` and `batch6-8/` wholesale, so the decoded factory outlines and the from-Rhino loft captures are untracked too; `graphs/` IS tracked (clusters, presets, the nine templates). And docs/ROADMAP.md's Niceties list (line 195-197) already wants "reference-mesh import + deviation report as a core feature (the exact point-to-triangle measure and the crease census, today script-only)" — i.e. the second half of this recommendation is already parked on the Shelf, so promoting it is consistent with the owner's own plan rather than new.
+
+#### F163 Two designs in one session can share an alpha name and silently swap art — `medium` / `S` / code-architecture
+
+**Problem.** `RingDesign::unpack_embedded` skips any alpha whose name already exists in the library, and the GUI/engine library accumulates for the whole session. So opening design A (whose embedded "leaf" is one drawing) and then design B (whose embedded "leaf" is a different one) renders B with A's artwork — silently, with B's own file untouched. The same collision hits `bake_drawn`/`bake_texts`/`bake_svgs`, which use `insert` and therefore *overwrite* rather than skip, so the ordering of the two mechanisms is also inconsistent.
+
+**Evidence.** crates/ringdesign-core/src/lib.rs `unpack_embedded`: `if lib.get(&e.name).is_some() { continue; }` with the comment "The local library wins on a name collision, so a machine that has the original keeps using it." `DesignEngine::load_design` (crates/ringdesign-core/src/engine.rs:186-192) unpacks into the same long-lived `Arc<AlphaLibrary>`; crates/ringdesign-gui/src/export.rs:382 does the same into `app.library_mut()`. `AlphaLibrary::insert` replaces on name match, so drawn/text/svg sources do overwrite — the two paths disagree.
+
+**Do this.** Unchanged in aim, with the mechanism preferred: hash the alpha content into the embedded key so identical art dedupes and different art cannot collide — that fixes the collision without needing a resident-vs-incoming comparison and without a disambiguation rewrite of the loaded design's `alpha` references. If a content-addressed key is too invasive for the file format, then compare dimensions plus a cheap content hash at lib.rs:237, insert under a suffixed name on mismatch, and rewrite that layer's reference. Either way, make `unpack_embedded` and the `bake_*` family agree on precedence and say which wins in the doc comment. Sequence this BEFORE finding 5's fold of `unpack_embedded` into `bake_all`, since that fold makes the skip-on-collision rule run on every bake.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Compare content before deciding: if the incoming embedded alpha differs from the resident one (dimensions or a cheap content hash), insert it under a disambiguated name and rewrite that layer's `alpha` reference in the loaded design — or, more simply, hash the alpha content into the embedded key so identical art dedupes and different art cannot collide. At minimum, log a warning naming both designs so the mismatch is discoverable.
+
+</details>
+
+**Castability.** The field verdict is computed on the substituted art, so a ring can be judged castable on artwork it will not be cast with. Two different reliefs of the same nominal height can easily have different wall angles.
+
+**Verified.** Verified. crates/ringdesign-core/src/lib.rs:234-249 `unpack_embedded` opens with `if lib.get(&e.name).is_some() { continue; }` under the comment "The local library wins on a name collision, so a machine that has the original keeps using it." `AlphaLibrary::insert` (alpha.rs:1464-1471) replaces by name, so `bake_drawn`/`bake_texts`/`bake_svgs`/`bake_recipes` overwrite while `unpack_embedded` skips — the two mechanisms genuinely disagree, as claimed. The library really is long-lived across designs: engine.rs:196-197 unpacks into the same `Arc<AlphaLibrary>` and gui/src/export.rs:382-383 into `app.library_mut()`, neither of which is reset per open. One narrowing worth stating: painted bands are safe, because `embed_alphas` (lib.rs:209-211) explicitly excludes builtin and drawn alphas, so the shared name "band" from `paint::ensure_band_layer` travels as strokes and goes through the overwrite path. The exposure is imported PNG and SVG art with a generic name — two designs both carrying a "leaf" or "pattern".
+
+#### F164 `FORMAT_VERSION` has been frozen at 1 through every format addition — `medium` / `S` / code-architecture
+
+**Problem.** The migration ladder is well built — versioned save, a forward-version refusal with a clear message, a test that every version has a step — and then it is never used. `FORMAT_VERSION` is 1 with a single no-op migration, while the format has since gained `graph`, `recipes`, `svgs`, the whole lofted signet (`loft`, `table_dome_mm`, `hollow_mm`), `CustomOutline`, keyframes, `tilt_deg`, `shared_prong_mm`, `bezel_bearing_mm`, `Openwork` and more. Forward compatibility therefore rests entirely on every one of those fields carrying `#[serde(default)]`, which is a per-field human check with no test behind it. A single missed `default` makes every older design file fail to load with a raw serde error rather than the friendly version message the ladder exists to give.
+
+**Evidence.** crates/ringdesign-core/src/library.rs:38 `pub const FORMAT_VERSION: u32 = 1;` and :43-46 (`MIGRATIONS` = `[migrate_v0_to_v1]`, which is empty). :34-35 records the deliberate decision to add `graph` without a bump. Spot-checked coverage: `SignetHead` has 9 `serde(default)` on 15 public fields, `SeatRunLayer` 4 on 8, `ShankStyle` 5 on 7 — the uncovered ones are presumably older fields, but nothing verifies that.
+
+**Do this.** Add a golden-file test: commit two or three real `.ring.json` files captured at earlier points (a plain band, a prism signet, a stone-set band) and assert each still loads and builds. That catches a missing `default` the day it lands, which is what the ladder was for. Then bump `FORMAT_VERSION` when the next change is genuinely not default-able, so the ladder is exercised at least once and the refusal path is proven on a real file rather than a synthetic one.
+
+#### F165 Restart the build worker after a panic instead of going read-only for the session — `medium` / `S` / code-architecture
+
+**Problem.** The build worker is a single thread running an unguarded loop over `mesh::build`, `castability::analyze`, `attributed_field_report`, `stones::report`, `modulus_scan` and `gems::preview_vertices`. A panic in any of them kills the thread. The disconnect is detected and reported ("Build worker stopped"), which is good — but nothing restarts it, so every subsequent edit sets `in_flight`, fails to send, and reports the same message. The app becomes a viewer of a stale mesh for the rest of the session with no path back except quitting, and the user's unsaved work sits behind that.
+
+**Evidence.** crates/ringdesign-gui/src/app.rs:955-1010 (the worker loop, no `catch_unwind`), :498-501 (`Err(TryRecvError::Disconnected) => { self.in_flight = false; self.status = "Build worker stopped".into(); }`), :536-539 (`if self.worker.jobs.send(job).is_err() { ... }`). No `Worker::new` call outside `RingDesignerApp::new`.
+
+**Do this.** Unchanged, with one detail to get right: because the `parallel` feature routes fan-outs through rayon, a panic inside a rayon closure is re-raised on the calling thread, so the `catch_unwind(AssertUnwindSafe(...))` must wrap the whole per-job body from graph evaluation through `gems::preview_vertices`, not just the `mesh::build` call. Send back a `Done::Failed { generation, message }` so the panic is attributed to the design that caused it — that also makes the failing design reproducible, which a bare respawn would not. Prompt the user to save when it fires. Cheaper interim fix if `catch_unwind` is unpalatable: respawn at app.rs:497 on `Disconnected` and re-dispatch, but note that re-dispatching the same design will panic again immediately, so the failure message matters either way.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Wrap the per-job body in `std::panic::catch_unwind(AssertUnwindSafe(...))` and send back a `Done::Failed { generation, message }` so the panic is reported against the design that caused it and the loop survives — or, if that is unpalatable, respawn the worker on `Disconnected` and re-dispatch. Either way, prompt the user to save. Note that `parallel` means a rayon-internal panic propagates to this same thread, so the guard needs to be around the whole job body, not just `mesh::build`.
+
+</details>
+
+**Verified.** Verified. The worker loop at crates/ringdesign-gui/src/app.rs:~955-1010 runs graph evaluation, `mesh::build`, `castability::analyze`, `attributed_field_report`, `stones::report`, `modulus_scan` and `gems::preview_vertices` with no `catch_unwind` anywhere. `Worker::spawn()` is called exactly once, at app.rs:327, inside `RingDesignerApp::new` — there is no other construction site. The two disconnect handlers (app.rs:497-500 in `tick`, and app.rs:537-540 in `dispatch`) both just set `in_flight = false` and the status string; neither respawns. So every subsequent edit reports "Build worker stopped" and the app is a viewer of a stale mesh for the rest of the session. The eframe autosave (main.rs:28-31) means unsaved work is not necessarily lost on quit, which softens the consequence but does not fix the dead session.
+
+#### F167 Undo does not re-bake drawn, text or SVG alphas, so painted metal survives Ctrl+Z — `high` / `S` / ux-workflow
+
+**Problem.** `RingDesign` carries strokes (`drawn`), inscriptions (`texts`) and vector art (`svgs`) as source data; the rasters live in the shared `AlphaLibrary` and are derived by `bake_drawn`/`bake_texts`/`bake_svgs`. Every load site calls that trio. `apply_history` does not. So Ctrl+Z after a paint stroke restores `design.drawn` without the stroke but leaves the *baked* "band" alpha in the library, and the tiling layer that shows it renders the stroke exactly as before — undo appears to do nothing. Same for editing an inscription's text or re-importing an SVG under the same name: undo restores the old source and the ring keeps showing the new raster. The paint bar's own local undo button works only because it calls `bake_band` itself.
+
+**Evidence.** crates/ringdesign-gui/src/app.rs:604-620 `apply_history` (sets `self.design`, marks dirty, never touches the library); crates/ringdesign-gui/src/panels/unrolled.rs:1332 `bake_band` (the only re-bake on the stroke path); grep shows `bake_all` is called at exactly two sites — `app.rs:252` (startup) and `export.rs:384` (open a file) — and nowhere in the history path.
+
+**Do this.** Add the bake to `apply_history` (app.rs:605) only — `let d = self.design.clone(); d.bake_all(self.library_mut());` plus a thumbnail clear. Skip `Command::New` and `load_template`: both land on designs with no `drawn`/`texts`/`svgs`, so a bake there buys nothing and costs an `Arc::make_mut` deep copy. `open_graph` (app.rs:807) does not replace the design at all — it only sets `design.graph` — so it needs no bake either. Pin it with a test: paint a stroke, snapshot, undo, assert the library's "band" alpha equals the pre-stroke raster.
+
+<details><summary>The auditor's original recommendation</summary>
+
+In `apply_history`, after `self.design = design`, call `let d = self.design.clone(); d.bake_all(self.library_mut());` and clear the affected thumbnails. `bake_all` already replaces entries by name, and `Arc::make_mut` is the same deep copy `bake_band` pays on every stroke end, so the cost is one bake per undo, not per frame. Also do it in `Command::New`, `load_template` and `open_graph`, all of which replace the design.
+
+</details>
+
+**Verified.** Confirmed. `apply_history` (app.rs:604-617) sets `self.design`, fixes the selection, sets status, marks dirty, pushes to MCP — it never touches the library. `bake_all` has exactly three call sites in the whole workspace: app.rs:252 (startup), export.rs:384 (open a file), engine.rs:197 (`DesignEngine::load_design`). The paint path's own `bake_band` (unrolled.rs:1333) is called from the stroke-end at :1327 and the local undo at :1448, which is why the brush-bar undo works and Ctrl+Z does not. Also verified `Command::New` (panels/mod.rs:443) and `load_template` (export.rs:400) replace the design without baking — for those two the practical bite is small (a default design and the templates carry only builtin alphas), so the real defect is undo/redo and it is worth stating that way.
+
+#### F172 The first thing a new user does produces an uncastable ring, and the Add menu knows better everywhere else — `high` / `S` / ux-workflow
+
+**Problem.** The default band is `ProfileStyle::HalfRound` 6×2 with a 1.8 mm crown — the profile the doctrine says "honestly has no side". Add layer ▸ Tiling builds `TilingLayer::default_for`, which centres the tiling on `ctx.crest_v_mm` at 0.35 mm relief over 60% of the band, and picks whatever alpha sorts first in the library. That is the measured lock case (a crest holds ~0.15 mm), on the app's own out-of-the-box band, from the app's own first menu item. Meanwhile the Curve presets, Openwork, Channel set and Halo in the same menu all *do* place onto a side face or refuse with a sentence explaining what to change.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:508 `style: ProfileStyle::HalfRound, width 6.0, thickness 2.0, crown 1.8`; crates/ringdesign-core/src/tiling.rs:172-198 `default_for` (`v_center_mm: ctx.crest_v_mm`, `height_mm: 0.35`); crates/ringdesign-gui/src/panels/layers.rs:63-78 (Tiling takes `app.lib.names().first()` and places nothing) against :99-128 (Curve presets call `retarget_v` onto `side_faces_std().wider()` and set `VGate::SideFaces`) and :158 (Openwork calls `fit_to_side_faces`).
+
+**Do this.** Two small edits, both in files already open. (1) layers.rs:63-74: after `TilingLayer::default_for`, call `t.fit_to_side_faces(&ctx, SIDE_FACE_MIN_DRAFT_DEG)` and set the entry's `window.v_gate = VGate::SideFaces(SideFacePick::Wider)` when it returns true — literally the Openwork arm's own three lines at :158. When it returns false, set the status to the refusal the Channel-set item already uses. (2) layers.rs:1912 (`.on_disabled_hover_text`): put a `Square the sides` button beside the disabled Fit button calling `profile.flatten_sides()` directly. Changing `BandProfile::default` is the riskier half — it moves every file that omits the field and every test baseline — so prefer opening the template gallery on first run (finding 6) over changing the default profile.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Make Tiling behave like its neighbours: call `fit_to_side_faces` and set `VGate::SideFaces(Wider)` when the profile has a face, and when it does not, add the layer *and* set the status to the refusal sentence the other items use, with an inline "Square the sides" button. In `side_face_fit` (layers.rs:1897) the disabled-button path already tells the user to go to the Design tab — put a button there that calls `profile.flatten_sides()` directly, so the fix is one click from where the problem is named. Separately, consider `ProfileStyle::DShape` or `Flat` as the default band, or open the template gallery on first run so nobody starts on the one profile that carries no ornament.
+
+</details>
+
+**Castability.** Directly: it moves the default ornament from the crest (measured 0.75–1.77% undercut at 0.15–0.30 mm on a half-round) to the side face (measured 0.000% to 1.60 mm).
+
+**Verified.** Confirmed on every limb. `BandProfile::default` (profile.rs:505-512) is HalfRound 6.0 x 2.0 with crown 1.8 — usable side-face width is `thickness - crown` = 0.2 mm, i.e. none. `TilingLayer::default_for` (tiling.rs:171-198) sets `v_center_mm: ctx.crest_v_mm`, `v_span_mm: band_v_len * 0.6`, `height_mm: 0.35`. The Add-menu Tiling arm (layers.rs:63-74) takes `app.lib.names().first()` and calls `default_for` with no placement, while the Curve arm (:99-128) closes over `ctx.side_faces_std().and_then(|sf| sf.wider())`, calls `retarget_v` and sets `VGate::SideFaces(SideFacePick::Wider)`, and the Openwork arm (:158+) calls `fit_to_side_faces`. Per CLAUDE.md's own measured table, 0.30 mm of relief on a half-round crest is 1.77% undercut. Worth knowing: the remedy button already exists one level in — `side_face_fit` (layers.rs:1896-1955) draws "Fit to sides" in the tiling editor and its disabled-hover says to square the sides on the Design tab, with no button to do it.
+
+#### F196 `--steps` is silently ignored on a design that carries a refine tolerance — `medium` / `S` / interop
+
+**Problem.** `ringdesign export --steps 1536x448` writes `params.theta_steps`/`profile_steps`, but `mesh::build` returns `build_refined` before reading either whenever the design's saved `BuildParams::refine` is `Some`. The caller gets a build at whatever tolerance the file happened to carry, with no warning, and the manifest CSV records a triangle count they did not ask for. Worse, there is no `--refine` flag at all — so the CLI, which is the size-run and export tool, cannot request the refined build CLAUDE.md calls the export build ("Sweep for the interactive preview, refine for export").
+
+**Evidence.** crates/ringdesign-cli/src/main.rs, the `--steps` arm setting `params.theta_steps`/`params.profile_steps`; no `--refine` in the option match or in `USAGE`. crates/ringdesign-core/src/mesh.rs:294-301 — `if let Some(rp) = params.refine { return build_refined(...) }` before `let n_theta = params.theta_steps.clamp(...)`. mesh.rs:222-226 documents it: "When set, `theta_steps` and `profile_steps` are unused".
+
+**Do this.** Add `--refine <tol_mm>[/<deg>]` and `--refine-preset <name>` reading RefineParams::PRESETS (already consumed by the graph's sink.refine node at nodes/sink.rs:399), plus `--sweep` to clear a design's stored refine. Make --steps a hard error, not a no-op, when the effective params still carry refine, and name --sweep in the message. Add the refine stats to the manifest CSV — worst error and RefineStats::saturated_leaves especially, since CLAUDE.md records that a depth-limited tree otherwise reports a worst error of 0.0, which in a regression diff reads as a perfect build.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `--refine <tol_mm>[/<deg>]` and `--refine-preset <name>` reading `RefineParams::PRESETS` (already used by the graph's build node), plus `--sweep` to clear a design's stored refine. Make `--steps` error rather than no-op when the effective params carry `refine`, naming the flag that would clear it. Print the refine stats (`RefineStats::saturated_leaves`, worst error) into the manifest CSV, since a depth-limited tree silently reports a worst error of 0.0.
+
+</details>
+
+**Castability.** Indirect but real: a swept build where a refined one was asked for smooths fine relief away, and CLAUDE.md warns "the castability report will look better than the real casting". The field verdict is resolution-independent, but the exported STL is not.
+
+**Verified.** Confirmed exactly as described, and it is the sharpest small bug in this set. crates/ringdesign-core/src/mesh.rs:293-296: `if let Some(rp) = params.refine { return build_refined(design, lib, params, rp, started); }` sits before `let n_theta = params.theta_steps.clamp(24, 4096)`, and mesh.rs:222-226 documents "When set, `theta_steps` and `profile_steps` are unused". The CLI's --steps arm (main.rs:146-153) writes both fields into `params` cloned from `base.build`, which carries the design's saved `refine`, and nothing warns. There is no --refine, --refine-preset or --sweep anywhere in the option match or in USAGE. So the export tool cannot request the refined build CLAUDE.md calls the export build, and cannot tell that the resolution it asked for was discarded. Worth noting the second-order harm: the manifest CSV records a triangle count the caller did not request, which corrupts exactly the export-regression diff the manifest exists to be.
+
+#### F197 OBJ and PLY writers skip the non-finite guard the other writers have — `medium` / `S` / interop
+
+**Problem.** `to_stl_binary`, `to_glb` and `to_3mf` all filter faces touching a missing or non-finite vertex — `whole_faces` and the `ok` closures — with a comment saying why. `write_obj` and `write_ply` iterate `mesh.vertices` and `mesh.faces` raw. A single NaN from a degenerate parameter therefore writes `v NaN NaN NaN` into an OBJ (Rhino and MeshLab either reject the file or import garbage) and a NaN float into a PLY, where the two formats that scan and measurement tools read are exactly the two with no guard. Neither states units either, while STL puts `UNITS=mm` in its 80-byte header and 3MF says `unit="millimeter"`.
+
+**Evidence.** crates/ringdesign-core/src/stl.rs:22-27 `whole_faces` used by `to_stl_binary` and `to_stl_ascii`; stl.rs:78-100 `write_obj` — `for v in &mesh.vertices` and `for f in &mesh.faces`, no filter; stl.rs:101-139 `write_ply` — same. Compare gltf.rs:24-26 (`let ok = |i: u32| ... is_finite()`) and threemf.rs:118-120.
+
+**Do this.** Hoist one `finite_faces(mesh) -> (Vec<Vec3>, Vec<[u32;3]>)` helper in stl.rs testing both index range and is_finite, and route OBJ, PLY, STL (binary and ASCII), GLB and 3MF through it — the guard is missing from three writers, not two, and five call sites is exactly the drift that produced this. Add `# RingDesigner <version>; <name>; UNITS=mm` as the first OBJ line and the same text on the PLY comment line (which today carries only the name). Add a test that builds a mesh, pokes a NaN into one vertex, and asserts every writer's output parses — the existing round-trip tests only ever see meshes this crate produced, which is why the hole was invisible.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Hoist one `finite_faces(mesh) -> (Vec<Vec3>, Vec<[u32;3]>)` helper in stl.rs and route OBJ, PLY, STL, GLB and 3MF through it so the five writers cannot drift again. Add `# RingDesigner <version>; <name>; UNITS=mm` as the first OBJ line and the same as the PLY `comment` (PLY already has a comment line carrying only the name).
+
+</details>
+
+**Castability.** n/a — a writer fix. Note the guard drops faces rather than repairing them, so a build that trips it was already not watertight and `Mesh::validate()` should be the thing that shouts.
+
+**Verified.** The gap is real but the evidence misreads one file, and the correction makes the fix bigger, not smaller. stl.rs:22-27 `whole_faces` filters ONLY on index range — `f.iter().all(|&i| (i as usize) < mesh.vertices.len())` — it does not test is_finite at all. So binary and ASCII STL are equally unguarded against a NaN coordinate; they will happily write NaN into a facet's 50-byte record. Only gltf.rs:22 and threemf.rs:122-123 carry the `is_finite()` ok-closure (and both also substitute [0,0,0] for a non-finite vertex in the position stream). write_obj (stl.rs:79-100) and write_ply (stl.rs:104-139) iterate mesh.vertices and mesh.faces raw with no filter of either kind. The units observation is correct: binary STL's 80-byte header carries "RingDesigner {version}; {name}; UNITS=mm" (stl.rs:9-19) and 3MF says unit="millimeter"; OBJ writes only `o {name}` and PLY only `comment {name}`.
+
+#### F203 Profile and outline library files carry no version and vanish silently — `medium` / `S` / interop
+
+**Problem.** Designs have a `format_version`, a migration ladder and a test that every version has a step. The other two user libraries have none: `.profile.json` and `.outline.json` are bare serde dumps, and both listers `continue` past any file they cannot read — no message, no count, no path. A shop's curated section library or its imported signet plans can quietly shrink across an upgrade or a hand-edit, and the picker will simply show fewer entries with no explanation. There is also no way to move the library between machines: designs embed their alphas and copy their outlines, but the profile/outline/alpha/gem directories are hand-copied.
+
+**Evidence.** crates/ringdesign-core/src/library.rs:36-48 — `FORMAT_VERSION`, `MIGRATIONS`, `VersionedDesign`, applying only to designs. library.rs `list_profiles_in` — `let Ok(text) = ... else { continue }; let Ok(profile) = serde_json::from_str::<BandProfile>(&text) else { continue };`. `list_outlines_in` — same shape plus a silent `o.r.len() == 720` check. `save_profile_in` / `save_outline_in` write `serde_json::to_string(_pretty)` with no version key. Directories: `profile_dir()`, `outline_dir()`, `user_alpha_dir()`, `gem_mesh_dir()`.
+
+**Do this.** Stamp the same format_version key on .profile.json and .outline.json through a VersionedDesign-style wrapper with its own (initially empty) ladder — and remember library.rs:312's `assert_eq!(MIGRATIONS.len(), FORMAT_VERSION as usize)` is the pattern to copy, so each new ladder gets the same test. Read a bare, unversioned file as version 0 so every existing user file still loads. Change both listers to return `(Vec<T>, Vec<(PathBuf, String)>)` so the profile panel and the Face combo can say "3 profiles skipped" and name them — the outline lister's silent 720-entry check is the one most likely to eat a hand-edited or hand-written plan, which is exactly what finding 2's import path will start producing. Then a "Library bundle" export/import: one deterministic zip through threemf::zip_store carrying profiles, outlines, user alphas, gem meshes and prices.json, so a bench, a laptop and the shop machine can be made identical in one file.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Stamp the same `format_version` key on `.profile.json` and `.outline.json` through the same `VersionedDesign`-style wrapper and give each its own (initially empty) ladder — the machinery and its test are already written. Change both listers to return `(Vec<T>, Vec<(PathBuf, String)>)` so the GUI picker can say "3 profiles skipped" and name them. Then add a "Library bundle" export/import: one deterministic zip via `threemf::zip_store` carrying profiles, outlines, user alphas, gem meshes and `prices.json`, so a bench, a laptop and the shop machine can be made identical in one file.
+
+</details>
+
+**Castability.** n/a — a saved profile is a shape and never a size (`apply_shape`), which stays true; the version key only protects that guarantee across upgrades.
+
+**Verified.** Confirmed line by line. library.rs:38-43 scopes FORMAT_VERSION/MIGRATIONS/VersionedDesign to designs only. save_profile_in (library.rs:216-233) writes `serde_json::to_string_pretty(profile)` and save_outline_in (library.rs:193-207) writes `serde_json::to_string(outline)` — both bare, no version key. list_profiles_in (library.rs:243-259) does `let Ok(text) = ... else { continue }; let Ok(profile) = serde_json::from_str::<BandProfile>(&text) else { continue };` and list_outlines_in (library.rs:171-190) does the same plus a silent `o.r.len() == 720 && all finite && > 0.0` filter — three silent drops, no message, no count, no path. The comment at library.rs:236 even says "Unreadable files are skipped — one bad import must not hide the rest of the library", which is the right instinct and the wrong outcome when it is silent. And there is no bundle: designs embed alphas and copy outlines, but profile_dir, outline_dir, user_alpha_dir and gem_mesh_dir are hand-copied between machines.
+
+#### F223 The kiosk will save an order the graph sinks would refuse — `medium` / `S` / product-business
+
+**Problem.** `save_order` calls `order_files` and writes the folder regardless of the verdict; the review step colours a NotCastable ring red and says "the jeweler will follow up" but the Save button is unguarded. The rest of the system takes the opposite position — graph file sinks refuse to write an unjudged or NotCastable ring at all. Two policies for the same question, and the lax one is on the path a customer touches.
+
+**Evidence.** crates/ringdesign-configurator/src/main.rs:441-450 `save_order` — no verdict check; main.rs:812-833 renders the verdict then the Save button unconditionally. crates/ringdesign-graph/src/nodes/sink.rs:67 `if field.verdict == Verdict::NotCastable` refuses, and the test at sink.rs:659 asserts an unjudged export errors with "judged first".
+
+**Do this.** Unchanged, and it becomes load-bearing rather than theoretical the moment either finding 7 (data-driven catalogue) or finding 12 (a process choice) lands, since both widen the space that test sweeps. Note the order the code suggests: `save_order` already has `self.field` in hand from the last frame, so the guard is a match on `Verdict` before the `order_files` call — but the enquiry path should still capture the config and contact, so route it to the same writer with the pattern-bearing files (design.ring.json, ring.glb) omitted rather than skipping the write entirely.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Make the configurator adopt the sink's rule: on NotCastable, replace Save with an "Ask the jeweller about this one" action that still captures the config and contact but files it as an enquiry rather than an order, and never emits a pattern STL. The `every_offered_combination_is_castable` test means this should be unreachable through the offered options — which is exactly why the guard belongs there, as the assertion that keeps it unreachable when the catalogue becomes data-driven.
+
+</details>
+
+**Castability.** Directly: it is the one place a NotCastable design can become a work order. The refusal is the same one `sink.export` already makes.
+
+**Verified.** Confirmed, and the inconsistency is exactly as described. `save_order` (main.rs:441-450) calls `order_files` then `deliver_order` with no verdict test anywhere in the function; `step_review` (main.rs:812-838) renders the verdict, then unconditionally adds the "Save my ring" button — the NotCastable arm's own text ("Needs adjustment — the jeweler will follow up") sits directly above a button that writes the pattern STL and GLB anyway. The opposite policy is in graph/src/nodes/sink.rs:67 (`if field.verdict == Verdict::NotCastable` → refuse), with sink.rs:659 asserting an unjudged export errors with "judged first". `every_offered_combination_is_castable` (compose.rs:379) is what currently keeps this unreachable, and it sweeps only the sand process.
+
+**Merged into a canonical finding above:** F30 (Two disagreeing wall floors, both hard constants, neither moving with the process) -> F17, F114 (Switching Lost wax back to Sand leaves investment floors in place) -> F21, F166 (Make one verdict speak everywhere — the status chip and the Draft view still read the mesh) -> F123.
+
+### M11 — The band has a thickness across it, too (L, 20 findings)
+
+**Done when:** An axial web is reported per slice beside thinnest_wall_mm; two opposing 0.9 mm side-face carves on a 2.0 mm band report 0.2 mm and fail.
+
+#### F3 No section-modulus ratio: a heavy head on a thin shank is never flagged — `high` / `M` / sand-process
+
+**Problem.** `min_section_mm` is a single floor and `thinnest_wall_mm` a single number. Neither says anything about the *progression* from thin to thick, which is what decides whether a casting feeds. A 12 mm lofted signet head on a 1.9 mm shank has a section modulus several times the shank's; the shank freezes first, isolates the head, and the head draws porosity at the junction — and if the mould restrains the contraction, that same junction hot-tears. The modulus curve that would show this is computed 64 times per build and thrown away except for its maximum.
+
+**Evidence.** castability.rs:631 `modulus_scan` returns the whole curve; app.rs:990 keeps only `.max_by()`. `FieldReport` (castability.rs:977) carries `thinnest_wall_mm` / `thinnest_wall_theta_deg` and no ratio, no gradient, no junction. CLAUDE.md's signet section documents tapers "down to a 1.9 mm shank on a 12 mm head" as a *pull* result (0.000% undercut) with no thermal comment. `dfm.rs` checks feature sizes only; it has no section-thickness check at all.
+
+**Do this.** Unchanged. One addition: keep it out of the *verdict* and in the notes. `analyze_field` already promotes to Marginal on thin wall (castability.rs:1186), and a head-to-shank modulus ratio over 1.5 is normal for every signet the app ships — gating on it would fail nine of the templates. Make it a note plus a DFM-style finding, and have the note name `hollow_mm` by its GUI label ("Hollow") so the fix is one control away.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Extend the modulus scan into `castability::thermal_scan` returning `{ modulus: Vec<(theta, m)>, max, min, ratio, steepest_gradient_theta_deg }`, and add two notes to `analyze_field`: one when `max/min > ~1.5` ("the head at 90° freezes ~2.3× slower than the shank at 270°; gate into the head or riser it, and do not gate the shank"), one naming the steepest modulus gradient as the hot-tear/shrink junction ("section steps fastest at 118° — fillet the head-to-shoulder blend or expect a tear there"). It should also read `SignetHead::hollow_mm`, which lowers head modulus and is exactly the right fix — so the note can suggest it.
+
+</details>
+
+**Castability.** n/a — the pull verdict is unchanged; this is a fill/feed verdict alongside it.
+
+**Verified.** Verified. The modulus curve is computed and discarded: gui/app.rs:990 keeps `.max_by()`. `FieldReport` (castability.rs:977) carries `thinnest_wall_mm` / `thinnest_wall_theta_deg` and no ratio, gradient or junction. `analyze_field`'s note block (castability.rs:1155-1195) emits exactly three note families — lost-wax pull stats, undercut/noise, thinnest wall — nothing thermal. `dfm.rs` is entirely a feature-size module (its own doc, dfm.rs:1-7) with no section check. Confirmed the enabling data is there: `modulus_scan` reads `section_at`, which goes through `modulation_at`, so a signet's head and its shank genuinely appear as different moduli in the same curve, and `SignetHead::hollow_mm` really does move it.
+
+#### F10 DFM measures how wide a feature is and never how deep — so "polish will eat this" cannot be said — `high` / `M` / sand-process *(also found as F116)*
+
+**Problem.** Every DFM check in the app is a plan measure. `FeatureFootprint` carries `feature_u_mm` and `feature_v_mm` and no depth at all, so a 0.06 mm-deep engraving with a 0.9 mm-wide stroke passes every check the app has — it is comfortably above the detail floor in plan and will be sanded flat on the first pass. The as-cast preview softens the height field with a Gaussian at the detail radius, but it is display-only and produces no number, no finding and no sheet line.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:687-724 — `FeatureFootprint { feature_u_mm, feature_v_mm, u_mm, v_mm }`; `min_feature_mm` and `metal_feature_mm` both reduce over the two plan axes only. dfm.rs:130-137 folds `metal_feature_mm` and compares to `min_detail_mm`; nothing anywhere reads `height_mm` / `depth_mm` / `relief_mm` for a DFM verdict. mesh.rs:229-232 `soften_mm` is documented "Display only; exports and the section view stay at true geometry", set from `min_detail_mm` at crates/ringdesign-gui/src/app.rs:530.
+
+**Do this.** Add `relief_mm: f64` to `FeatureFootprint` (every layer already knows its own displacement: `TilingLayer::height_mm`, `MilgrainLayer` bead height, `BorderLayer`, `CurveLayer`, `Decal::height_mm`, `OpenworkLayer::depth_mm`) and add two checks to `dfm.rs`: relief below the finishing stock ("0.06 mm of relief against 0.15 mm of finishing stock — this sands off; raise it to 0.25 mm or drop the layer") and aspect ratio, both directions (a raised feature narrower than it is tall is a fin that will not fill; a carved feature deeper than it is wide leaves a sand rib that crumbles on ram-up — see the venting/sand-fragility finding). Fold `soften_mm` into a measured statement too: report the peak relief lost to softening as a percentage so "as-cast" is a number, not just a picture.
+
+**Castability.** n/a — reporting only. Note the raise-the-relief advice must be checked against the pull, which `analyze_field` already does.
+
+#### F11 Nothing tells a user their relief walls are vertical, and the fix is wired to one layer type — `medium` / `M` / sand-process
+
+**Problem.** Side-face doctrine guarantees relief there cannot undercut, which is true and is not the same as saying it releases cleanly. A 1.6 mm-deep letter with dead-vertical walls in fine Delft clay drags sand out with the pattern and reads scuffed. The tool for it exists — `Alpha::draft_limited` bakes a cone opening so no wall exceeds a chosen angle — but nothing produces a finding telling you to use it, and the GUI wires it to `Layer::Tiling` and nothing else.
+
+**Evidence.** crates/ringdesign-core/src/alpha.rs:375 `pub fn draft_limited(&self, max_wall_deg, mm_per_px, relief_mm) -> Alpha`. Its only non-test caller is crates/ringdesign-gui/src/panels/layers.rs:708-716, whose match is `Layer::Tiling(t) => ..., _ => None` — so decals, text, SVG art, openwork masks, curve wires, flutes and seat pads have no drafting path. `dfm.rs` never mentions wall angle. `analyze_field` counts these walls into `vertical_area_mm2` but, per the drag finding above, says nothing about them.
+
+**Do this.** Split the two halves and do the finding first — a check that names the problem is worth more than a bake button nobody knows to press. Compute the steepest wall per relief layer from its own parameters (a tiling's `edge_mm` ramp over `height_mm`, a pad's `blend_mm`, a stamp's measured alpha gradient) and flag above ~80 deg with the sand's own `min_draft_deg` in the message. Then generalize the `bake_draft` arm at layers.rs:708 past `Layer::Tiling`, and expose `draft_limited` as an MCP tool and a graph node — note that the graph already has `alpha.*` nodes to hang it beside, so it is a node spec rather than new plumbing.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a DFM check that computes each relief layer's steepest wall from its own parameters (edge_mm ramp over height_mm for a tiling, blend_mm over height_mm for a pad, the alpha's measured gradient for a stamp) and flags anything above ~80° with the sand's own draft in the message. Then generalize the GUI's `bake_draft` arm to every alpha-backed layer — `Layer::Decals`, `Layer::Openwork`, and the text/SVG sources — and expose `draft_limited` as an MCP tool and a graph node so the fix is reachable from every frontend, not just one panel row.
+
+</details>
+
+**Castability.** Opening the walls strictly increases draft; it cannot create an undercut. It slightly narrows features at the top, so it must run before, not after, the detail-floor check.
+
+**Verified.** The tool exists and the reach is exactly as narrow as claimed. `Alpha::draft_limited` (alpha.rs:375) is real; its only non-test caller in the whole workspace is gui/panels/layers.rs:708-716, whose match is `Layer::Tiling(t) => ..., _ => None`, so decals, openwork masks, text and SVG sources have no drafting path, and it appears in no MCP tool and no graph node. The finding half is a clean gap: `dfm.rs` never computes or mentions a wall angle, and `analyze_field` counts these walls into `vertical_area_mm2` but (per finding 5) emits no field note about them. Craft check: the doctrine is right that side-face relief cannot undercut, and the finding is right that this is not the same as releasing cleanly — a deep dead-vertical letter in fine clay-bonded sand drags.
+
+#### F66 The seat report reads the bare band, so a seat over a carve over-credits its metal — `high` / `M` / stone-setting
+
+**Problem.** `stones::base_at` samples `design.profile.sample_mod(...)` — the modulated bare profile, with no layers evaluated. Every number in `check_seat` is therefore measured against a band that may not be there: a seat placed over an `Openwork` carve or any `Subtract` layer is credited the full uncarved thickness for its pavilion and the full uncarved section for its edge clearance, which is the unsafe direction. The reverse also happens and is merely annoying: the halo's centre seat stands on a 0.6 mm plate the check cannot see, so it under-credits and can warn spuriously about a culet that has plenty of room. The shelf already names the missing piece, `stones::probe_seat`.
+
+**Evidence.** crates/ringdesign-core/src/stones.rs:672-703 `base_at` — profile only, `LayerStack` never consulted; :562-584 — `through`, `along` and `surface_len` all come from that bare sample; crates/ringdesign-core/src/pave.rs:498-506 — the halo pushes Plate then Centre, so the centre genuinely stands on 0.6 mm the check ignores; docs/ROADMAP.md:191 "Shelf: ... `stones::probe_seat`".
+
+**Do this.** Promote the shelf item at docs/ROADMAP.md:191. `probe_seat(design, lib, theta, v) -> SeatProbe` evaluates the composed field with the seat's own entry muted (reuse the muting from `castability::attribute_undercuts`) and returns the true local surface, the true radial metal to the bore and the true arc to each band edge; feed `check_seat`'s `through`, `along` and `clearance` from it. `stones::report` must gain a `&AlphaLibrary` argument — check every caller when scoping: the GUI report panel, the MCP `castability` tool, `spec.rs`, `stonemap.rs` and the CLI all call it, and all already hold a library. Prioritise the Openwork/Subtract direction (unsafe) over the halo direction (merely a spurious warning).
+
+<details><summary>The auditor's original recommendation</summary>
+
+Promote the shelf item. `probe_seat(design, lib, theta, v) -> SeatProbe` evaluates the composed height field under the seat with the seat's own layer muted (the muting machinery already exists in `castability::attribute_undercuts`), and returns the true local surface, the true radial metal to the bore and the true arc to each band edge. Feed `check_seat`'s `through`, `along` and `clearance` from it. It needs the library, so `stones::report` gains a `&AlphaLibrary` argument — every caller already has one.
+
+</details>
+
+**Castability.** None to the sweep; it makes an existing check truthful in both directions. It costs the report a field evaluation per seat, which is why `report` stays analytic per station rather than per texel.
+
+**Verified.** Verified. `base_at` (stones.rs:672-703) calls `design.modulation_at` then `design.profile.sample_mod(inner_r, 192, &m)` and scans `l.pts` — the `LayerStack` is never consulted and the function does not take a library. `check_seat` (stones.rs:562-584) derives `worst_draft`, `clearance` (from `b.along`, `b.surface_len`) and `depth` (from `b.width`, `b.r`) entirely from that bare sample, so every seat number is measured against a band the layers may have carved or built up. The halo case is real: `halo` pushes "Plate" (`height_mm: 0.6`) then "Centre" (pave.rs:498-506), so the centre seat genuinely stands 0.6 mm higher than `base_at` believes. The muting machinery the fix needs does exist — `castability::attribute_undercuts` already mutes layers one at a time at a fixed parting plane. Note this is on docs/ROADMAP.md:191's Shelf list by name (`stones::probe_seat`), so it is a promotion, not a new item.
+
+#### F72 A bezel's collar wall and a pad's prong post are never checked against the sand's detail floor — `medium` / `S` / stone-setting
+
+**Problem.** `dfm::findings` judges each layer by `feature_footprints`, and `Layer::SeatPad` reports one footprint whose feature size is `blend_mm` — the skirt, and only the skirt. The bezel's collar wall (`bezel_wall_mm`, default 0.5, freely editable down to 0.2 by the clamp in `height`) and the pad's prong post diameter are finer features on the same layer and neither is measured. A 0.3 mm collar wall standing 0.8 mm tall will not fill in Delft clay's 0.8 mm floor, and nothing says so — while the identical post on a seat run is checked explicitly in stones.rs. The bearing ledge (`bezel_bearing_mm`, 0.3) is finer still.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1592-1606 — the SeatPad footprint's feature is `l.blend_mm.clamp(0.15, ...)`; :1348 `let wall = self.bezel_wall_mm.clamp(0.2, r);`; :1080-1082 `default_bezel_wall() = 0.5`; crates/ringdesign-core/src/stones.rs:262-268 — the run's post diameter is checked against `min_detail_mm`, the pad's identical bump is not.
+
+**Do this.** Extend the `Layer::SeatPad` arm at field.rs:592 to return additional footprints: `bezel_wall_mm` and `bezel_bearing_mm` when `style == SeatStyle::Bezel`, and the prong diameter when `prongs > 0` — factoring that radius out of field.rs:1397 into a `SeatPadLayer::prong_r_mm()` shared with finding 4's check, so the two land as one change. Keep the early return for a zero-height marker pad (field.rs:595-597) ahead of them or the halo's melee starts reporting findings. `dfm::findings` then names them with no further edit; give the collar its own message text distinguishing "thicken the wall" from "move to a bench-made bezel".
+
+<details><summary>The auditor's original recommendation</summary>
+
+Return additional footprints from `Layer::SeatPad::feature_footprints`: `bezel_wall_mm` and `bezel_bearing_mm` when the style is Bezel, and the prong radius `(0.28*rb).clamp(0.35,0.8)*2` when `prongs > 0`. `dfm::findings` then names them with no further change, since it already takes the minimum over a layer's footprints. Give the wall its own message text ("the collar wall measures 0.30 mm against the sand's 0.80 mm floor — thicken the wall or move to a bench-made bezel").
+
+</details>
+
+**Castability.** None — footprints also seed refinement, so naming a finer feature makes the refined build a little denser under a bezel, which is correct.
+
+**Verified.** Verified. `Layer::SeatPad`'s arm in `feature_footprints` (field.rs:592-606) returns exactly one `FeatureFootprint::round` whose feature size is `l.blend_mm.clamp(0.15, l.diameter_mm.max(0.15))` — the skirt and nothing else. `bezel_wall_mm` defaults to 0.5 (field.rs:1080) and is clamped only at `self.bezel_wall_mm.clamp(0.2, r)` when the height is evaluated (field.rs:1348), so a 0.2 mm collar wall is reachable and unmeasured; `bezel_bearing_mm` defaults to 0.3 (field.rs:1096) and is finer still. Neither appears in the footprint. The prong bump is real geometry at amplitude `height_mm + prong_mm` (field.rs:1409-1412) and is likewise absent — while the identical post on a run is checked explicitly at stones.rs:262-268 against `design.draft.min_detail_mm`. `dfm::findings` takes the minimum over a layer's footprints, so the fix is additive with no changes to the finding machinery. (I checked the uncommitted dfm.rs working-tree diff: it refactors the tiling granulometry path into `tiling_finest_mm` and adds a `fit_to_floor` solver — it does not touch seat footprints, so this is unaffected.)
+
+#### F115 Nothing measures the band's axial web — only radial outer-to-bore wall — `critical` / `L` / dfm-verdict *(also found as F4, F226, F47)*
+
+**Problem.** Both wall measures in the engine are radial. `thinnest_wall` walks bore points and interpolates the surface at the same *z*; `bore_span_wall` bins by *z* and subtracts bore radius from surface radius. Neither can see metal removed *across* the band. So two Openwork or Flutes layers carving opposing side faces, a deep painted stroke on both faces, a bezel pocket floor, or a hollowed head all thin the ring in a direction the fill check is blind to. Openwork's own cap is explicitly radial and *opens up* on a side face (`radial / nr` with nr≈0), so `depth_mm` is the only limit there — precisely the case where the remaining web is axial. A 1.8 mm band pierced 0.8 mm from each side leaves a 0.2 mm web and reports a healthy wall.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:875-905 (`thinnest_wall`: `wall.min(outer - b.r)`), castability.rs:930-975 (`bore_span_wall`, same radial subtraction with a 15% end inset). crates/ringdesign-core/src/field.rs:663-671 — OpenworkLayer's comment states the cap "eats D·nr of radial metal" and "on a side face nr is ~0 and the cap opens up". crates/ringdesign-core/src/mesh.rs displacement clamp `r = r.max((inner_r + min_wall).min(p.r))` is likewise radial-only.
+
+**Do this.** Unchanged in substance, with two corrections. (a) The precedent for an axial read already exists in `stones::check_seat` (stones.rs:580, `b.width` on a side face) — generalize that idea rather than inventing it. (b) The right place is `analyze_field`'s per-slice loop, which already builds the closed `Section` polygon: add `min_local_thickness_mm` + its (theta, v) to `FieldReport` as the minimum over surface-sample pairs of |p_i − p_j| whose connecting segment stays inside the loop, gate it on `min_section_mm` alongside `thinnest_wall_mm`, and give Openwork/Flutes a real cap on side faces where `depth_mm` is currently the only limit.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Replace the radial probe with a true local-thickness measure on the displaced section polygon: for every surface sample, the largest inscribed disc centred on the inward medial direction, or cheaply the minimum over all sample pairs of |p_i − p_j| where the segment stays inside the loop. Report `min_local_thickness_mm` and its (theta, v) on `FieldReport` alongside `thinnest_wall_mm`, gate it on `min_section_mm`, and drop the `INSET: 0.15` fudge in `bore_span_wall` — that constant exists only because the radial measure reads a legitimately tapered edge as a thin wall.
+
+</details>
+
+**Castability.** None — a thin web does not lock the mould, it fails to fill. This is the `min_section_mm` voice, said where it is currently silent.
+
+**Verified.** Both measures confirmed radial. `thinnest_wall` (castability.rs:897-922) interpolates the surface r at each bore point's z and takes `outer - b.r`. `bore_span_wall` (castability.rs:930-975) bins bore radius by z over the middle 70% (`INSET: 0.15`) and takes `p.r - bore_r[bin]`. `mesh.rs:356` clamps `r = r.max((inner_r + min_wall).min(p.r))` — radial again. `FieldReport` (castability.rs:970-1008) carries only `thinnest_wall_mm`/`_theta_deg`. OpenworkLayer::height (field.rs:665-670) caps depth at `radial / nr.clamp(0.05, 1.0)` with a comment that on a side face `nr` is ~0 and the cap opens up, leaving `depth_mm` unbounded — exactly the axial-web case. One partial exists that the auditor missed: `stones::check_seat` (stones.rs:580) reads `let through = if b.nz.abs() > b.nr.abs() { b.width } else { b.r - inner_r }`, so a side-face *seat's* pavilion depth is judged across the band. That is one consumer, not the verdict, and it does not see the opposing face's carve.
+
+#### F118 A 0.9 mm sterling shank passes as Castable — there is no strength check at all — `high` / `M` / dfm-verdict *(also found as F136)*
+
+**Problem.** The engine has exactly one section rule and it is a *fill* rule. Nothing anywhere asks whether the finished ring is stiff enough to wear. A 6 mm x 0.8 mm sterling band fills fine, fields 0.000%, and bends out of round in a month; a split or bypass shank whose arms each carry half the section is worse. The prompt's own case — "a 0.9 mm shank bends" — is currently reported as Castable with no note.
+
+**Evidence.** No occurrence of bend/stiffness/section-modulus in crates/ringdesign-core/src (grep returns only unrelated uses in adaptive.rs and tiling.rs). `SeatCheck` (stones.rs:33-57) checks pavilion depth, edge clearance and bridges but nothing structural. `FieldReport` (castability.rs:988-1008) carries `thinnest_wall_mm` and nothing else dimensional. `Metal` (metal.rs:6-14) carries density and shrink but no hardness or modulus.
+
+**Do this.** Unchanged, plus a free fix to bundle with it: rename the report panel's label at crates/ringdesign-gui/src/panels/report.rs:75 from "section modulus" to "casting modulus" the moment a real stiffness figure exists, or the panel will show two different things called modulus. For the check itself, `castability::modulus_scan` already walks every slice's section polygon (castability.rs:610-645) computing area and perimeter — add the second moment about the ring's bending axis in the same loop for free, reduce to an equivalent radial thickness over the palm arc, and emit an advisory `FieldReport` note against a per-alloy floor on `Metal`. Never gate: a wire ring is legitimate.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `castability::stiffness_scan`: per slice, the second moment of the section about the ring's own bending axis, `I ≈ ∫ t³ dw / 12` taken off the same `section_at_spaced` points the field verdict already builds, reduced to an equivalent radial thickness at the palm (the 180° region opposite the top). Add a per-alloy floor to `Metal` (sterling ~1.1 mm equivalent, 14k ~0.9, platinum ~0.8 — it work-hardens) and emit a `FieldReport` note: "palm section 0.86 mm equivalent in Silver 925 — this will go out of round in wear; thicken to 1.1 or widen the shank". Never gate the verdict on it; a wire ring is a legitimate design. Say it.
+
+</details>
+
+**Castability.** None — it is a wear check, reported and never gating.
+
+**Verified.** `grep -rni "stiffness|section modulus|second moment|out of round|bend out|springy|rigid"` across crates/ returns two hits, neither structural: pave.rs:886 ("% out of round" about a pavé lattice, not wear) and — importantly — gui/panels/report.rs:75, which prints the Chvorinov area/perimeter figure as **"section modulus {m:.2} mm"**. That label is wrong in the jeweller's and the engineer's vocabulary alike: section modulus is a bending property, casting modulus is V/A. So the one place in the app that says "section modulus" is talking about freezing time, which makes the absence worse, not better. `Metal` (metal.rs:6-14) carries only name, density, shrink_pct — no modulus, no hardness, no temper. `SeatCheck` (stones.rs:33-57) and `FieldReport` (castability.rs:970-1008) carry nothing structural.
+
+#### F120 An undercut is attributed to a layer but never solved — the fix is a one-dimensional bisection — `high` / `M` / dfm-verdict *(also found as F178)*
+
+**Problem.** `attribute_undercuts` does the expensive half of the job — it clusters the undercut, mutes each layer in turn, and names the culprit — then stops at "muting it clears it". Muting is not a fix; nobody wants the layer gone. The number the jeweller needs is the largest relief that still clears, and for every layer that carries a single depth parameter this is a monotone one-dimensional root find over eight or ten field passes. The precedent already exists in this repo: the in-flight `dfm::fit_to_floor` solves the detail floor in closed form and its test is named "the solver is the checker read backwards".
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:1361-1409 — `attribute_undercuts` builds `masked` by cloning the design with `d.layers.layers[i].enabled = false` and reports `culprit`; `UndercutRegion::note` (castability.rs:1247-1259) ends at "muting it clears it". crates/ringdesign-core/src/dfm.rs:409-431 — `fit_to_floor` returning `FloorFit::Repeats(n)` / `NeedsTallerCell { min_cell_h_mm }` is the shape to copy.
+
+**Do this.** Unchanged, with the cost accounting corrected: `attribute_undercuts` already builds one full field pass per enabled layer, so the honest budget for `fit_relief_to_pull` is ~8 additional passes for the one named culprit, not per layer. Return the same three-arm shape `fit_to_floor` uses — `Clears(mm)` / `NeverClears { move_to_side_face: bool }` / `Unsolvable` — so the two solvers read alike, and hang it off `UndercutRegion` so the note becomes "caused by 'Flat boss': clears at 0.28 mm relief (now 0.90)". Surface as a layer-row Apply button, an MCP field on `castability`, and a graph node.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `castability::fit_relief_to_pull(design, lib, settings, layer_idx) -> ReliefFit` — bisect the culprit layer's depth knob (`TilingLayer::height_mm`, `SeatPadLayer::height_mm`, `CurveLayer` height, `OpenworkLayer::depth_mm`) on undercut area at the design's own parting plane, 8 passes at 160x112, and return `Clears(mm)` or `NeverClears { move_to_side_face: bool }` when even a hair of relief locks (a wall on a near-vertical crown). Put it on the finding as "Flat boss: clears at 0.28 mm relief (now 0.90)" with an Apply button on the layer row, an MCP field, and a graph node.
+
+</details>
+
+**Castability.** None — it only searches; the verdict still judges whatever is applied.
+
+**Verified.** Read `attribute_undercuts` (castability.rs:~1300-1409): it clones the design per enabled layer with `d.layers.layers[i].enabled = false`, re-runs `field_undercuts`, and picks the layer whose muting leaves under 20% of the region's area. `UndercutRegion::note` (castability.rs:1247-1259) ends literally at `— caused by "{name}"; muting it clears it.` No search over any depth parameter exists. The precedent is stronger than the auditor said: `dfm::fit_to_floor` (dfm.rs:409-431) is *shipped*, not in flight — it returns `FloorFit::Repeats(n)` / `NeedsTallerCell { min_cell_h_mm }` / `Unmeasurable`, is called from examples/patternbands.rs:67, and its test is `fitting_to_the_floor_silences_the_finding` with the doc comment "The solver is the checker read backwards". The mute passes are already paid for, so the marginal cost is the bisection alone.
+
+#### F121 Undercut severity is an area fraction, so a sand-tearing gouge and a burnishing drag read alike — `high` / `M` / dfm-verdict
+
+**Problem.** The verdict compares `undercut_area / total_area` to a 1% threshold and reports one `worst_draft_deg`. Those two numbers cannot distinguish the two failure modes a moulder cares about. A 0.4 mm² patch at −70° will tear a lump of sand out of the cope and ruin the mould on the *first* draw; 20 mm² at −1° will drag, burnish, and release. The first reports 0.04% — under the 1% gate, so "Castable with care". The second reports 2% — "Will not release". Both verdicts are wrong. There is also no contiguous-patch measure: a hundred scattered single samples and one solid 12 mm² lump sum identically.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:21-23 (`NOT_CASTABLE_FRACTION: f64 = 0.01`, `DRAG_FRACTION = 0.12`), :1143-1152 (the verdict ladder reads `frac(undercut_area)` and `drag_frac` only), :988-1008 (`FieldReport` carries area sums and one worst angle). The noise exemption at :1140 requires *both* a small fraction and a shallow angle, which shows the authors already know one number is not enough — the same reasoning has not reached the verdict itself.
+
+**Do this.** Unchanged. Add the concrete detail that the sample tuple in `analyze_field` is already `(nz, z, area, bore)` and the loop already computes `draft` per sample — so `locked_mm3 += area * (-draft).to_radians().tan()` is one line in the existing loop with no new pass. `largest_patch_mm2` needs the (theta, s) grid indices, which `field_undercuts` (castability.rs:~1262+) already reconstructs; reuse it rather than adding a third sampler. Report which criterion fired in the note, so "NotCastable" always says why.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Carry a locked-depth integral on `FieldReport`: `locked_mm3 = Σ area · tan(−draft)` over undercut samples, which is roughly the sand volume that has to shear, plus `largest_patch_mm2` from a connected-components pass over the (theta, s) grid the sampler already builds. Gate NotCastable on any of {fraction > 1%, locked_mm3 over a small absolute floor, largest_patch deeper than ~15° over more than a mm²}, and say which one fired. Report the depth histogram alongside.
+
+</details>
+
+**Castability.** Tightens the verdict in the small-deep direction and could loosen it in the large-shallow direction; the loosening half must not ship without a measured table, the way the side-face and shoulder tables were built.
+
+**Verified.** Verified the constants (castability.rs:21-23: `NOT_CASTABLE_FRACTION = 0.01`, `DRAG_FRACTION = 0.12`) and the ladder in `analyze_field`: `if lost_wax { Castable } else if frac(undercut_area) > NOT_CASTABLE_FRACTION { NotCastable } else if (undercut_area > 0.0 && !noise) || drag_frac > DRAG_FRACTION { Marginal } else { Castable }`. The per-sample loop accumulates `undercut_area` and tracks `worst` as a single scalar — no depth-weighted integral, no per-patch accounting, no connected-components pass anywhere in the file. The auditor's supporting observation is right and telling: the noise exemption at the line above requires *both* `frac(undercut_area) < FIELD_NOISE_FRACTION` **and** `worst_draft_deg > -FIELD_NOISE_DEG`, so the two-number logic already exists for the phantom case and simply has not reached the verdict.
+
+#### F122 Undercut regions are clustered in theta only, and drag is never located at all — `medium` / `M` / dfm-verdict
+
+**Problem.** Two separate undercut patches at the same ring angle but different heights across the band — a stamp on the low flank and a wire on the high flank, or both edges of a symmetric mirrored tiling — merge into one region. Its `across` label is an area-weighted mean of the two v values, which for a symmetric pair lands on "crest", naming the one place on the band that is clean. Separately, the marginal and vertical areas — the drag that decides the verdict as often as undercut does — are summed globally and never located or blamed at all, so "12% of the surface drags" comes with no angle and no culprit.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:1372-1390 — `sorted.sort_by(|a, b| a.0.total_cmp(&b.0))` then split on a theta gap; the v coordinate is carried per sample (`s.1`) but used only for `v_mean` at :1424. The `across` bands at :1425-1432 map that single mean to one label. `analyze_field` accumulates `marginal_area` and `vertical_outer_area` (castability.rs:1126-1135) with no positional record.
+
+**Do this.** Unchanged. Two implementation notes from the code: cluster in (theta, v) with separate gap thresholds per axis, since the theta gap is derived from the sample count `T` while v is normalized 0..1 — do not reuse one epsilon. And `attribute_drag` costs nothing extra: the `masked` vector of per-layer muted passes is already built in `attribute_undercuts`; return `Marginal`-class samples from `field_undercuts` alongside the undercut ones behind a flag, and both attributions come out of one set of passes.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Cluster in (theta, v) — the samples already carry both — so a mirrored pair becomes two regions with honest labels. Then add `attribute_drag`, the same mute-one-layer pass keyed on `FaceClass::Marginal`, so a drag verdict names its arc and its layer the way an undercut does. The `masked` field passes are already computed; reuse them rather than paying twice.
+
+</details>
+
+**Castability.** None — reporting only.
+
+**Verified.** Verified line by line. `sorted.sort_by(|a, b| a.0.total_cmp(&b.0))` then split on `gap = (360.0 / T) * 2.5` — theta only. The v coordinate is carried in the sample tuple as `s.1` and used exactly once, for `v_mean = Σ(s.1 * s.2) / area`, which then picks one of five `across` labels ("low flank" … "high flank", with 0.45..0.55 mapping to "crest"). A symmetric mirrored pair therefore averages to ~0.5 and is labelled "crest" — the auditor's worst case is real and follows directly from the arithmetic. For drag: `analyze_field` accumulates `marginal_area` and `vertical_outer_area` as bare f64 sums with no positional record, and `grep` finds no `attribute_drag` or equivalent. Since `drag_frac > DRAG_FRACTION` can set Marginal on its own, this is a verdict that can fire with no location and no culprit at all.
+
+#### F126 Nothing measures a concave corner radius, though the doctrine repeatedly says one is needed — `medium` / `M` / dfm-verdict
+
+**Problem.** A sharp internal corner in the metal is a sharp external edge in the sand: it erodes under the pour, washes into the casting, and is a stress riser in the finished ring. The codebase knows this — CLAUDE.md says "Leave some `fade_deg`: a hard end raises a wall the mould has to clear" and the whole signet rebuild was about eliminating creases — but no check enforces it. A `SeatPadLayer` with `blend_mm = 0`, a window with `fade_deg = 0`, a tiling with `edge_mm = 0` at 0.5 mm relief, and a `Blend::Replace` boundary all raise a wall onto a knife-edge sand corner with nothing said.
+
+**Evidence.** grep for `fade_deg` in dfm.rs, stones.rs and castability.rs returns nothing — it is read only by `LayerStack::feature_footprints` (crates/ringdesign-core/src/field.rs:833-840) for refinement seeding, never for a finding. `SeatPadLayer`'s footprint clamps `blend_mm` to a 0.15 floor for the refiner (field.rs:603) rather than flagging it. `dfm::findings` (dfm.rs:122-160) branches on layer kind for a *label* only and reads nothing but the footprint minimum.
+
+**Do this.** Unchanged. Add that the cheap per-layer half is genuinely cheap — `dfm::findings` already has every layer in hand and already branches on kind, so flagging `SeatPadLayer::blend_mm`, `TilingLayer::edge_mm` and `Window::fade_deg` near zero at a relief that makes the resulting wall steep is a few match arms in an existing loop, no new pass. Do that first; the general second-derivative-along-s measure inside `analyze_field`'s existing sweep is the follow-on, and it pairs naturally with finding 2's local-thickness probe since both want the section polygon the sweep already builds.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a cheap per-layer concavity pass to `dfm::findings`: flag `SeatPadLayer::blend_mm`, `TilingLayer::edge_mm`, `BorderLayer` and `CurveLayer` edge treatments, and `Window::fade_deg` where the resulting wall is steeper than a chosen radius at the layer's own relief — "the boss meets the band at a square corner; break it 0.2 mm or the sand edge will wash". For the general case, sample the section's second derivative along `s` in the same sweep `analyze_field` already runs and report the tightest concave radius with its (theta, v).
+
+</details>
+
+**Castability.** None — it only asks for fillets, which never introduce undercut.
+
+**Verified.** Verified the negative precisely. `grep -rn "fade_deg" crates/ringdesign-core/src` returns four hits, all in field.rs and none a check: :431 and :445 are defaults/constructors, :458 is `Window::half_span`, and :835 is `LayerStack::feature_footprints` widening a refinement footprint by `span_deg * 0.5 + fade_deg`. Nothing in dfm.rs, stones.rs or castability.rs reads it. `blend_mm` appears in stones.rs exactly once (:575, `let foot = seat.half_extents_mm().1 + seat.blend_mm.max(0.0)`) — used to grow the seat's footprint for the edge-clearance check, never flagged when zero. `edge_mm` appears nowhere in dfm.rs or stones.rs. `dfm::findings` (dfm.rs:122-160) branches on layer kind only to pick a noun ("beads", "tile cells", "the wire"…) and reads nothing but the footprint minimum. Craft check passes twice over: a sharp internal corner in metal is a knife edge in sand that erodes under the pour, and it is a stress riser in a worn band.
+
+#### F130 Nothing checks wearability: proud settings, total stand-off, comfort fit on a wide band — `medium` / `S` / dfm-verdict
+
+**Problem.** A ring can be perfectly castable and unwearable. A prong standing 0.8 mm proud catches on knitwear and bends; a signet head standing 5 mm off the finger snags; a 7 mm flat band with no comfort dome is uncomfortable on a knuckle by bench convention. The engine computes every one of these numbers and gates on none of them. `shared_prongs` even reports the proud height into the sheet as a bare figure with no threshold.
+
+**Evidence.** crates/ringdesign-core/src/stones.rs:33-57 — `SeatCheck` carries `shared_prongs: Option<(u32, f64, f64)>` where the third is proud mm, printed verbatim by spec.rs:157-162 with no comparison. `check_seat` (stones.rs:541-640) warns on bezel-on-crown, flat-top rim draft, edge clearance and pavilion depth — nothing about height above the band. `BandProfile::comfort_fit_mm` defaults to 0.25 (profile.rs:516) and is never checked against `width_mm`. `Report.bounds_mm` and `max_relief_mm` exist and are printed but never judged.
+
+**Do this.** Unchanged in substance, advisory-only as the auditor says, with one craft exemption to build in: a signet or a statement cocktail ring is *meant* to stand proud, so gate the total-height note on shank kind (skip `Signet`, and skip any design whose head or centre stone is the declared subject) or it will cry wolf on the app's flagship family. The proud-prong note has the cleanest home — `SeatCheck::shared_prongs` already carries the figure at stones.rs:54 and spec.rs:157-162 already prints it; adding a threshold there is a few lines and immediately improves the sheet the setter holds.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a small wearability section to `stones::report` and `dfm::findings_in`: flag a stone or prong standing more than ~1.0 mm proud of the local crest ("catches on fabric — lower the seat or bead-set flush"), flag total ring height over ~4 mm off the finger for a daily band, and flag `width_mm > 6.0` with `comfort_fit_mm < 0.3` ("a band this wide is normally comfort-fit"). Advisory notes, never gating.
+
+</details>
+
+**Castability.** None — advisory only, and comfort fit actively *gains* bore draft per the doctrine.
+
+**Verified.** Verified by reading `check_seat` (stones.rs:540-640) end to end: it produces exactly four warning kinds — bezel-on-crown, flat-top rim on low base draft, `clearance < MIN_EDGE_MM`, and `gem.pavilion_mm() > depth`. Nothing about height above the band. `shared_prongs` is `Option<(u32, f64, f64)>` (stones.rs:54, "(pairs, post diameter mm, proud mm)") and spec.rs:157-162 prints "{proud:.2} mm proud" verbatim with no comparison to anything — confirmed, the number is reported and never judged. `grep "comfort_fit_mm"` finds no consumer in stones.rs or dfm.rs. `Report.bounds_mm` and `max_relief_mm` are printed by spec.rs:98-113 and never tested. Craft check: the snag hazard is real and is why bench convention bead-sets rather than prong-sets a band that gets daily wear; the comfort-fit convention on wide bands is real too.
+
+#### F140 A heavy head has no balance measurement — nothing predicts a signet spinning on the finger — `medium` / `M` / sizing-fit
+
+**Problem.** "It spins" is the top wear complaint about signet and cocktail rings, and the app cannot say anything about it. There is no centre of mass anywhere: `Mesh::volume_mm3` is a divergence-theorem sum over the faces, and the only `centroid` in core is a 2D polygon helper used by the smooth-table loft. `SignetHead::hollow_mm` exists and its own doc says it "Lightens a heavy head" — but nothing measures whether the scoop was enough, or how much it bought. The configurator will happily put a 14 mm signet head on the same default section as a 4 mm court band.
+
+**Evidence.** crates/ringdesign-core/src/mesh.rs:77-96 (`volume_mm3`, the exact loop a centroid needs); grep for `centroid` in core finds only profile.rs:2913-2914 (2D polygon) and castability.rs:237 (a face-centre height); crates/ringdesign-core/src/profile.rs:1347-1353 (`hollow_mm` doc); crates/ringdesign-configurator/src/compose.rs:249-256 (14 mm signet bases). The measured hollow figure in CLAUDE.md — "the hollow takes 11% out of a 12 mm clover signet" — is a *volume* number, with no statement of what it did to balance.
+
+**Do this.** Sharpened on which number to report. `Mesh::centroid_mm()` from the same face loop as `volume_mm3` (three more accumulators, no new traversal), but the figure a jeweller acts on is the centroid's RADIAL offset in the ring's own plane from the bore axis — the moment arm that turns the head to the palm — not the raw 3D distance. Put `balance_offset_mm` on `Report` (mesh.rs:405) and print it on the `spec.rs` sheet with the two remedies the app already owns, in the order a bench would try them: raise `SignetHead::hollow_mm` (profile.rs:1353, measured 11% off a 12 mm clover), then thicken the palm with a `ShankKind::Keyframes` station. Calibrate the threshold against BlankSignet.obj, which `examples/common/scan.rs` can already load and bore-fit — a real 14.7 mm signet that does NOT habitually spin is the correct zero point, so the number to publish is the ratio to it, not an absolute mm.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `Mesh::centroid_mm() -> [f64;3]` using the same face loop as `volume_mm3` (the divergence-theorem first moment is three more accumulators, no new traversal), put `balance_offset_mm` on `Report` as the centroid's distance from the bore axis, and print it on the sheet with the two remedies the app already owns: raise `SignetHead::hollow_mm`, or thicken the palm with a `Keyframes` station. Calibrate the "will spin" threshold against `/home/shadowbroker/jewelry-scan/RING/BlankSignet.obj`, which is a real 14.7 mm signet already used as a reference elsewhere in `profile.rs`.
+
+</details>
+
+**Castability.** None — a read of the built mesh. The remedies it points at are already field-proven: `hollow_mm` is castable because a bore surface's normal is radial at any radius, and a keyframed palm is a monotone width/thickness modulation.
+
+**Verified.** Verified. `Mesh::volume_mm3` (mesh.rs:77-96) is the signed tetrahedron sum over faces — exactly the traversal a first moment needs. Grepped `centroid|center_of_mass|centre_of_mass|balance` across all crates: `profile.rs:2914` is a 2D polygon area centroid used by the smooth-table loft, `castability.rs:237` is a face-centre height for draft, `graph.rs:472` is node layout, `refine.rs` hits are tree balancing. Nothing measures the solid's mass centre. `Report` (mesh.rs:405-419) carries volume, area, bounds, diameters, relief, metals, build_ms, quality — no balance term. `SignetHead::hollow_mm` doc at profile.rs:1347-1352 does say "Lightens a heavy head" with no measurement of the effect. `/home/shadowbroker/jewelry-scan/RING/BlankSignet.obj` exists (4.4 MB, verified by ls).
+
+#### F141 MIN_WALL_MM does double duty as the wear floor under a culet, and there is no open-back seat — `high` / `L` / sizing-fit
+
+**Problem.** Two coupled gaps, both about what the finger touches. First, `stones.rs` credits metal under a stone down to `MIN_WALL_MM` — a *mould* constant, per its own doc — so a stone is passed when 0.5 mm of as-cast silver stands between its culet and the bore. That thins further at polishing, telegraphs through as a bump, and is not what a bench leaves. Second, the app has no drilled-through seat at all: every real eternity band and most gypsy-set bands are cored clean through so the culet shows in the bore, which is how light reaches the stone and how a 1.8 mm band can carry a 2.5 mm one. Here the pavilion must fit inside `through − MIN_WALL_MM` or the seat is refused, and the only way to open the bore is `Layer::Openwork`, which is a mask-driven carve with no relationship to a seat.
+
+**Evidence.** crates/ringdesign-core/src/mesh.rs:19-20 (constant scoped to the mould); crates/ringdesign-core/src/stones.rs:15, 580-584 (`depth = depth.min(through - MIN_WALL_MM + stand_off(seat))`), 617-625 (the culet warning, against `MIN_WALL_MM`); crates/ringdesign-core/src/field.rs (`Layer::Openwork` is a tiling mask carved toward a floor, unconnected to `SeatPadLayer`/`SeatRunLayer`).
+
+**Do this.** Unchanged, and split the two halves into separate work — the first is a one-day fix, the second is a real feature. (1) `Metal::wear_floor_mm` alongside the new stiffness fields from finding 5 (as-cast silver ~0.8, 14k ~0.65, Pt ~0.5), and a SECOND warning in `stones.rs` seat_check distinct in wording from the existing culet line at stones.rs:619 — one is a casting refusal, the other a "this will telegraph and wear through" note. (2) `SeatPadLayer::open_back: bool` (serde-default false). When set, `depth` at stones.rs:583 is skipped entirely and the check becomes the RIM of metal left around the hole against `MIN_EDGE_MM`; the setter's sheet and `stonemap.rs` say "drill through, countersink from the bore side". Critically, flag it as a BENCH operation, not cast geometry — do not emit a hole in the height field, or the sand verdict and the watertight-by-construction guarantee both have to be reasoned about again. This is what actually unlocks 2.5 mm stones on a 1.8 mm eternity band, which the app currently refuses.
+
+<details><summary>The auditor's original recommendation</summary>
+
+(1) Introduce `metal::Metal::wear_floor_mm` (as-cast silver ~0.8, 14k ~0.65, platinum ~0.5) and warn separately in `stones::seat_check` when the pavilion clears fill but not wear — distinct wording, since one is a casting refusal and the other is a service-life note. (2) Add `SeatPadLayer::open_back: bool`. When set, the seat emits a cored hole under the stone, the report drops the depth check entirely and instead checks the *rim* of metal left around the hole against `MIN_EDGE_MM`, and the setter's sheet and stone map say "drill through, countersink from the bore side". Flag the hole as bench-drilled so the sand verdict stays honest.
+
+</details>
+
+**Castability.** The wear floor is purely additive reporting. The open back must be declared bench-drilled, not cast: as a *cast* feature its walls are radial and fall under the same bore doctrine that makes the comfort dome and `hollow_mm` safe (`castability.rs:424-428`), but reporting it as bench work keeps the two-part pull guarantee unambiguous and matches how `stones.rs` already treats every seat.
+
+**Verified.** Both halves verified. First: `stones.rs:583` is `depth = depth.min(through - MIN_WALL_MM + stand_off(seat))` and the warning at stones.rs:619-624 reads "culet needs {need:.2} mm; {depth:.2} mm before the {MIN_WALL_MM} mm wall" — a mould constant (mesh.rs:19-20, doc says "between a displaced surface and the bore") used as the service-life floor. Second: grepped `open_back|open back|drill through|cored|through hole` across all crates — the only two hits are prose in castability.rs:390 and :426 about the BORE being excluded from the undercut scan. `OpenworkLayer` (field.rs:640-675) confirms the auditor's read exactly: it carves toward `keep_mm` ("Metal left standing over the bore, mm", floored at 0.2) and the module doc at field.rs:637-638 says outright it reads "as piercing without ever piercing". Nothing connects it to `SeatPadLayer`/`SeatRunLayer`.
+
+**Merged into a canonical finding above:** F4 (The minimum section is measured radially only — nothing measures across the band) -> F115, F47 (Openwork can carve straight through the band and nothing measures it) -> F115, F116 (No sand-fin aspect ratio: depth over gap width is never computed) -> F10, F136 (There is no durability check — MIN_WALL_MM and min_section_mm are fill floors, not strength floors) -> F118, F178 (Undercut attribution names the culprit layer in prose and then does nothing with it) -> F120, F226 (Nothing measures the axial wall between two side-face carves) -> F115.
+
+### M12 — Draw the plan, notch the band (M, 19 findings)
+
+**Done when:** A head plan is drawn or imported without touching the graph; a ShankKey axial offset produces a notched band; "14 x 12 head on a 3 mm shank" is typed in mm and printed on the sheet.
+
+#### F40 Add an axial offset to ShankKey — it is the whole contoured/notched wedding-band category — `critical` / `M` / ring-typology
+
+**Problem.** A contoured (notched, chevron, "fitted") wedding band — the band whose top edge is cut away so it nests against a solitaire's head — cannot be expressed. It is the single largest bridal category after the engagement ring itself, and every solitaire sold wants one. Keyframes is the general band authoring tool and it can only scale width/thickness/crown symmetrically about the band's own mid-plane, so it can pinch the top but never notch one edge.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:1667 `pub struct ShankKey { theta_deg, width_scale, thickness_scale, crown_scale }` — four fields, no axial term. profile.rs:2415 `let read = |kk: &ShankKey| [kk.width_scale, kk.thickness_scale, kk.crown_scale];` and profile.rs:2484 builds `ShankMod { width_scale, thickness_scale, crown_scale, ..ShankMod::identity() }`, so `z_center_frac` is left at identity for every keyframed design. The machinery already exists one layer down: profile.rs:2287 `ShankMod::z_center_frac` is documented as "where this section sits along the finger axis", ShankKind::Wave sets it (profile.rs:2527 `z_center_frac: 0.6 * k * phase.sin()`), and `sample_spaced` already biases the crest span back to the parting plane for exactly that case.
+
+**Do this.** Add `z_offset_frac: f64` (default 0) to `ShankKey`, carry it as a fourth interpolated channel in the Catmull-Rom `read` closure in `ShankStyle::modulation`'s Keyframes arm, and write it to `ShankMod::z_center_frac` under the same 0.6-of-half-width cap Wave uses. Low edge = c − w/2, high = c + w/2, so `width_scale` plus `z_offset_frac` place the two band edges independently — a notch on one edge only, a V-point chevron, an asymmetric wishbone. Then ship two keyframe presets: "Contour (notch at the top)" and "Chevron".
+
+**Castability.** None new. It reuses Wave's exact mechanism, whose swing is capped at 0.6 of the half-width where measured undercut converges to phantom scale, and `sample_spaced` already widens the crest span to straddle the parting plane for offset sections. The keyframe cap must be the same 0.6.
+
+#### F45 Cathedral is a shoulder swell, not a cathedral — `high` / `M` / ring-typology
+
+**Problem.** `ShankKind::Cathedral` widens and thickens the shoulders and does nothing else. A cathedral ring reads from the side: the shoulders arch upward to meet the setting and there is a void beneath the head. What the model produces is closer to a reverse-tapered shoulder — a jeweller looking at the render would not call it a cathedral.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:2566 `ShankKind::Cathedral => { let s = (1.0 - d).powf(2.2); ShankMod { width_scale: 1.0 + 0.55*k*s, thickness_scale: 1.0 + 0.25*k*s, ..identity() } }` — two scalars, no crest rise of its own and no arch. Contrast the signet, which names an absolute crest radius through `ShankMod::outer_r` (profile.rs:2282) precisely because "a head's depth is set by where its table plane sits, not by a fraction of the band's own thickness". templates.rs's "Cathedral solitaire stock" and configurator `Base::Cathedral` both inherit the weak version.
+
+**Do this.** Unchanged, sharpened by where the idiom already lives. Give Cathedral its own crest ramp through `ShankMod::outer_r` — the field the signet uses precisely because "a head's depth is set by where its table plane sits, not by a fraction of the band's own thickness" — as `base_outer_r + rise_mm · shape(theta)` falling over a shoulder arc, and expose `rise_mm` / `shoulder_deg` on `ShankStyle` reusing the signet's `HEAD_RISE_MM` / `HEAD_SHOULDER_DEG` idiom rather than new names. Because the ramp only *raises* the crest and the profile stays a single-crest superellipse drop, the guarantee is the terrain argument the signet already makes, not a new one — but pin it with a field-verdict test at several rises the way `scratch_signet_head_undercuts` does. Then update `description()` at profile.rs:1284 to say plainly that the open gallery under the arch is a through-void and belongs to Free mode, since that is the half of a cathedral this construction will still not have.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give Cathedral its own crest ramp through `ShankMod::outer_r` — a stand-off in mm at the top falling over a `shoulder_deg` arc with a shape exponent, so the crest climbs to meet the seat, exactly the way `SignetHead` already raises a table. Expose rise and shoulder arc on `ShankStyle` (they can share the signet's `rise_mm`/`shoulder_deg` idiom). Say plainly in the kind's `description()` that the arch's *underside* — the open gallery a cathedral is named for — is a through-void and belongs to Free mode.
+
+</details>
+
+**Castability.** A band that rises toward the top while remaining single-valued in Z over (r, θ) is a terrain and releases by construction — the same argument the signet already makes and measures at 0.000%. The under-arch is what would lock, and it stays out.
+
+**Verified.** Confirmed verbatim. profile.rs:2566-2574: `ShankKind::Cathedral => { let s = (1.0 - d).powf(2.2); ShankMod { width_scale: 1.0 + 0.55*k*s, thickness_scale: 1.0 + 0.25*k*s, ..identity() } }` — two scalars, no `outer_r`, no shoulder arc, no shape exponent. Its `description()` at profile.rs:1284 is honest about it: "Shoulders swell toward the top of the ring." Contrast the signet, which names an absolute crest radius via `ShankMod::outer_r` (profile.rs:2282) and `FlatTop`, which uses `outer_max_r` (profile.rs:2551) — both idioms are already in the file and neither is reachable from Cathedral. `templates.rs:138` "Cathedral solitaire stock" and `compose::Base::Cathedral` (compose.rs:218-225, DShape 4.0×2.2, amount 0.8) both inherit it.
+
+#### F48 The side-face groove is locked inside ShankKind::Split — promote it to the profile and it becomes the whole grooved/stepped men's band family — `high` / `S` / ring-typology
+
+**Problem.** A concave (dished) men's band is genuinely impossible in a two-part ±Z pull — a dish is a valley between two rims and every rim leans back over the mould half beneath it, which is the same 8.2%/−22° the showcase measured on melon lobes. The castable read of that look is a groove in each side face, and the code already has one — but only Split can use it, and only at one hard-coded strength as part of a width flare.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:2317 `ShankMod::side_groove_mm` — "channel depth carved into each side face... the groove's floor faces along the pull and its walls stand radial, so it is castable wherever a side face is"; profile.rs:966 `let groove_cap = ((hw*0.35).min((thickness - comfort)*0.9)).max(0.0);`. It is set only by the Split arm of `ShankStyle::modulation` (profile.rs:2587) and is not reachable from `BandProfile` at all. `BandProfile` (profile.rs:427) has no groove field; `ProfileStyle` (profile.rs:38) is nine single-crest laws.
+
+**Do this.** Add `BandProfile::side_groove_mm` and `side_groove_v` (position inward from each edge), read in `sample_spaced` at the same clamp Split uses, and have `ShankKind::Split` set its own on top. Then add `ProfileStyle::Grooved` and `ProfileStyle::Stepped` presets. Say in `ProfileStyle::casting_note` that a truly concave outer surface is a two-rim valley no parting plane clears and belongs to lost wax or machining.
+
+**Castability.** None new: the groove floor faces along the pull and its walls stand radial. The existing Split cap (0.35 of the half-width, 0.9 of thickness less comfort) carries over unchanged.
+
+#### F49 Milgrain and borders are pinned to an absolute v — a beaded edge cannot follow the band's edge — `high` / `M` / ring-typology
+
+**Problem.** `MilgrainLayer::v_mm` and `BorderLayer::v_mm` are absolute millimetres in the reference chart. A milgrain-edged band is a bead row a fixed inset from the band's *edge*, and on any band whose section moves — Wave, Twist, Keyframes, a signet's shoulder — the edge moves while the bead row does not. The configurator already gates milgrain off on Wave and Twist for exactly this reason, which is a workaround standing in for a missing anchor.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1994 `pub struct MilgrainLayer { v_mm, bead_diameter_mm, beads_around, height_mm, mirror }`; field.rs:911 `BorderLayer { v_mm, ... }`. crates/ringdesign-configurator/src/compose.rs:88 `pub fn crest_is_stationary(self) -> bool { !matches!(self, Base::Wave | Base::Twist) }` with the comment "a fixed-v bead row lands on the dome flank and leans — measured 3% at 50° before this gate", and compose.rs:184 `if !self.base.crest_is_stationary() { self.milgrain = false; }`.
+
+**Do this.** Add a `VAnchor { Absolute(mm), Crest, BandEdge { inset_mm, pick: SideFacePick } }` to `MilgrainLayer` and `BorderLayer`, resolved per angle from the modulated section the way `VGate::SideFaces` is already resolved at evaluation time (field.rs:402). `Crest` and `BandEdge` then track Wave, Twist, Keyframes and a signet's shoulder, and the configurator's milgrain gate can be dropped.
+
+**Castability.** Improves it — the whole point of the anchor is to keep the bead row on the crest line or on a side face, the two places the doctrine measures clean, instead of letting it drift onto the dome flank where it was measured at 3%/50°.
+
+#### F51 Inlay channels are buildable by accident but are not a concept — no material, no fill volume, no retention check — `medium` / `M` / ring-typology
+
+**Problem.** A recessed groove meant to be filled later with wood, stone, enamel or opal is a large and fashionable category. The geometry is already reachable (a `Blend::Subtract` flat Border), but nothing knows it is an inlay: the sheet does not name the fill material, nobody computes the fill volume the inlay supplier needs, and nothing says whether the channel's walls are the straight-walled kind an adhesive inlay needs or the undercut lip a burnished metal or stone inlay needs — the latter being flatly impossible to cast in sand on the crest and a bench operation on a side face.
+
+**Evidence.** crates/ringdesign-core/src/pave.rs:307-319 `channel_set` builds the recess as `BorderLayer { profile: BorderProfile::Flat, ... }` with `channel.blend = Blend::Subtract;` — the exact shape an inlay channel is, but labelled "Channel" and sized from a `Gem`. `Blend::Subtract` exists (field.rs:278). No `Inlay` type, no fill material and no fill-volume computation anywhere; `spec.rs` prints metal weights only.
+
+**Do this.** Add an `InlayLayer` (or an `inlay: Option<InlayMaterial>` on `BorderLayer`) carrying material name and density, computing fill volume by integrating the carved depth over the channel footprint the way `Mesh::volume_mm3` integrates the solid, printed on the casting sheet next to the metal weights. Have `dfm.rs` warn when the channel's walls are asked to undercut, and state in the layer's doc that a retaining lip is burnished at the bench, never cast.
+
+**Castability.** A straight-walled recess on a side face is castable by side-face doctrine; on the crest its walls turn to ceilings, the same hazard the bezel already warns about, so the finding is partly about saying so.
+
+#### F55 Keyframed shank shapes are not a library asset, so no authored band shape is shareable — `medium` / `S` / ring-typology *(also found as F237)*
+
+**Problem.** `ShankKind::Keyframes` "hands the band over outright" and is the model's most expressive tool, but there is no way to save or share a keyframed shape. Every interesting one in the repo — the cloud band, the sketch bands — is hardcoded in an example. Cross-sections are saveable assets; the shape *around* the ring is not.
+
+**Evidence.** crates/ringdesign-core/src/library.rs:211 `save_profile` / 238 `list_profiles` round-trip `crate::BandProfile` only, into `profile_dir()`; library.rs:161 `outline_dir()` does the same for `CustomOutline`. Nothing saves `ShankStyle`. `ShankKey` is constructed only in crates/ringdesign-gui/src/panels/design.rs:831 (one blank station at a time) and in examples: gallery.rs:451, showcase.rs:432, patternbands.rs:208, sketches.rs:166/263/305. There is no keyframe preset anywhere in core.
+
+**Do this.** Extend the library with `<name>.shank.json` carrying `ShankStyle` (kind, amount, waves, keys — not the head, which belongs to the signet), with the same save/list/apply trio and the same "a shape, never a size" rule `apply_shape` establishes for profiles. Seed it with the shapes the examples already prove: wishbone, chevron, cloud, cigar swell, and (once `ShankKey` gains the axial term) contour.
+
+**Castability.** None: applying a saved `ShankStyle` runs the same modulation with the same clamps. The `mix(...)` clamps in the Keyframes arm (0.3–3.0 on width and thickness) bound anything an imported file can ask for.
+
+#### F57 Figural heads — Claddagh, class rings, crests — have the pieces but no path and no example — `medium` / `S` / ring-typology
+
+**Problem.** A Claddagh, a class ring and a family-crest ring are three of the most-asked-for named rings, and a jeweller opening the app has no idea whether it can make them. The pieces exist — `CustomOutline` from any closed polyline, SVG import, `DecalLayer` stamps, the side-face doctrine for the shoulders — but nothing connects them, and the parts that genuinely cannot be done (a Claddagh's crown standing proud over the hands, a class ring's sculpted three-dimensional shoulders) are nowhere stated.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:2069 `SignetOutline::Custom(u8)` plus `CustomOutline::from_points`, and 19 factory plans in `library::outline_dir()`. crates/ringdesign-core/src/svg.rs rasterizes imported art into the alpha library; field.rs:1536 `DecalLayer` free-places stamps. crates/ringdesign-core/examples/commissions.rs and sketches.rs are the closest existing work (a gem-set cross band, the Nocturnal face as a sand pattern) and neither is a named figural ring. `claddagh` appears nowhere in crates/.
+
+**Do this.** Unchanged, and the missing-assets point strengthens it: since `library::outline_dir()` is a user directory and ships empty, a new user has neither an example nor a plan. Ship one worked example (`examples/figural.rs`, in the discipline of commissions.rs — field-checked, rendered, sheet and stone map, saved to designs/) and one template built from it, so the path is discoverable from the File menu rather than from the source tree. The construction to demonstrate: `CustomOutline` head for the plan, the motif imported through svg.rs and placed by `Decals` on the head's side faces or terraced on the table via `Remap`, shoulders windowed. State in the signet doc what the height field refuses — anything standing *over* something else (a Claddagh's crown above the hands, an undercut claw) is a second surface, not relief, and is Free mode — while making the point a jeweller will care about: a class ring's shoulder emblems are relief on a side face and are therefore entirely castable in sand, which is the sellable half of this category.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Ship one worked example and one template. The construction is: a `CustomOutline` head for the plan, the motif imported as SVG and stamped by `Decals` on the head's own side faces or on the table with `Remap` terracing for the relief steps, and the shoulders windowed. State in the signet doc what the height field refuses — anything that stands over something else (a crown over hands, an undercut claw) is a second surface, not relief, and belongs to lost wax. A class ring's shoulder emblems, being relief on a side face, are entirely castable and should be shown as such.
+
+</details>
+
+**Castability.** Relief on the head's side faces is the sanctioned zero-undercut ground; relief on the table is fine except that a dot or a bar off the parting line leans (measured 14° in sketches.rs), so a figural stamp on a table wants the parting line through it. Nothing here needs a new guarantee, only the existing ones applied.
+
+**Verified.** Confirmed. `grep -rni "claddagh|class ring|crest ring|family crest|heraldic"` across the whole repo (excluding target/.git) returns exactly one hit, and it is unrelated: a comment at profile.rs:1746 about a heraldic shield's notch count in `suggest_dome`'s lobe test. The pieces are all present as claimed — `SignetOutline::Custom(u8)` + `CustomOutline::from_points` (field.rs:2069), svg.rs rasterizing imported art, `DecalLayer` free-placed stamps (field.rs:1536), per-layer `Remap` for terraced relief, and the side-face doctrine for shoulders. The closest existing worked examples are commissions.rs (a gem-set cross band) and sketches.rs (the Nocturnal face as a sand pattern), neither of which is a named figural ring. I could not find the 19 factory `.outline.json` plans on disk — `find . -name "*.outline.json"` returns nothing — so they are user-dir assets per the harvest rule, which means a fresh machine has no figural plan at all.
+
+#### F99 Head-rim ornament that follows the outline — `high` / `M` / signet-heads
+
+**Problem.** Milgrain, rope and bright-cut borders around the head's rim are standard signet dressing, and none of them is expressible. `MilgrainLayer` and `BorderLayer` are rails at a constant `v` running the whole way round the ring; the head's rim is a closed loop in (u,v). A user can hand-draw a closed `CurveLayer`, but its path is control points in cell space with no relation to the head, so it goes stale the moment the head's length, rise or outline changes.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1992-2000 (`MilgrainLayer { v_mm, bead_diameter_mm, beads_around, height_mm, mirror }`) and 2013-2038 (`beads_at` — nearest bead along `u` at a single `centre_v`); 911-951 (`BorderLayer::rail_at`, same shape); crates/ringdesign-core/src/curve.rs:62-90 (`CurveLayer.points` are `(x, v_mm)` in cell space, `closed: bool` exists). Meanwhile `ShankStyle::head_at` already returns `face: (f64, f64)` — the table's own span per theta — at crates/ringdesign-core/src/profile.rs:2103.
+
+**Do this.** Unchanged. Add one code-grounded warning to the spec: `HEAD_FACE_DRAFT` is 0.02 (a 2% proportional inset — CLAUDE.md's own note that the reference head is a prism), so the flank immediately under the rim is effectively a wall to a ±Z pull, and a proud bead row there is the off-crest-rails failure the templates already measured at 5.8%/29°. So the generator must gate on `DraftSettings::process` the way `pave::halo` does (the CastProcess switch already exists there), and in sand ship the bright-cut/recessed-panel variants, not the bead row. Name it `pave::head_rim` so it lands beside `fill`/`halo`/`channel_set` and inherits `GenRecipe`/`regenerate_live` for free.
+
+<details><summary>The auditor's original recommendation</summary>
+
+A `gen::head_rim(design, head, RimSpec)` generator emitting a live `GroupLayer` with a `GenRecipe`, so it re-solves when the band or head moves (the exact lifecycle `pave::regenerate_live` already runs). Path = the head's `face` span traced round the table, inset by `RimSpec::inset_mm`; treatments: bead row, rope, a plain raised fillet, a bright-cut V-groove, and a recessed panel with a raised border (rim ridge + carved interior). Gate it on process: the rim's ±Z runs sit on a near-vertical flank (`HEAD_FACE_DRAFT` is 0.02 — a 2% inset, i.e. essentially a wall), so a bead there undercuts; report it honestly and offer the whole family unconditionally under `CastProcess::LostWax`, and as a bright-cut post-cast operation in sand.
+
+</details>
+
+**Castability.** Real and interesting. Only the parts of the rim crossing the parting plane (the head's theta-ends) release cleanly; the runs at the band's ±Z extremes sit on the drafted flank and will lean. Measure it the way `mesh::tests::scratch_signet_head_undercuts` measures the head, and let the number decide which treatments ship as sand-castable.
+
+**Verified.** Verified. `pave.rs`'s generator surface is `fill`, `channel_set`, `halo`, `GenRecipe::generate`, `regenerate_live` (pave.rs:140, 285, 431, 572, 590) — no rim generator. `MilgrainLayer`/`BorderLayer` are single-`v` rails as described. `CurveLayer` points are cell-space `(x, v_mm)` with no head relation. `head_rim_mm` on `ShankMod` (profile.rs:2316) is the head's *fillet radius*, not ornament — a different thing that grep will collide with.
+
+#### F100 No way to draw or import a head plan outside the graph — `critical` / `M` / signet-heads *(also found as F175, F187)*
+
+**Problem.** `SignetOutline::Custom(u8)` and `CustomOutline` are excellent — a 720-entry polar table carried in the design file, containment proved by the rolling-ball closing, `fair_r` sized from the hull defect, 19 factory plans shipped. But a user cannot make one. `CustomOutline::from_points` is reachable only from the graph node `shank.outline_custom` with a literal point list, from examples, and from the harvest scripts. The GUI picker lists library plans and adopts them; there is no Import button. MCP resolves a plan *by name* against the library and cannot create one. `library::save_outline_in` exists but has no `save_outline()` wrapper reading `outline_dir()`, so nothing in the app can write a plan to the library either.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:2884 `CustomOutline::from_points`; callers: crates/ringdesign-graph/src/nodes/shank.rs:156, examples/cg_signet.rs:81, examples/sketches.rs:206, and tests. crates/ringdesign-gui/src/panels/design.rs:850-905 — the Face combo lists `SignetOutline::ALL`, then design-local customs, then `library::list_outlines()`; no import path. crates/ringdesign-mcp/src/tools.rs:901-920 `resolve_signet_outline` only looks up existing names. crates/ringdesign-core/src/library.rs:193 `save_outline_in` — no public wrapper.
+
+**Do this.** Keep all three doors, but state the gap precisely as *creation*, not adoption: every consumer can already adopt a plan by name from `outline_dir()`. So the work is (1) `CustomOutline::from_alpha(name, &Alpha)` threading `signed_distance_px` → `from_boundary` → the existing `fair_r_for(hull_defect(..))` sizing, which turns any SVG/painted/PNG asset into a head plan on every path at once; (2) a `library::save_outline()` wrapper over `save_outline_in(outline_dir(), ..)` plus GUI Import/Save buttons beside the Face combo; (3) an MCP `import_outline { name, svg | points }`. Offer `symmetrize` on import as opt-in — it is already the documented answer to a hand-drawn plan reading fuller on one side.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Three doors, all cheap because the pieces exist: (1) `CustomOutline::from_alpha(name, &Alpha)` — threshold the alpha, take the level-0 contour of `Alpha::signed_distance_px` (crates/ringdesign-core/src/alpha.rs:334), feed `from_boundary`; that instantly turns any SVG import, any painted stroke, and any PNG into a head plan. (2) A GUI "Import plan…" file picker beside the Face combo, plus "Save plan to library" and a `library::save_outline()` wrapper. (3) An MCP `import_outline { name, svg | points }` tool. Reuse the exporter's `fair_r_for(hull_defect)` on every path — it already is the shared rule.
+
+</details>
+
+**Castability.** None new: `from_points` already runs the recentre-fit-raycast and the rolling-ball fairing, so containment (`the_body_contains_the_face_it_carries`) is inherited by construction, and `suggest_dome` already routes lobed plans onto the cut dome.
+
+**Verified.** Mostly verified, with one correction. Confirmed: `CustomOutline::from_points` (field.rs:2884) is called only from ringdesign-graph/src/nodes/shank.rs:156, examples/cg_signet.rs:81, examples/sketches.rs:206 and tests — no GUI, no MCP, no CLI. Confirmed: `library::save_outline_in` (library.rs:193) has no `save_outline()` wrapper reading `outline_dir()` (library.rs:161), so no app surface can file a plan. Confirmed: the GUI Face combo (panels/design.rs:860-905) only lists `SignetOutline::ALL`, design-local customs and `library::list_outlines()` — no import. CORRECTION: MCP is not merely name-resolving for the primary head — `resolve_signet_outline` (tools.rs:901-921) adopts a library outline for the *second* head too (tools.rs:1613-1630), so adoption is fully wired on both heads; what is missing everywhere is *creation*. Also confirmed the building blocks exist: `Alpha::signed_distance_px` (alpha.rs:334), `CustomOutline::from_boundary` (field.rs:2155), `hull_defect` (field.rs:2805), `fair_r_for` (field.rs:2854), `symmetrize` (field.rs:2931).
+
+#### F101 A head cannot be rotated in plan — `medium` / `M` / signet-heads
+
+**Problem.** Plan orientation is hardcoded. `SignetOutline::upright()` is a two-arm match returning true for Heart and Shield only, and `distance_norm` swaps or negates axes on that basis. There is no rotation on `SignetHead` — even though `SignetLayer`, the *pad* that CLAUDE.md correctly calls the wrong way to make a signet, does have `rotation_deg`. So there is no north-south hexagon, no diagonal cushion, no rotated marquise, and an imported plan bakes its orientation into its point list at import time with no way to turn it after.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:2414-2444 (`upright()`, `distance_norm` — Hexagon is `y.abs().max(x.abs() + 0.5*y.abs())`, a fixed orientation with its points at the length ends); crates/ringdesign-core/src/profile.rs:1314-1390 (`SignetHead` — outline, theta, length, rise, shoulder, swell, body_fair, table_flat, table_dome, hollow, rim_round, dome, loft, loft_frontal, loft_lateral; no rotation); contrast crates/ringdesign-core/src/field.rs:3003 `SignetLayer::rotation_deg`.
+
+**Do this.** Unchanged. Two code-grounded cautions to attach: the rotation must also flow through `SignetOutline::half_extent`'s cached silhouette scan (CLAUDE.md's "scan inward from the extent" table) or a rotated plan will read its old silhouette, and through `outline_aspect`/`fit_length_to` so 90° re-proportions rather than stretches. For `Custom(u8)` it is an index offset into the 720-entry polar table and costs nothing. Serde-default 0.0 keeps every file bit-identical, and `upright()` then becomes a default rotation for Heart/Shield rather than a hardcoded branch.
+
+<details><summary>The auditor's original recommendation</summary>
+
+`SignetHead::plan_rotation_deg: f64` (serde default 0.0, so nothing migrates), applied where the outline is queried: rotate the (x, y) ray in `SignetOutline::distance_norm` and in the `half_extent` scan that builds the cached silhouette. For a `CustomOutline` this is an index offset into the 720-entry polar table — free. Constrain the cached tables to be keyed by rotation, and make `head_aspect`/`fit_length_to` read the rotated bounding box so picking 90° re-proportions the head instead of stretching it.
+
+</details>
+
+**Castability.** Low. Rotation does not change the containment argument (the closing is applied to whatever table is read) and every symmetric outline stays symmetric. The one thing to re-measure is the upright-outline phantom: `mesh::tests::scratch_signet_head_undercuts` already asserts residuals stay on the crest line, and a rotated shield should be added to that sweep.
+
+**Verified.** Verified. `SignetHead` (profile.rs:1313-1384) carries outline/theta_deg/length_mm/rise_mm/shoulder_deg/swell_deg/body_fair/table_flat/table_dome_mm/hollow_mm/rim_round_mm/dome/loft/loft_frontal_mm/loft_lateral_mm — no rotation. `SignetOutline::upright()` (field.rs:2414-2416) is literally `matches!(self, Heart | Shield)` and `distance_norm` (field.rs:2421+) branches on it to take a fixed quarter turn. `SignetLayer::rotation_deg` does exist on the pad (field.rs:3003), which is the inconsistency the auditor names. grep for `plan_rotation`, `rotate` on head: nothing.
+
+#### F102 Head size and shank width are not authorable in millimetres — `high` / `S` / signet-heads
+
+**Problem.** A jeweller specifies a signet as "14 × 12 head on a 3 mm shank". The app cannot say that. The head's extent across the band *is* `profile.width_mm`, and the shank is a fixed fraction of it: `signet_shank_frac` ignores theta entirely and returns `1 - (1 - 0.16) * amount`, so the only lever is the taper slider. To get a 3 mm shank under a 12 mm head you must solve `amount = (1 - 3/12)/(1 - 0.16) = 0.893` by hand — which `examples/cg_signet.rs` literally does, in code.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:1849-1852 (`signet_shank_frac`, `_theta_deg` unused); 1774-1779 (`apply_signet` sets kind, `amount = SIGNET_TAPER` 0.85, `fit_length_to`, `loft = 1.0`); 1321-1323 ("The extent *across* the band is the profile's own width"); crates/ringdesign-core/examples/cg_signet.rs:78-80 — `let shank_frac = (side_w / table_l)...; d.shank.amount = ((1.0 - shank_frac) / (1.0 - SIGNET_MIN_SHANK_FRAC))` is the inverse solve, done by hand in an example.
+
+**Do this.** Unchanged, and stronger than the auditor put it: the inverse solve is written out by hand in four places (examples/cg_signet.rs:79-80 and profile.rs tests at 4027 and 4553), which is the codebase's own warning sign about duplicated formulas. Add `ShankStyle::shank_width_mm: Option<f64>` solved back onto `amount` inside `signet_shank_frac` so the geometry path is untouched, and have those four call sites read it instead. Then make the GUI hint at panels/design.rs:1183 — which already prints "Face L x W mm on a X mm shank" — three editable fields.
+
+<details><summary>The auditor's original recommendation</summary>
+
+`ShankStyle::shank_width_mm: Option<f64>` and `SignetHead::width_mm: Option<f64>`, both solved back onto the existing machinery on read (`amount` from the shank width, `profile.width_mm` from the head width) so the geometry path is untouched and no file migrates. Surface them as the primary controls in the GUI signet panel and on MCP `set_shank`, with the taper slider demoted. The GUI hint at crates/ringdesign-gui/src/panels/design.rs:1183 already computes and prints "Face L × W mm on a X mm shank" — make those three numbers editable instead of derived.
+
+</details>
+
+**Castability.** None — it is a reparameterization of existing inputs, and clamping to `SIGNET_MIN_SHANK_FRAC` keeps the solved `amount` in range.
+
+**Verified.** Verified exactly as stated. `signet_shank_frac(&self, _theta_deg: f64)` (profile.rs:1849-1852) ignores theta and returns `1.0 - (1.0 - SIGNET_MIN_SHANK_FRAC) * k` with `SIGNET_MIN_SHANK_FRAC = 0.16` (profile.rs:1437). `apply_signet` (profile.rs:1774-1779) sets kind, `amount = SIGNET_TAPER` (0.85, profile.rs:1466), `fit_length_to`, `loft = 1.0` — no width control. The head's cross-band extent is `profile.width_mm` by construction (documented at profile.rs:1321-1322). And the inverse solve is done by hand in an example: examples/cg_signet.rs:79-80, `let shank_frac = (side_w / table_l).clamp(...); d.shank.amount = ((1.0 - shank_frac) / (1.0 - SIGNET_MIN_SHANK_FRAC)).clamp(0.0, 1.0);` — plus the same inversion appears twice more in tests (profile.rs:4027, 4553).
+
+#### F103 No trade head-size table to suggest from — `medium` / `S` / signet-heads
+
+**Problem.** Head sizes are conventionally quoted and conventionally chosen by finger size and wearer: roughly 8×6 child, 10×8 / 11×9 / 12×10 ladies, 13×11 / 14×12 / 16×14 gents, with the plate scaled to the finger so it does not overhang. The app has no such table. `fit_length_to` only multiplies whatever band width is already set by the outline's aspect, and `HEAD_LENGTH_MM` is a flat 12.0 default regardless of `design.size`.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:1560-1563 (`fit_length_to(band_width_mm)` = `band_width * head_aspect()`, clamped 2..40); 1404 (`HEAD_LENGTH_MM: f64 = 12.0`); crates/ringdesign-core/src/sizing.rs — the entire sizing module is 54 lines of US size arithmetic, no head or proportion data. The reference measurements exist in CLAUDE.md (the heart's table sits 1.75 mm over the bore *on every size*, i.e. the factory scales the plan and not the stand-off) but are not in code.
+
+**Do this.** Unchanged. Anchor it on the measurement already in CLAUDE.md rather than a catalogue: the reference heart's table sits 1.75 mm over the bore *on every size*, i.e. the factory scales the plan and holds the stand-off — so `suggest_for` should set `length_mm` and `profile.width_mm` from the plate and leave `rise_mm` alone. Pair it with finding F10: a plate table is only useful once head width and shank width are authorable in mm, so land F10 first and make the plate combo a preset over those two fields.
+
+<details><summary>The auditor's original recommendation</summary>
+
+A `signet::head_sizes()` table of named trade plates (name, length_mm, width_mm, typical size range) plus `SignetHead::suggest_for(size: RingSize, plate: Plate)` that sets `length_mm`, `profile.width_mm` and `rise_mm` together. Offer it as a combo above the Face picker ("Gents 14×12", "Ladies 11×9", "Custom") in the GUI and configurator, and as an MCP enum. Anchor `rise_mm` on the measured 1.75 mm table-over-bore rather than scaling it with the plate, which is what the reference does.
+
+</details>
+
+**Castability.** n/a — presets over existing parameters, each of which already fields 0.000%.
+
+**Verified.** Verified. `fit_length_to` (profile.rs:1557-1559) is `length_mm = (band_width.max(1.0) * outline.head_aspect()).clamp(2.0, 40.0)` — nothing else. `HEAD_LENGTH_MM = 12.0` (profile.rs:1401) is a flat constant, `HEAD_RISE_MM = 0.3` likewise. `crates/ringdesign-core/src/sizing.rs` is 54 lines total and holds only US-size arithmetic. grep for `head_size`, `plate`, `Gents`, `Ladies` across crates: no hits in core.
+
+#### F104 The casting sheet never states the head — `medium` / `S` / signet-heads
+
+**Problem.** `spec::html` prints inside/outside diameter, band width, overall bounds, relief and volume — but nothing about the head, which is the whole ring. A customer orders a 14×12; a bench hand checks the plate's stand-off and the shank behind it. None of table length, table width, table area, stand-off at the centre, stand-off at the corner, or shank width appears on the sheet, in `Report`, or on MCP's describe.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:96-118 (the Dimensions table — inner dia, outer dia, band width, overall x/y/z, relief, volume); crates/ringdesign-core/src/mesh.rs:263-281 (`Report` — no head fields). The GUI does compute the numbers for a tooltip (crates/ringdesign-gui/src/panels/design.rs:1177-1190: face L × W, shank width via `signet_width_frac`, and the corner stand-off `(crest_r + rise).hypot(length/2) - crest_r`) — so the arithmetic exists and only lives in a hint string.
+
+**Do this.** Unchanged. The lift is small and the payoff is disproportionate: the numbers are already computed correctly in the GUI hint, they just live in a `format!`. Return `HeadDims` from a `ShankStyle::head_dims(&BandProfile, inner_r)`, have the GUI hint read it instead of recomputing, put it on `Report` under an `Option` so non-signets are unaffected, and print a Head section on the sheet. Include table area — it is the number CLAUDE.md benchmarks against the reference (119 -> 210 mm2 against 242) and it currently exists nowhere a user can see.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Lift that GUI computation into `profile::HeadDims { length_mm, width_mm, table_area_mm2, stand_off_centre_mm, stand_off_corner_mm, shank_width_mm, shank_thickness_mm }` returned by a `ShankStyle::head_dims(&BandProfile, inner_r)`, add it to `Report` when the shank is a Signet, and print a "Head" section on the casting sheet. Table area is already the number CLAUDE.md compares against the reference (119 → 210 mm² against 242), so it belongs in the shipped report, not only in commit archaeology.
+
+</details>
+
+**Verified.** Verified. `Report` (mesh.rs:263-281) is validation/volume/surface_area/bounds/inner_diameter/outer_diameter/band_width/max_relief/min_relief/metals/build_ms/refine/quality — no head fields. `spec.rs`'s Dimensions table (spec.rs:98-118) prints inner dia, outer dia, band width, overall x/y/z, relief and volume. And the arithmetic genuinely does exist only as a GUI hint string: panels/design.rs:1177-1190 computes `shank_mm` via `sh.signet_width_frac(back, inner_r, crest_r, &profile)` and `corner = (crest_r + rise).hypot(length * 0.5) - crest_r`, then formats it into a tooltip.
+
+#### F112 Table treatments stop at flat, cab and cut dome — `medium` / `M` / signet-heads
+
+**Problem.** Three table treatments exist — flat (`table_flat`), a cabochon or apex dome (`table_dome_mm`), and the cut-dome facet (`dome`). The stepped family is absent: a tiered or stepped table (a smaller plateau standing on a larger one), a bevelled table (a chamfer round the plate rather than a fillet), and a recessed panel with a raised border. Those are three of the commonest ways a plain plate is given a look, and each is one monotone-drop-per-section construction away from what already exists.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:1339-1348 (`table_flat`, `table_dome_mm`), 1385-1391 (`dome`), 1394-1400 (`rim_round_mm` — a fillet, not a chamfer); crates/ringdesign-gui/src/panels/design.rs:986-1105 — the head panel's sliders are Face length, Rise, Body fairing, Swell, Shoulder, Table flat, Cut dome, Lofted body, Body growth ×2, Cab dome, Hollow, Rim round, Around. Nothing stepped, nothing bevelled. The cut-dome arm (profile.rs:2637-2657) proves the pattern: a per-section `min(dome, plane)` is a single-plateau monotone drop and so fields 0.000% by construction.
+
+**Do this.** Unchanged in substance; reorder by payoff. The bevelled table is the cheapest and most classical — it is an alternative to the existing rim blend at profile.rs:708/928 where `head_rim_mm` is already threaded through `keep` and the edge fillet, so it is a second law on an existing knob rather than a new construction. Stepped tables come second (nested plane solves, min of monotone drops, same by-construction guarantee as the cut dome). The recessed panel is really finding F7's generator plus a shallow `Subtract`, so file it there rather than here — and yes, measure it: a panel centred on and symmetric about the parting plane is a plausible sand feature where the rim bead row is not.
+
+<details><summary>The auditor's original recommendation</summary>
+
+`SignetHead::table_steps: u8` + `step_drop_mm`: build the plate as `min` of two or three nested plane solves at descending radii and shrinking outline scales — each is a plateau, the min of monotone drops and constants is monotone, so the same by-construction guarantee holds. A bevelled table is the rim fillet replaced by a straight chamfer of the same reach (a one-line alternative in the wall's rim blend). A recessed panel with a raised border falls out of the head-rim generator above plus a shallow `Subtract` inside it — and unlike the rim ornament, a recessed panel centred on the parting plane and symmetric about it may well cast; measure it.
+
+</details>
+
+**Castability.** Low for the stepped and bevelled tables — `min` of a monotone drop and a constant is monotone, which is exactly the argument `HEAD_DOME_INSET`/`cut_dome_heads_field_clean_and_never_pinch` rests on, and the arris must stay a hard `min` for the documented reason (the smooth-min's 8.7%-of-radius overshoot measured a −3° lip). The recessed panel is the one to measure honestly: a pocket in a zero-draft plane undercuts on both ±Z walls unless it straddles the parting plane symmetrically.
+
+**Verified.** Verified. `SignetHead`'s table controls are `table_flat` (profile.rs:1338-1340), `table_dome_mm` (1341-1347), `dome` (1364-1371) and `rim_round_mm` (1355-1359, explicitly a fillet). GUI head panel sliders (panels/design.rs:986-1105) match that list exactly. grep for `table_steps`, `chamfer`, `bevel` on the head: nothing (the only `bevel` hits are tiling edge bevels in tiling.rs and alpha.rs). The cut-dome arm at profile.rs:2637-2657 does establish the min-of-monotone-drops pattern the recommendation leans on.
+
+#### F113 Shoulder windows are hand-typed degrees that go stale when the head moves — `medium` / `M` / signet-heads
+
+**Problem.** Decorated shoulders — chased scrolls, stepped shoulders, gem-set or fluted shoulders — are not first class. A user hand-windows every layer with a literal arc, and that arc has no relation to the head that defines where the shoulders are. The shipped template writes `Window::except(TOP_DEG, 120.0)`; change the head's length, rise or `swell_deg` and the ornament no longer lines up with the shoulder it was placed on, silently.
+
+**Evidence.** crates/ringdesign-core/src/templates.rs:106 `e.window = Window::except(TOP_DEG, 120.0);` — a literal 120°; crates/ringdesign-core/src/field.rs:438-459 (`Window::around` / `except` take raw degrees; `Window` is positional and carries no live resolution) versus 402-415 (`VGate::SideFaces` *does* resolve live from `ctx.side_faces_std()`, which is the precedent). The numbers a shoulder window wants are already computed inside `head_at`: `face_edge` (where the plate ends), `head.shoulder_deg` (where the crest lands), `head.swell_arc_deg(face_edge)` (where the width lands) — profile.rs:1925,2003,2005 — and all three are discarded.
+
+**Do this.** Unchanged. Two additions from the code: the numbers a shoulder gate wants are computed and then discarded inside `head_at` — `face_edge`, `head.shoulder_deg` and `swell_arc_deg(face_edge)` (profile.rs ~1925, 2003-2005) — so the resolver is a read, not a derivation. And note this pairs with finding F17: once a shoulder gate exists, the DFM correction knows exactly which stations to sample, because the gate names them. Mirror `VGate`'s serde shape so the `Fixed` variant is the default and no file migrates, exactly as `SideFacePick` did.
+
+<details><summary>The auditor's original recommendation</summary>
+
+An `AngularGate` enum alongside `VGate`, mirroring it exactly: `Fixed { theta, span, fade }` (today's behaviour, the serde default) and `Shoulders { of_head: u8, from: ShoulderEdge }`, resolved at evaluation time against `ShankStyle` so the window tracks the head the way a side-face gate tracks the profile. Then a `gen::shoulders` generator emitting a live group — fluted, chased, or a graduated three-stone run — windowed by that gate. Wire it into the add-layer menu the way the wire presets already land on a side face automatically.
+
+</details>
+
+**Castability.** None new — it changes where a layer is gated, not what it displaces, and the shoulder is the drafted surface the doctrine already sends ornament to. It should be paired with the tiling-DFM fix above, or a correctly-placed shoulder pattern will still be measured at the wrong scale.
+
+**Verified.** Verified. `Window` (field.rs:349-363) is enabled/theta_deg/span_deg/fade_deg/invert/v_gate — raw degrees, no live resolution. `VGate` (field.rs:370-380) is the stated precedent and does resolve live: `SideFaces(SideFacePick)` is documented "resolved at evaluation time so the gate tracks profile edits". templates.rs:106 is the literal `e.window = Window::except(TOP_DEG, 120.0);`. grep for `AngularGate`, `shoulder_window`, `gen::shoulders`: nothing; pave.rs's generators are only `fill`/`channel_set`/`halo`.
+
+#### F148 Angular windows drift against millimetre-placed ornament across a size run or a matched pair — `medium` / `M` / sizing-fit
+
+**Problem.** `Window` is stated in degrees (`theta_deg`, `span_deg`, `fade_deg`) while `VGate` and `Decal` are in millimetres (`v_mm`, `size_mm`). Across a size run the two diverge: a window holding an inscription to ±40° covers 34.4 mm of crest arc at size 5 and 41.5 mm at size 9, while the stamps inside it stay their authored millimetre size and sit at fixed angles. So a three-stamp inscription spreads 20% further apart on the larger ring while each glyph stays the same size. This bites hardest on the most common order a shop takes: a matched pair of wedding bands at, say, size 6 and size 11, which must read as the same design.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:345-359 (`Window`: `theta_deg`, `span_deg`, `fade_deg` all degrees) versus field.rs:364-372 (`VGate` in mm) and field.rs:1505-1517 (`Decal`: `theta_deg` but `v_mm` and `size_mm`); crates/ringdesign-core/src/sizing.rs:14-16 for the circumference figures; crates/ringdesign-cli/src/main.rs:172-174 (a size run changes nothing but `d.size`).
+
+**Do this.** Sharpened, and narrow the blast radius — the auditor's framing risks touching doctrine it must not. `TilingLayer::repeats_around`, `MilgrainLayer::beads_around` and `BorderLayer::rope_twists` are integers BY DESIGN so they close on themselves, and a pattern repeating N times regardless of size is correct behaviour a jeweller expects; do not anchor those in mm. The genuine bite is narrower: a fixed-mm `Decal` (or an engraved inscription, which the configurator emits as a single Decal of a TextAlpha) placed at a fixed `theta_deg` inside a fixed-degree `Window`. So add the anchor to `Decal::theta_deg` first — an `ArcMm` alternative converting through `FieldContext::circumference_mm` at evaluation time, which is precisely where `arc_scale` already corrects chart arc to metal — and to `Window` second. Serde-default both to `Degrees` so nothing saved moves. `ringdesign export --pair 6,11` reporting what moved between the two is the feature that actually sells this to a shop taking wedding-band orders, and it needs finding 7's `resize_to` underneath it anyway.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `Window` an anchor: `enum WindowAnchor { Degrees, ArcMm }` (serde-defaulting to `Degrees` so nothing saved moves), with `ArcMm` converting through `FieldContext::circumference_mm` at evaluation time — the same place `arc_scale` already corrects chart arc to metal. Do the same for `Decal` placement so a stamp can be anchored a fixed number of millimetres from the top. Then add a `ringdesign export --pair 6,11` mode that builds a matched pair and reports what moved between them.
+
+</details>
+
+**Castability.** None to the pull, but `fade_deg` interacts with it: the file's own doctrine notes a hard window end raises a wall the mould must clear, so an mm-anchored fade must convert its *fade* too, not just its span, or a small size will get a shorter fade in degrees than it was authored with.
+
+**Verified.** Structurally verified. `Window` (field.rs:348-362) is `theta_deg` / `span_deg` / `fade_deg`, all degrees, positional not periodic. `VGate::Band` (field.rs:375) is `center_mm` / `span_mm` / `fade_mm`. `Decal` (field.rs:1508-1521) is `theta_deg` for position around the ring but `v_mm`, `size_mm` and `height_mm` in millimetres. Grepped field.rs for `WindowAnchor|arc_mm|anchor` — nothing. Grepped all crates for `--pair|matched pair` — nothing. So two decals at 60 deg and 90 deg are 30 deg apart at every size, which is 8.6 mm of crest arc at size 5 and 10.4 mm at size 9, while each stamp stays its authored size_mm. Real for the matched-pair order.
+
+**Merged into a canonical finding above:** F175 (A custom signet plan can only be created from the node graph — the biggest lever on ring variety is behind the hardest door) -> F100, F187 (Nothing in the app can import a drawn signet plan) -> F100, F237 (Keyframed bands cannot be authored from the graph) -> F55.
+
+### M13 — The first ten minutes (M, 10 findings)
+
+**Done when:** A new install opens on a visual gallery, three shipped templates carry stones, every user library has one browser, Ctrl+S saves the file it opened.
+
+#### F56 The template gallery and the kiosk base list are both signet-heavy and stone-light — `medium` / `M` / ring-typology
+
+**Problem.** The nine templates are the shop window and MCP's `apply_template`, and four of them are signets. Not one carries a `SeatRun`, a pavé group, a halo or a channel — the generators the app is proudest of are invisible to a new user. The kiosk's eight bases have no plain comfort-fit flat band, no cigar band, no knife edge, and its stone step offers only "none / one solitaire / full eternity".
+
+**Evidence.** crates/ringdesign-core/src/templates.rs:64 `static TEMPLATES: [Template; 9]` — Court band, Heart signet, Waved hexagon signet, Shouldered cushion signet, Braided band, Cathedral solitaire stock, Wishbone wave, Split shank, Toi et moi. Only "Cathedral solitaire stock" carries any stone, one `SeatPadLayer`. crates/ringdesign-configurator/src/compose.rs:22 `Base` is eight variants; compose.rs:94 `Stone` is `None | Solitaire { cut, mm } | Eternity { mm }`; compose.rs:206-260 fixes the profile per base, so the customer never chooses a section.
+
+**Do this.** Templates: add "Half-eternity" (a `SeatRun` on its own arc), "Pavé shoulders" (`pave::fill` gated to a side face), "Channel band", "Cigar band" (7.5 × 2.4 CushionDome with a comfort fit) and "Contour band" once the keyframe axial term lands — each held to `analyze_field` by the existing test. Kiosk: add `Base::FlatComfort`, `Base::Cigar`, `Base::KnifeEdge`; extend `Stone` with `HalfEternity { mm, arc_deg }` and `ThreeStone`, and let the customer pick a setting style (gypsy / bezel) since `SeatStyle` already offers both.
+
+**Castability.** Each addition goes through `every_template_builds_watertight_and_none_is_uncastable` and the kiosk's own every-base-every-dress field test, so nothing ships unjudged. The cigar band's mass is the one thing to watch — a wide heavy band should be run through `modulus_scan` so the sheet names where it freezes last.
+
+#### F171 There is no Help, no first-run path, and nowhere the sand doctrine is explained once — `high` / `M` / ux-workflow
+
+**Problem.** A jeweller opens the app and gets a bare HalfRound 6×2 band, four dense tool panels and a viewport. No welcome, no template gallery on start, no tour, no Help menu, no About, no shortcut list. The per-control tooltips are genuinely excellent — but they teach the doctrine one sentence at a time, at the moment a control is hovered, and never tell you the shape of the rule. Nothing anywhere says "the mould pulls along ±Z; the two side faces are free; the crest holds about 0.15 mm" as a single screen, and nothing links a warning to an explanation.
+
+**Evidence.** grep for `welcome|onboard|tour|first run|Help|about` across crates/ringdesign-gui/src returns only prose inside unrelated tooltips; `RingDesignerApp::new` (crates/ringdesign-gui/src/app.rs:236) falls back to `RingDesign::default()` with no first-run branch; the toolbar (panels/mod.rs:600) has File, Panels, history, layout, view toggles and MCP — no Help.
+
+**Do this.** Unchanged, with the precedent named precisely: copy `Thumbs` (configurator/src/main.rs:221-240) for the template card grid, feeding it `templates::all()` instead of `Base::ALL`. For the "Why?" panel, note that the explanations largely already exist as strings in the codebase — layers.rs:1949 ("All dome, no side face. Relief here undercuts above about 0.15 mm.") and `side_face_fit`'s disabled-hover text are the doctrine said one control at a time; the panel's job is to collect them plus the CLAUDE.md tables into one screen, not to write new prose.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Two pieces. (1) A first-run pane (shown when there is no stored workspace) offering the nine templates as rendered cards — `templates::all()` plus `render::png_bytes` on a one-shot thread, exactly as the configurator's `Thumbs` already does for its bases. (2) A "Why?" affordance: give every warning a stable key and open a docked `ToolKind::Why` panel carrying the one-screen explanation with the measured table from CLAUDE.md — the side-face vs crest undercut table, the off-crest-rails number, the two-flange valley. Wire it from the field banner, the DFM badges, the `side_face_fit` message and the flange snap warning.
+
+</details>
+
+**Verified.** Confirmed. Grepped `welcome|onboard|first.run|"Help"|About|tour` across crates/ringdesign-gui/src — every hit is the word "about" inside unrelated tooltip prose (panels/mod.rs:926,980; design.rs:1095; layers.rs:939,1362,1949). The toolbar has exactly four menu buttons: History (mod.rs:572), File (:608), New from template (:617, a submenu), Recent (:629) and Panels (:768). No Help, no About, no shortcut sheet. The configurator's `Thumbs` (crates/ringdesign-configurator/src/main.rs:221-240) is confirmed as the working precedent — a `compose-thumbs` thread rendering one base per `Base::ALL` entry — so the first-run card grid is a port, not new work.
+
+#### F173 Ctrl+S is always Save As — the app has no idea which file it has open — `high` / `S` / ux-workflow
+
+**Problem.** There is no current-file path anywhere in `RingDesignerApp`. `save_design` opens an rfd save dialog every time, seeded from `design.name`; Ctrl+S runs the same thing. There is no dirty flag, no modified marker, no window title showing the file, and New / Open / New-from-template / Open-a-template-graph all replace the design with no prompt. `Workspace.recent` records paths but nothing tracks *the* path.
+
+**Evidence.** crates/ringdesign-gui/src/export.rs:350 `save_design` (unconditional `.save_file()`); `Command::Save => export::save_design(app)` (panels/mod.rs); `RingDesignerApp` has `recent: Vec<String>` but no `path: Option<PathBuf>` (app.rs:120-230); `Command::New` (panels/mod.rs:441) replaces `app.design` with no confirmation; `main.rs` titles the window `RingDesigner v{version}` only.
+
+**Do this.** Unchanged. One dependency worth naming: `History` (crates/ringdesign-gui/src/history.rs) already runs a 400 ms `SETTLE` coalescer and a `touch()` call — hang the autosave off that same settle rather than adding a second timer, and use `history`'s existing generation as the `saved_generation` comparand so the modified dot and the undo stack cannot disagree.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `path: Option<PathBuf>` and `saved_generation: u64`. Ctrl+S overwrites `path` when set and falls back to Save As; add Ctrl+Shift+S for Save As. Put the file name and a modified dot in the window title (`ViewportCommand::Title`) and in the status bar. Prompt on New/Open/template when modified, and keep a rolling autosave into `designs/.autosave/<name>.ring.json` on the same settle timer `History` already runs, so a crash costs 400 ms not a session.
+
+</details>
+
+**Verified.** Confirmed in full. `save_design` (export.rs:350-366) opens `rfd::FileDialog::save_file()` unconditionally, seeded from `slug(&app.design.name)`. `RingDesignerApp` has `push_recent` (app.rs:354) but no path field — grepped `path:|PathBuf|current_path|saved_gen|modified` in app.rs and the only hit is `push_recent`'s parameter. `Command::New` (panels/mod.rs:443-449) replaces the design with no prompt. Grepped `ViewportCommand::Title|set_title|with_title` across the GUI — nothing, so the title is fixed at whatever main.rs sets. Grepped `autosave|auto_save` across the GUI and core — no hits at all.
+
+#### F174 Window-level drag and drop is switched on and never handled — `medium` / `S` / ux-workflow
+
+**Problem.** `ViewportBuilder::with_drag_and_drop(true)` is set, so the window accepts drops and the OS shows a drop cursor — and nothing reads `dropped_files`. Dragging a `.ring.json`, a PNG texture, an SVG or a `.profile.json` onto the app does nothing at all, which reads as a broken feature rather than a missing one.
+
+**Evidence.** crates/ringdesign-gui/src/main.rs:60 `.with_drag_and_drop(true)`; grep for `dropped_files|hovered_files` across crates/ringdesign-gui/src and crates/ringdesign-configurator/src returns nothing.
+
+**Do this.** Unchanged. Note the dispatch already has its landing sites: `export::open_design_path` (export.rs:380) for a design, `library::list_profiles`'s serde shape for a `.profile.json`, `import_svgs`'s per-file body (export.rs:409+) for SVG, and — once finding 10 lands — `CustomOutline::from_points` for a head plan. Disambiguate `.json` by peeking at `format_version` and the top-level keys rather than by filename.
+
+<details><summary>The auditor's original recommendation</summary>
+
+In `panels::render`, read `ctx.input(|i| i.raw.dropped_files.clone())` and dispatch by extension: `.json` → `export::open_design_path` (or `library::load_profile` if it parses as a `BandProfile`, or a graph/cluster/preset by its `format_version`), `.png/.jpg/.bmp` → `AlphaLibrary::insert` via the same path as Import images, `.svg` → the `SvgAlpha` path, `.stl/.obj` → offer it as a reference mesh. Paint a drop overlay from `hovered_files` naming what each file will become.
+
+</details>
+
+**Verified.** Confirmed exactly. `crates/ringdesign-gui/src/main.rs:58` has `.with_drag_and_drop(true)`. Grepping `drag_and_drop|dropped_files|hovered_files` across crates/ringdesign-gui/src and crates/ringdesign-configurator/src returns that single line and nothing else — no reader anywhere.
+
+#### F176 Five library systems, five different front doors, and no way to browse or manage most of them — `high` / `L` / ux-workflow
+
+**Problem.** The user owns alphas, profiles, outlines, designs, templates, graph clusters and graph presets. Only alphas get a real browser (thumbnail grid, search, import, edit, delete). Profiles are a nameless "Saved…" combo with a tiny drawn section; outlines are a section at the bottom of the signet's Face combo; designs are an OS file dialog plus a ten-entry Recent menu with no previews; templates are a File submenu of hover-text; graph clusters and presets appear only in the graph pane's empty state. Nothing but alphas can be renamed, deleted, tagged or searched from inside the app, and there is no place that shows what you own.
+
+**Evidence.** crates/ringdesign-gui/src/panels/library.rs (the alpha browser: `search_row`, `source_row`, `grid`, `TileHit.removed`); crates/ringdesign-gui/src/panels/design.rs:118-131 (profiles as a combo) and :860-895 (outlines inside the outline combo); crates/ringdesign-gui/src/panels/mod.rs:600-640 (templates and Recent in the File menu); crates/ringdesign-gui/src/panels/graph.rs:63-87 (graph templates only in the empty state); `library::save_profile` has a caller, no delete or rename does.
+
+**Do this.** Unchanged, with one prerequisite the audit skipped: core has no delete or rename for any asset kind (`library.rs` has only save/list per kind), so the browser needs `library::delete_profile/outline/design` and a rename added there first. `profile_row` (design.rs) is already the profile thumbnail widget and can be reused verbatim in a grid. Keep the in-context combos — the ComboBox at design.rs:117 is the right quick picker — and let the browser own management.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Promote `ToolKind::Library` to an Assets browser with a tab strip — Tiles, Profiles, Head plans, Designs, Templates, Graphs — sharing the existing search box, thumbnail grid and right-click menu. Profiles and outlines already draw well at thumbnail size (`profile_row` in design.rs is the widget); designs render through `render::png_bytes` with a small on-disk thumbnail cache beside each file. Add rename/delete/reveal-in-folder for every kind, and a free-text tag stored in a sidecar. Leave the in-context combos as quick pickers.
+
+</details>
+
+**Verified.** Confirmed. `ToolKind` (dock.rs:17-41) has exactly five arms and `Library` is labelled "Tiles" — the alpha browser is the only asset pane, and it alone has search (`search_row`, library.rs:303), a grid (:446), a tile (:484) and delete (`TileHit.removed`, :442/:465, acted on at :64). Profiles are a `Saved…` ComboBox at design.rs:117-132 drawing `profile_row` per entry; outlines are a section inside the head's outline combo at design.rs:871-895. Templates and Recent are File submenus (panels/mod.rs:617,629). Confirmed in core: library.rs exposes `save_profile`/`save_profile_in`/`list_profiles`/`list_profiles_in` and `save_outline_in` — grepping for `delete`/`rename` in library.rs returns nothing, so the management verbs do not exist at any layer.
+
+#### F181 The phone has no undo, and two unconfirmed buttons that destroy a design — `high` / `M` / ux-workflow
+
+**Problem.** The Android app carries the full core, the graph editor and the paint brush, and has exactly one undo: the brush bar's per-stroke pop. There is no design-level history. Beside it sit "Clear layers" (empties the whole stack) and "Clear" (drops every stroke), both single-tap, both unconfirmed, both unrecoverable. A ring opened from the desktop with six composed layers can be wiped by one mis-tap. The desktop's `History` is design-only and depends on nothing but `RingDesign` and `serde_json`, so it is portable as-is.
+
+**Evidence.** ~/Documents/Rust/Mobile/EguiMobile/examples/ringdesigner-android/src/app.rs:1153 (the only `Undo`, inside the brush panel, popping `d.strokes`) and :895-900 (`Clear layers` → `self.design.layers.layers.clear()`); grep for `history|History` across that crate returns nothing; crates/ringdesign-gui/src/history.rs has no egui or GUI dependency beyond `Instant`.
+
+**Do this.** Unchanged. Two specifics from reading history.rs: the module names steps by diffing serialized snapshots (`first_difference`), so it labels edits made from the phone's own panels with no per-call-site work; and its 400 ms `SETTLE` coalescer is what makes it affordable on a phone, since a slider drag commits once. Move it to `ringdesign-core` behind the same `BuildClock` treatment `Instant` already gets for wasm.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Move `history.rs` into `ringdesign-core` (it is pure design + serde_json; `Instant` is already handled elsewhere by `BuildClock` for the wasm case) and use it from both apps. On the phone, a persistent undo/redo pair in the top bar plus a confirm on the two Clears. While there, the phone has no layer list at all — a read-only stack with enable/disable and reorder would let a desktop-composed design be adjusted at the bench instead of only viewed and painted on.
+
+</details>
+
+**Verified.** Confirmed against the phone crate. Grepping `history|History|Undo|undo` across ~/Documents/Rust/Mobile/EguiMobile/examples/ringdesigner-android/src/ returns exactly one hit: app.rs:1153, the brush bar's `d.strokes.pop()`. "Clear layers" at app.rs:895-900 calls `self.design.layers.layers.clear()` on a single click with only a hover text; "Clear" at :1161 empties `d.strokes` the same way. Portability confirmed: crates/ringdesign-gui/src/history.rs imports only `std::time::{Duration, Instant}`, `ringdesign_core::RingDesign` and `serde_json::Value` — no egui, no GUI type. The "no layer list" claim is also right: the only iteration over `layers.layers` in the phone's app.rs is the viewport probe at :489 naming the topmost contributing layer, plus push/clear sites.
+
+#### F184 The status line is the only channel for results and errors, and it is one overwritable string — `medium` / `S` / ux-workflow
+
+**Problem.** `app.status` is a single `String` that every code path overwrites. A finished export ("Wrote /path/ring.stl • 196608 tris • 9.4 MB"), a failure ("STL export failed: …"), an MCP bind error, a refused generator ("The plate does not fit this band — widen it") and the routine per-build line ("110592 tris • 13 ms") all land in the same place, and the build line arrives every 90 ms during editing. So any message a user needs is gone before they read it, there is no log to scroll back through, and a written file offers no way to open it or its folder.
+
+**Evidence.** crates/ringdesign-gui/src/app.rs:210 `pub status: String`, overwritten in `dispatch` (:525 `"Building…"`), in `tick` (:415, every completed build), in `poll_export` (:373), `set_status` (:700) and from every panel; crates/ringdesign-gui/src/panels/mod.rs:1015 renders it as one label.
+
+**Do this.** Unchanged in direction. Correct one detail: the status bar's right slot (panels/mod.rs:1025) already shows size/diameter/weight, so the routine build line needs a *new* slot rather than an existing one. The highest-value single change is narrower than the whole message log: stop `dispatch` (app.rs:525) from writing "Building…" into the same string that carries export results — put the build state in its own field and let `app.status` hold only things a person needs to read.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Keep a `Vec<(Instant, Level, String)>` of the last ~200 messages behind the status line, with routine build stats going to a separate right-hand slot (they already have one for tris/ms). Click the status to open a Messages panel; toast warnings and errors so they persist a few seconds; give a completed export a "Reveal" action opening its folder. Log to a rolling file so a bug report has something in it.
+
+</details>
+
+**Verified.** Confirmed, and the churn is worse than described. `pub status: String` at app.rs:208, written from eleven sites in app.rs alone (:430 MCP edit, :439 every completed build, :489 graph errors, :499/:541 worker stopped, :525 "Building…" on every dispatch, :612 undo/redo, :715 `set_status`, :724/:730/:739 MCP server) plus ~40 more across the panels and export.rs. `dispatch` (app.rs:525) sets "Building…" on every debounced rebuild, so any message is destroyed within 90 ms of the next edit. One correction to the finding: the right-hand slot at panels/mod.rs:1025-1043 carries size, outer diameter, band width and 14k grams — not tris/ms — so the build stats do not already have a home there. `env_logger` (main.rs:50) writes to stderr only; there is no rolling log file and no toast.
+
+#### F185 Keyboard coverage stops at seven shortcuts and there is nowhere to see them — `medium` / `S` / ux-workflow
+
+**Problem.** The app binds Ctrl+Z/Shift+Z/Y, Ctrl+S/O/N, Ctrl+K and Delete. There is no Ctrl+Shift+S, no export binding, no pane or tool focus keys, no camera keys (the standard views are toolbar buttons only), no arrow-key nudge for a selected layer or a grabbed handle in the unrolled editor, and no F1 or shortcut sheet — the only place a binding is written down is inside the command palette's own labels, which you must already know Ctrl+K to reach. The palette itself has no arrow-key selection: Enter always runs the first hit.
+
+**Evidence.** crates/ringdesign-gui/src/panels/mod.rs:250-320 `shortcuts` (the complete list) and :488-530 `command_palette` (`let go = i.key_pressed(Enter)` applied to `first`, no highlight index); `StandardView::ALL` is drawn as `small_button`s in `pane_head` with no bindings; grep finds no F1 or shortcut listing.
+
+**Do this.** Unchanged. Cheapest first: the palette fix is a `palette_sel: usize` on the app, Up/Down consuming in the same `ui.input_mut` block the other shortcuts use, and `go && k == sel` in place of `go && first` at panels/mod.rs:528. For the sheet, derive it from `Command::ALL` plus the `KeyboardShortcut` consts already declared at :267-274 — put the consts in a table keyed by `Command` so the binder and the sheet read one source and cannot go stale.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add arrow-key navigation and a highlighted row to the palette; bind the standard views to 1–6 over a focused Solid pane; Ctrl+E for the last export repeated; Ctrl+1..4 to focus a pane and Alt+1..5 to focus a tool; arrow keys to nudge the selected layer's window or handle by 0.1 mm (shift for 1 mm) in the unrolled editor. Then add a `Command::Shortcuts` entry that opens a generated sheet — derive it from the same table that binds the keys so it cannot go stale.
+
+</details>
+
+**Verified.** Confirmed. `shortcuts` (panels/mod.rs:266-321) binds UNDO (Ctrl+Z), REDO (Ctrl+Shift+Z), REDO_ALT (Ctrl+Y), SAVE, OPEN, NEW, PALETTE (Ctrl+K) and bare Delete — that is the complete list; grepped for F1 and any shortcut listing, nothing. `command_palette` (:492-535) confirms the Enter behaviour exactly: `let go = ui.input(|i| i.key_pressed(Key::Enter))` and then `|| (go && first)` inside the per-hit loop, with `first = k == 0` — no highlight index, no arrow keys, Enter always fires the first filtered hit. The standard views are `small_button`s in the pane head with no bindings.
+
+#### F239 The first ten minutes: nine template names in a menu and a dropdown of words for a shape — `high` / `M` / competitor-parity
+
+**Problem.** A Matrix or RhinoGold user opens this app and finds no visual entry point at all. New-from-template is a text menu of nine names with hover blurbs. The signet outline — which is purely a shape — is chosen from a combo box of words, even though the profile panel already proves the app can draw a picker. There is no design browser, no thumbnail anywhere, and no way to see the 19 imported factory plans before choosing one.
+
+**Evidence.** crates/ringdesign-gui/src/panels/mod.rs:617-624 — the template menu is `ui.button(t.name).on_hover_text(t.blurb)`. crates/ringdesign-gui/src/panels/design.rs:861-899 — the outline picker is an `egui::ComboBox` listing `o.label()` and then custom/library names as text. CLAUDE.md notes `profile_row` already draws every profile entry "as its own little section", and `render::png_bytes` plus `examples/template_shots.rs` and `examples/profile_gallery.rs` already render galleries for eyeballing.
+
+**Do this.** Correct the premise: alpha raster thumbnails (`app.rs:692`) and drawn profile sections (`design.rs:597`) already exist — the app has the habit, it just has not applied it to the two places a first-time user actually starts. Highest value first and it is nearly free: draw each outline in the picker at `design.rs:861-899` with the same treatment `profile_row` gives sections — the `CustomOutline` polar table and the builtin `half_extent` tables are already there and drawing one is a polyline, no renderer involved. That alone makes the 19 imported factory plans browsable. Second: a Gallery pane of templates, recent designs, saved outlines and saved profiles as cards, thumbnails baked once by `render::png_bytes` and cached beside the file — `examples/template_shots.rs` and `examples/profile_gallery.rs` already produce exactly these images for eyeballing, so the renderer call is written.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Draw outline plans in the picker with the same treatment `profile_row` gives sections — the polar table is right there and drawing it is a polyline. Add a Gallery pane: templates, recent designs, saved outlines and saved profiles as thumbnail cards, thumbnails rendered once by `render::png_bytes` and cached beside the file (the CG preset gallery's `index.html` is the shape of it).
+
+</details>
+
+**Castability.** n/a.
+
+**Verified.** "No thumbnail anywhere" is wrong — two thumbnail systems already ship. Alphas have real raster thumbnails: `app.rs:692-705` `thumbnail()` caches an `egui::TextureHandle` per alpha from `Alpha::thumbnail_rgba8`, with `alpha_editor.rs:224-236` doing the same for previews and `export.rs:466` invalidating them. Profiles have drawn section thumbnails: `design.rs:597-626` allocates a 48x24 rect per row and draws the section into it (the `profile_row` the doctrine describes). Everything else in the finding is confirmed: `panels/mod.rs:617-624` is `ui.button(t.name).on_hover_text(t.blurb)` over `templates::all()`, and `design.rs:861-899` is an `egui::ComboBox` listing `o.label()` text for all of `SignetOutline::ALL` plus the on-design and library custom names as bare strings — for a picker whose entire content is a shape, with a 720-entry polar table sitting right there. No design browser, no template thumbnail, no outline thumbnail.
+
+#### F240 A fresh install has almost nothing in its libraries, and the shippable ones cannot grow — `high` / `L` / competitor-parity
+
+**Problem.** The asset rule is right and must stay: CrossGems-derived assets live only in user dirs. But the consequence is that a new machine gets 28 procedural patterns, 12 builtin outlines, nine profile presets and no gem meshes, while this machine has 342 alphas, 68 profiles, 19 outlines and 20 gem meshes that can never ship. The app's own README for the bundled alphas is already stale about it.
+
+**Evidence.** ~/.local/share/ringdesigner: 342 alphas, 68 profiles, 19 `CG *.outline.json`, 20 gems — all gitignored per .gitignore's `assets/`. crates/ringdesign-core/src/alpha.rs:619-648 — 28 `Procedural` variants are the entire shipped texture library. assets/alphas/README.md still says "The 16 built-in patterns are generated procedurally". graphs/templates holds nine graphs; templates.rs holds nine templates.
+
+**Do this.** Unchanged, and it is the finding that most changes what a new user sees. Commit the generator, never the pixels: a `tools/` recipe enumerating `ProcRecipe` knob combinations into a named catalogue, bundled with a manifest the way `graphs/templates/*.graph.json` are bundled by `include_str!` and pinned by a golden test. Two dependencies worth naming: this is the natural consumer of finding 10's mm-true `.pat` hatch source (a public, freely-licensed texture corpus at real stroke widths is the legitimate answer to "448 presets"), and of finding 11's cluster publishing (a first-party cluster set is library content too). Fix `assets/alphas/README.md:22` — it says 16 where the count is 28 — as part of it.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Build a first-party library deterministically and commit the generator, not the pixels: a `tools/` recipe that enumerates `ProcRecipe` knob combinations into a named catalogue of a few hundred textures, a set of our own drawn signet plans (the outline machinery takes any closed polyline and fairs it), and a first-party profile set derived from our own `DropCurve` family. Ship it as bundled data with a manifest, the way `graphs/templates` are bundled by `include_str!`. This is the legitimate answer to "448 presets" and it owes the archive nothing.
+
+</details>
+
+**Castability.** Every generated entry should be field-checked at generation time on a reference band, the way `templates.rs` already holds all nine to `analyze_field` — a catalogue that ships uncastable defaults is worse than a small one.
+
+**Verified.** Verified on this machine: `~/.local/share/ringdesigner/` holds 342 alphas, 68 profiles, 19 outlines and 20 gems, and `.gitignore:3` is a bare `assets/` so none of it ships. Against that, a fresh install gets: 28 `Procedural` variants (alpha.rs:619-648, counted), `ProfileStyle::ALL` presets, 12 builtin `SignetOutline` arms, 9 templates (`templates.rs`, 238 lines) and 9 committed template graphs. `assets/alphas/README.md:22` does say "The 16 built-in patterns are generated procedurally" — stale by 12. The asset rule itself is sound and must stay; the finding correctly attacks the consequence, not the rule.
+
+### M14 — Cast is a stage; bench is the next one (L, 12 findings)
+
+**Done when:** LayerEntry::stage is Cast | Bench; a mirrored intaglio on a 12 mm head renders its own wax negative; the engraver's sheet prints artwork mirrored at 1:1 with a depth column.
+
+#### F79 Surface finish is not modelled — `Finish` is only a metal colour — `high` / `M` / ornament
+
+**Problem.** The only thing in the codebase called `Finish` is a display RGB triple in the viewport. Nothing in the design says whether a surface is bright-polished, satin, brushed, sandblasted, Florentine, matte or oxidised, and nothing says WHERE — finish is region-wise in practice (satin flanks with a polished crest ribbon, oxidised recesses in a Greek key, a bright-cut edge). It never reaches the casting sheet, so the sheet a caster and finisher hold says nothing about the surface they are meant to produce.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/viewport.rs — `pub struct Finish { name, rgb }` (l.526-530) and `FINISHES` (l.531-557): seven alloy colours, doc'd "Rendering only; density stays in core." `grep -rn 'Finish\b' crates/` finds no other definition. /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/spec.rs `html()` (l.29-35) takes design/report/field/stones/dfm/provenance — no finish parameter, and the sheet has no finishing section.
+
+**Do this.** Add `RingDesign::finishes: Vec<FinishSpec>` with `FinishSpec { name, kind: FinishKind, window: Window }` — reuse `Window` + `VGate::SideFaces` verbatim so "satin the side faces, polish the crest ribbon" is two entries and needs no new gating code. `FinishKind`: BrightPolish, Satin, Brushed, Sandblast, Florentine, Hammered, Matte, Oxidised. Print it as a Finishing section in `spec.rs::html`, drive a per-region roughness in `render.rs` so satin reads differently from polish in the hero shot and the turntable, and add it as a configurator step (it is a real upsell and costs the customer nothing in castability). Keep the alloy `Finish` in viewport.rs as-is and rename one of the two — two things called Finish meaning colour and surface will bite.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `RingDesign::finishes: Vec<FinishSpec>` where `FinishSpec { name, kind: FinishKind, window: Window }` reuses the existing `Window`+`VGate` gating verbatim, so "satin on both side faces, polish the crest" is two entries. `FinishKind` should be the shop's own list: BrightPolish, Satin, Brushed, Sandblast, Florentine, Hammered, Matte, Oxidised. Print it as a "Finishing" section in `spec.rs::html`; drive the render's specular term from it in `render.rs` (a roughness scalar per region is enough to make satin read differently from polish); offer it as a step in the configurator, where it is a real upsell; expose it on MCP and as a graph node.
+
+</details>
+
+**Castability.** None — finish is post-cast surface treatment carrying no geometry, so it cannot touch the two-part pull. The only honest caveat to print on the sheet is that heavy sandblasting or a deep Florentine finish removes a few hundredths of metal, which matters on a feather edge already near `MIN_EDGE_MM`.
+
+**Verified.** Verified. The only `Finish` in the workspace is `viewport.rs` l.526-557: `struct Finish { name, rgb }` and seven alloy colours, doc'd "Display color per alloy family. Rendering only; density stays in core." `grep -rn finish` across ringdesign-core and ringdesign-cli returns only unrelated words (`Density::finish`, "finished piece", "finishing loss"). `spec.rs::html` (l.29-35) takes design/report/field/stones/dfm/provenance and prints no finishing section — the sheet a caster and polisher hold says nothing about the surface. The configurator has no finish step either.
+
+#### F86 Curve wires have one constant width — no swell, and no graver-angle V — `high` / `M` / ornament
+
+**Problem.** `CurveLayer` carries a single `width_mm` for the whole path plus a `taper` that only fades the two ends. Hand-cut scrollwork does not look like that: a graver line swells from a hairline tip to a fat belly and back, and that varying weight is precisely what makes a scroll read as engraved rather than extruded. Every scroll, vine and rail the app can make is a constant-width noodle. Separately, `WireProfile::Knife` is `1.0 - x` — a linear V — but its included angle is an emergent consequence of `width_mm` and `height_mm` rather than something a user can state, and a jeweller thinks in graver angles (90°, 105°, 120°) at a stated depth.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/curve.rs — `CurveLayer` (l.62-76: `points: Vec<[f64; 2]>`, one `width_mm`, `taper`); `WireProfile` (l.24-58) with `Knife => 1.0 - x`; presets `preset_scroll`/`preset_vine`/`preset_wave_rail` (l.95-136) all constant width.
+
+**Do this.** (a) Add `widths: Vec<f64>` parallel to `points`, interpolated by the same Catmull-Rom that already interpolates position, multiplying `width_mm` — a parallel vec beats widening the points to `[f64; 3]` because it serde-defaults to empty and every existing file stays byte-identical. Ship `preset_scroll` with a real belly-to-hairline swell; that one change is what makes the app's scrollwork stop reading as extruded noodle. (b) Add `WireProfile::Vee { included_deg }` with half-width derived as `height_mm * tan(included_deg / 2)` so the jeweller states the graver (90/105/120) and the depth. Under `Blend::Subtract` that is a true engraved V-groove with a stated wall angle — which means `analyze_field` can be asked directly whether a given graver angle pulls, and the answer becomes a doctrine table like the flute-lean one.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Two changes on the same struct. (a) Give the path per-point width: either widen the control points to `[f64; 3]` with a serde-defaulted third component, or add a parallel `widths: Vec<f64>` interpolated by the same Catmull-Rom that already interpolates position, multiplying `width_mm`. `preset_scroll` then ships with a real swell and instantly looks hand-cut. (b) Add `WireProfile::Vee { included_deg }` whose half-width is derived as `height_mm * tan(included_deg/2)`, so the user states the graver and the depth and the geometry follows — and under `Blend::Subtract` that is a true engraved V-groove with a stated wall angle the field verdict can be asked about directly.
+
+</details>
+
+**Castability.** Positive for the swell: a wire that thins toward its tips has gentler flanks there, and the doctrine's headline placement for a wire is already a side face (measured 0.000% at 0.5 mm relief) where flank angle is free. The V is the one to watch — a carved V on the crown is a pit, and a pit's walls are a dome's inverse, which the commissions example already measured as locking even at the crest. Ship `Vee` gated to side faces by default and let `analyze_field` enforce the rest.
+
+**Verified.** Verified. `CurveLayer` (curve.rs l.60-76) carries `points: Vec<[f64; 2]>` as `(x, v_mm)` and a single `width_mm`; `taper` is doc'd "Fraction of each end the wire tapers over, 0..0.5. Open paths only" — ends only, nothing in the middle. All three presets (`preset_scroll` l.94, `preset_vine` l.113, `preset_wave_rail` l.126) are constant width. `WireProfile` is Round/Flat/Knife (l.25-29) with `Knife => 1.0 - x` (l.56) — a linear V whose included angle is emergent from width_mm and height_mm and is stated nowhere. The working-tree diff to curve.rs adds only `land_on_side_face`, which does not touch width.
+
+#### F89 Paint mode has no guides, no pressure-to-width, and a subtly elliptical brush — `medium` / `M` / ornament
+
+**Problem.** The band brush resolves pressure to millimetres against the local draft ceiling, which is genuinely good. What it has no notion of is drawing discipline. There is no mirror across the band's centre line, no k-fold repeat-around-the-ring while drawing (the tiling layer has `kfold`, the brush does not), no snap to the side-face boundary (the layout grips have snapping, the brush does not), no straight-line or arc constraint, no stroke stabilizer, and undo is `strokes.pop()` — the last stroke, once, with no history. Pressure maps to DEPTH only, so the swelling line a graver makes is unpaintable by construction. And the brush disc is round in texel space: `stamp` corrects only for the alpha's pixel aspect (`ry = r * wf / hf`), while the band alpha is a fixed 2048x320 stretched over `circumference x band_v_len_mm`, so on a typical 6x2 flat band (55 mm x ~9.5 mm) a painted circle comes out about 10% elliptical.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/paint.rs — `ceiling_mm`/`wanted_mm`/`bite` (l.47-107), `BAND_W = 2048`/`BAND_H = 320` (l.39-40). /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/drawn.rs — `Stroke { points, radius, soft, erase }` (l.35-44, one radius for the whole stroke), `stamp` aspect correction (`let ry = r * wf / hf.max(1.0);`). /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/panels/unrolled.rs — `paint_interaction` (l.1270-1329, `s.push(nx, ny, b.alpha_value())`); `paint_bar` (l.1376-1430: size, depth, soft, erase, nothing else). `TilingLayer::kfold` exists at /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/tiling.rs l.170.
+
+**Do this.** Drop the multi-level-undo item — the app-wide `History` already covers strokes via `mark_dirty`. Keep the other three and put the guides in core so the desktop and the Android pen share one behaviour: a `PaintGuides { mirror_v: bool, kfold: u32, snap_side_face: bool }` resolved in paint.rs, emitting each sample once per fold and mirrored about `band_v_len_mm / 2` — `TilingLayer::kfold` (tiling.rs l.170) is the precedent the brush should match. Make `Stroke::radius` per-point (a parallel width list, serde-defaulted empty) and drive it from pressure alongside depth; that is the swell a graver line has and it is the same change finding 12 wants on curve paths. Correct `stamp`'s aspect against millimetres rather than texels by passing the ctx's `circumference_mm / band_v_len_mm` into it — today the brush is round on the canvas and elliptical on the ring.
+
+<details><summary>The auditor's original recommendation</summary>
+
+On `paint::Bite` or beside it, add a `PaintGuides { mirror_v: bool, kfold: u32, snap_side_face: bool }` resolved in core so the desktop and the Android pen share it: a stroke sample is emitted once per fold, mirrored about `band_v_len_mm/2` when asked. Make `Stroke::radius` per-point (`points: Vec<[f32; 4]>` or a parallel width list) and drive it from pressure alongside depth, which is what gives a painted line its swell. Correct the brush aspect against millimetres rather than texels by passing the ctx's `circumference_mm`/`band_v_len_mm` ratio into `stamp`. Keep a small stroke ring buffer for multi-level undo.
+
+</details>
+
+**Castability.** None new. Every guide emits ordinary strokes through the same `bite()` ceiling, already read from the local base draft, so mirrored and folded marks are clamped exactly as the original is. The mm-true aspect fix makes the drawn footprint match the metal footprint, which if anything sharpens the DFM granulometry measurement that already reads the band alpha.
+
+**Verified.** Substance verified; one sub-claim is wrong. Confirmed: `paint_bar` (unrolled.rs l.1376-1454) offers only size/depth/soft/erase/undo — no mirror, k-fold, snap, line or arc constraint, no stabilizer. `paint_interaction` (l.1270-1328) does one `s.push(nx, ny, b.alpha_value())` per sample with no folding, and the side-face snapping that exists at l.434-447 and l.527-545 is wired to the layout grips only, not the brush. `Stroke` (drawn.rs l.35-44) has one `radius` for the whole stroke and points are `[x, y, pressure]` where pressure becomes value, so a swelling line is unpaintable. `stamp` (l.156-176) sets `ry = r * wf / hf`, i.e. round in TEXELS: on a 2048x320 canvas over ~55 mm x ~10 mm the texel pitches differ by ~15%, so a painted circle is that much elliptical in metal. WRONG: "undo is strokes.pop() — the last stroke, once, with no history." The bar's button pops one stroke per click, repeatedly, and `bake_band` calls `app.mark_dirty()` (l.1345), which drives `History::touch`/`commit_if_settled` (app.rs l.400/506) — Ctrl+Z already undoes strokes as design history.
+
+#### F90 Two bundled fonts, no user font, no outlined lettering — `medium` / `S` / ornament
+
+**Problem.** `TextFont` is a closed two-arm enum with the faces baked in by `include_bytes!` — EB Garamond and Great Vibes. A shop doing monograms, house-style lettering or a client's wordmark cannot use its typeface at all. `fontdue` accepts arbitrary font bytes, so the limitation is the enum, not the renderer. Beyond the face: no bold or weight axis, no multi-line, no outlined/stroked letters (an outline letter with an engraved centre is the standard inside-shank and signet style), no per-letter placement around the ring, and no arch or fit-to-arc helper — a name that should curve with the band has to be placed as a single stretched raster.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/text.rs — `TextFont` (l.25-30), `TextFont::font()` (l.43-60) with `include_bytes!("../../../assets/fonts/EBGaramond.ttf")` and `GreatVibes-Regular.ttf`; `TextAlpha { name, text, font, tracking }` (l.63-70); `rasterize` lays one baseline row (l.85-152). GUI: /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/panels/library.rs `text_window` (l.74-178) — a two-item combo and a tracking slider.
+
+**Do this.** Add `TextFont::User { name: String, ttf_base64: String }` carried in the design, following the established precedent for non-regenerable assets — `SvgAlpha` carries its document and `library.rs` embeds referenced alphas as 16-bit PNG on save, so a `.ring.json` with a house typeface still opens on another machine. Gate the import behind a licence acknowledgement in the UI: embedding a commercial font inside a design file that gets emailed to a caster is a real licensing exposure, and the OFL faces were presumably chosen to avoid it. Then `outline_mm` on `TextAlpha` (free once `Alpha::outline_mm` exists, finding 14) — an outlined letter with an engraved centre is the standard signet and inside-shank style — plus multi-line text and an arc/fit-to-band helper, since a name that should curve with the band is today one stretched raster.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `TextFont::User { name: String, ttf_base64: String }` carried in the design exactly as `SvgAlpha` carries its document and as embedded alphas are carried as 16-bit PNG — the precedent for embedding a non-regenerable asset in the `.ring.json` is already established in `library.rs`. Gate the import in the UI with a licence acknowledgement, since redistributing a font inside a design file is a real licensing question the bundled OFL faces were chosen to avoid. Then add `outline_mm: f64` to `TextAlpha` (free once `Alpha::outline_mm` exists) and a multi-line `text`.
+
+</details>
+
+**Castability.** Neutral. A user font is rasterized and then measured by the same `min_feature_px` granulometry every other mask goes through, so a hairline-serif face on a 2 mm face will be flagged like any fine texture. Outlined lettering is castability-POSITIVE at small sizes: a stroke of stated width clears the detail floor where a solid glyph's serifs do not.
+
+**Verified.** Verified. `TextFont` (text.rs l.23-30) is a closed two-arm enum; `font()` (l.42-58) hard-codes `include_bytes!` of EBGaramond.ttf and GreatVibes-Regular.ttf. `TextAlpha` (l.61-70) is `{ name, text, font, tracking }` — no weight, no outline, no line list; `rasterize` (l.85-152) lays one baseline row. The graph node mirrors the limit (`nodes/alpha.rs::text` deserializes into the same two-arm enum), as does the GUI's two-item combo. fontdue takes arbitrary bytes, so the ceiling is the enum.
+
+#### F93 Model a post-cast bench stage, so seal engraving has somewhere to live — `critical` / `M` / signet-heads *(also found as F77)*
+
+**Problem.** The design model has exactly one stage: as cast. `RingDesign` (crates/ringdesign-core/src/lib.rs:70) is a profile, a shank, a `LayerStack` and draft settings, and every layer in that stack is judged by `castability::analyze_field`. A real signet is cast blank and then seal-engraved, bright-cut and hallmarked at the bench. Today any such feature is an ordinary layer, so the field verdict correctly calls it an undercut and the ring reads NotCastable — the app has no way to say "this is metal removed after the pour".
+
+**Evidence.** crates/ringdesign-core/src/lib.rs:70-101 (`RingDesign` fields, no stage/finishing concept); crates/ringdesign-core/src/field.rs:485-505 (`Layer`) and 274-311 (`Blend`, `Subtract` labelled "Carve"); crates/ringdesign-core/src/castability.rs:1022 (`analyze_field` walks every section built from the full stack); crates/ringdesign-core/src/spec.rs:29-118 (the casting sheet has Cast check, Dimensions, Casting weight — no bench-operation section). CLAUDE.md already states the conclusion ("the table is a dead-flat, zero-draft wall… it is blank and hand-engraved") but nothing in code enforces or exploits it.
+
+**Do this.** Unchanged in shape. Sharpen the insertion points: `LayerEntry::stage: Stage` with `#[serde(default)]` — the crate already uses that pattern for every added field (`soft_mm`, `window`, `mask`, `remap` all carry it), so no file migrates and no `format_version` bump is needed. The skip must go in `castability::section_at`/`analyze_field`'s section builder rather than in `mesh::build`, so the mesh and the STL still show the finished piece while the verdict ignores post-cast metal. Note this finding is the prerequisite for F2, F3, F4, F16 and F19 — land it first or those all inherit a NotCastable verdict.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `LayerEntry::stage: Stage { Cast, PostCast }` (serde default `Cast`, so no file migrates). `castability::analyze_field` and `castability::attribute_undercuts` skip `PostCast` entries; `dfm::findings_in` judges them against a *graver's* floor (0.1 mm) rather than `min_detail_mm`; `mesh::build` still displaces them so the render and the exported STL show the finished piece; `spec::html` grows a "Bench operations" section listing each with its depth in mm. This is the same shape as the existing `CastProcess` gate in `pave::halo` — construction switches on process — one level up.
+
+</details>
+
+**Castability.** None to the guarantee — it strictly narrows what the field verdict judges. The risk is the opposite one: a user marking a cast feature PostCast to silence a real undercut. Mitigate by printing every PostCast layer on the sheet and in the report panel, and by keeping the cast-only verdict visible beside the finished one.
+
+**Verified.** Verified. `LayerEntry` (crates/ringdesign-core/src/field.rs:727-748) is exactly name/enabled/blend/opacity/soft_mm/window/mask/remap/layer — no stage, no finishing concept. `RingDesign` (lib.rs:70-101) is profile/shank/layers/build/draft plus asset carriers; nothing names a manufacturing stage. `Blend` (field.rs:273-287) has `Subtract` labelled "Carve" but it is judged like every other layer. `spec.rs` prints Cast check / Dimensions / Casting weight / stones / provenance only. grep for `stage`, `post_cast`, `bench` across crates finds nothing.
+
+#### F94 Intaglio: a mirrored, recessed, wax-releasing seal cut — `critical` / `M` / signet-heads
+
+**Problem.** A signet's whole point is that it is a seal: the device is engraved in reverse and recessed so the wax impression reads correctly. The app supports none of it. `grep -i intaglio` across all crates returns nothing. A recess is mechanically reachable (`Blend::Subtract`), but there is no mirroring for text or tilings (only `Decal::flip`, which exists to *undo* the chart's own mirror on the low side face — see `compose.rs:357` and showcase.rs:236), no wall-angle control sized for wax release rather than sand release, and no depth convention.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1505-1517 (`Decal` — `flip` is documented "Mirror the stamp left-to-right", and the only consumers derive it from which side face the stamp landed on); crates/ringdesign-core/src/text.rs:62-80 (`TextAlpha` has name/text/font/tracking — no mirror); crates/ringdesign-core/src/field.rs:1593 `h = h.max(d.height_mm * s)` starting from `h = 0.0`, so a negative decal height is silently ignored — a decal cannot carve itself, it needs the entry blend; crates/ringdesign-core/src/alpha.rs:2715 `Alpha::flipped(axis)` already exists and nothing wires it to a seal; crates/ringdesign-core/src/alpha.rs:375 `draft_limited` bakes a cone opening but is written for *raised* relief (`relief_mm` scales value-per-texel upward).
+
+**Do this.** Unchanged, with two specifics from the code: (a) the mirror does not need a new alpha — `Alpha::flipped(Axis::X)` at alpha.rs:2715 is already there and already tested, so a seal can be one bake-time flip in the `bake_texts`/`bake_svgs` trio rather than a sampling change; (b) `draft_limited`'s signature already takes `mm_per_px` and `relief_mm`, so an inverted variant (or a sign on `relief_mm`) is a small change, not a new algorithm. Depends on finding F1 for the verdict to leave it alone.
+
+<details><summary>The auditor's original recommendation</summary>
+
+A `SealLayer` (or `DecalLayer::seal: bool` plus a stage flag): rasterize the motif, `Alpha::flipped(Axis::X)` it, carve it with `Blend::Subtract` at an authored `depth_mm` (0.3–0.8 mm is the trade range), and run `draft_limited` in the *inverted* sense so no recess wall is steeper than a chosen release angle — a wax impression wants 5–15° of opening on every wall, which is the opposite requirement from the sand's. Mark it `Stage::PostCast` by default. The mirror must be a property of the seal, not a checkbox the user has to reason about, because getting it wrong produces a ring that stamps backwards and no render will show it.
+
+</details>
+
+**Castability.** A recess cut into the table is genuinely uncastable in two-part sand and the field verdict is right to say so: the table's normal is radial, so it is a vertical wall, and both ±Z end walls of a pocket in it become undercuts (the same physics `examples/sketches.rs` measured as "a 0.2 mm dot 2 mm off the parting line leaned 14° on its near flank"). This is why the feature must arrive as a post-cast stage, not as cast geometry. Under `CastProcess::LostWax` it can be cast directly and the verdict should say which.
+
+**Verified.** Verified in detail. `grep -rni intaglio` across all crates, docs, graphs: zero hits. `Decal` (field.rs:1505-1517) is theta/v/size/rotation/height/flip; `flip` is applied as `lx = -lx` at field.rs:1577 and its only derivations are the side-face correction (configurator compose.rs:357 `flip: !low_face`, asserted at compose.rs:438). `TextAlpha` (text.rs:62-80) is name/text/font/tracking — no mirror. The auditor's mechanical claim is exactly right: `DecalLayer::height` starts `let mut h: f64 = 0.0` and ends `h = h.max(d.height_mm * s)` (field.rs:1563, 1594), so a negative `height_mm` is silently swallowed — a decal genuinely cannot carve itself. `Alpha::flipped(axis)` does exist (alpha.rs:2715, tested at 2342) and nothing wires it to a seal. `Alpha::draft_limited` (alpha.rs:375) takes `relief_mm` and is written for raised relief.
+
+#### F95 Wax-impression preview: render the negative — `high` / `M` / signet-heads
+
+**Problem.** Nothing renders what the seal will actually stamp. `render.rs` draws the metal; there is no negative/impression view, so a user authoring an intaglio has no way to check that the device reads correctly, that it is legible at size, or that the wax will release.
+
+**Evidence.** crates/ringdesign-core/src/render.rs:48-176 — `render`, `render_tinted`, `render_classed`, `render_ss`, `render_parts_ss`, `png_bytes`, `turntable_gif_bytes`. No impression, no inverted-height path. `grep -ri impression|wax` across crates returns only lost-wax process notes.
+
+**Do this.** Sharpen: the field is already sampled on a (theta, s) grid by `castability::analyze_field`, and `ShankStyle::head_at` returns the table's own `face: (f64, f64)` span per theta (profile.rs ~2103), so the footprint comes for free — no mesh needed, which matters because `render.rs` is the CPU rasterizer used by the CLI, tests and the wasm configurator alike. Ship it as `render::impression_png_bytes` (bytes first, `write_` wrapper second) to match the byte-writer/fs-writer split `library::design_json` / `gltf::to_glb` / `render::png_bytes` already follow — otherwise the browser configurator cannot show it.
+
+<details><summary>The auditor's original recommendation</summary>
+
+`render::impression_png(design, lib, head, size_px)`: evaluate the field over the table's own (u,v) footprint (the head's `face` span per theta is already computed by `ShankStyle::head_at`), negate the relief, and rasterize it as a heightmap lit from a low raking angle — wax reads as a shallow relief, so a normal-mapped grey render at 2:1 is exactly right and costs no mesh. Put it beside the hero shot in the GUI's File > Render menu, in the configurator's review step, and on the casting sheet.
+
+</details>
+
+**Castability.** n/a — a render, no geometry.
+
+**Verified.** Verified. `render.rs`'s whole public surface is `Part::metal`/`Part::stone`, `render`, `render_tinted`, `render_classed`, `render_ss`, `render_parts_ss`, `write_png_parts`, `png_bytes`, `write_png`, `turntable_gif_bytes`, `write_turntable_gif` (render.rs:38-166). Every one takes a `&Mesh`. `grep -rni impression` across crates: zero hits.
+
+#### F96 The engraver's sheet: mirrored artwork at scale, with depth — `high` / `S` / signet-heads
+
+**Problem.** There is a setter's sheet (`stonemap.rs`) and a parting-line sheet, but nothing for the engraver — who is the one other tradesperson every signet passes through. A hand engraver or a laser shop needs the device as line art at a stated scale, mirrored or not (stated explicitly), the table outline it must fit inside, and a depth spec.
+
+**Evidence.** crates/ringdesign-core/src/stonemap.rs:1-200 is the exact precedent — plan and unrolled chart at 2:1, every stone to scale, tight pairs called out, wired to File menu, MCP `export_stone_map`, CLI `--formats stonemap`, and the phone Share menu. Nothing analogous exists for the table.
+
+**Do this.** Unchanged. Two implementation notes: mirror `stonemap`'s exact shape — an `Option<String>` producer that returns `None` when the design has nothing to draw (it refuses a design that sets no stones) plus a thin `write_*` wrapper, because the CLI's `--formats stonemap`, the MCP tool and the phone Share sheet all key off that. And state the mirror direction explicitly on the sheet: the chart reads true from −Z (CLAUDE.md's showcase lesson), so "as engraved" vs "as stamped" is not decorative, it is the thing that stops a backwards seal.
+
+<details><summary>The auditor's original recommendation</summary>
+
+`sealsheet::write_seal_svg(design, lib)`: the table outline at 2:1 from `ShankOutline`/`head_at`'s `face` span, the seal motif inside it, both an as-engraved (mirrored) and an as-stamped view side by side, the depth in mm and the wall angle, and the head's L × W. Refuse a design with no seal layer, the way `stonemap` refuses a design that sets no stones. Wire it the same five ways.
+
+</details>
+
+**Verified.** Verified. The precedent is real and complete: `stonemap::stone_map_svg` / `write_stone_map_svg` (stonemap.rs:14, 154), and `castability::parting_line` / `write_parting_svg` (castability.rs:666, 704). Nothing analogous for the table. grep for `seal`, `engraver`, `sealsheet` across crates: nothing.
+
+#### F97 Monogram layout: interlocking initials, engraver's alphabets — `high` / `M` / signet-heads
+
+**Problem.** `text.rs` lays one straight baseline of glyphs with kerning and uniform tracking, in two bundled faces (EB Garamond serif, Great Vibes script). A monogram is not a word: two or three letters are scaled differently (the surname initial larger and centred), overlapped, interlocked, and often set on a circular or oval plan to fill the table. None of that is expressible, and neither block, Roman engraver's, nor Old English is available — those are the three alphabets a signet catalogue actually offers.
+
+**Evidence.** crates/ringdesign-core/src/text.rs:24-59 (`TextFont` — exactly two variants), 62-80 (`TextAlpha` — name, text, font, tracking), 100-160 (`rasterize` — one pen, one baseline, glyph bitmaps hung from `ymin`); MAX_TEXT_CHARS = 64. The GUI describes it as suitable for "a name, date or monogram" (crates/ringdesign-gui/src/panels/library.rs:358) but offers no monogram machinery.
+
+**Do this.** Unchanged. One correction of scope worth making explicit on the roadmap: the fonts are `include_bytes!`'d from assets/fonts (text.rs:44-53) and both are SIL OFL, so adding a block/slab and a blackletter is a licence check plus two constants, not a loader change. The layout work is per-glyph affine placement into the buffer `rasterize` already assembles from `fontdue::Metrics` — the machinery is there, the taste is the work.
+
+<details><summary>The auditor's original recommendation</summary>
+
+A `MonogramAlpha { letters: [char; 3], style: MonogramStyle, font: TextFont, overlap: f64, plan: OutlinePlan }` beside `TextAlpha`, baked by the same trio (`bake_drawn`/`bake_texts`/`bake_svgs`). Styles: Stacked (equal), Classic (centre letter larger — first, last, middle order), Interlocked (script strokes overlapping by `overlap`), Circular (letters fitted to the table's own plan via `SignetOutline::distance_norm`). Bundle two more OFL faces: a slab/block and an Old English blackletter. The layout is per-glyph affine transforms into the same raster buffer `rasterize` already builds — the hard part is the taste, not the code.
+
+</details>
+
+**Castability.** n/a as raster; carried as a post-cast seal it inherits that stage's rules. A *raised* monogram cast on the table is not castable in sand for the reasons in the intaglio finding — the generator should refuse it or mark it lost-wax.
+
+**Verified.** Verified. `TextFont` has exactly two variants — Serif (EB Garamond) and Script (Great Vibes) — with `ALL` listing both (text.rs:24-40). `TextAlpha` is name/text/font/tracking (text.rs:62-80). `rasterize` (text.rs:86-120+) lays one pen along one baseline with `horizontal_kern` and uniform `tracking`; every glyph hangs from the same baseline. `MAX_TEXT_CHARS = 64`. The GUI blurb at ringdesign-gui/src/panels/library.rs:358 does say "a name, date or monogram" with no monogram machinery behind it. `grep -rni monogram` returns only those two lines.
+
+#### F98 No crest library and no crest placement — `medium` / `M` / signet-heads
+
+**Problem.** A heraldic crest or a family device is the other half of the signet market, and there is no asset library, no placement helper, and no depth convention for one. SVG art already travels in the design (`svg.rs`, resvg) so the import mechanism exists — but with `<text>` elements deliberately unrendered and no crest-shaped workflow, a user importing a crest gets a generic decal they must size and place by hand against a table whose extent they cannot read off anywhere.
+
+**Evidence.** crates/ringdesign-core/src/svg.rs:35-41 (`SvgAlpha::is_empty` / `rasterize` — the whole public surface); crates/ringdesign-core/src/field.rs:1505-1553 (`Decal`/`DecalLayer` — theta, v, size, rotation, height, flip, feather); the shipped user asset library is signet *plans* only (~/.local/share/ringdesigner/outlines, 19 `CG *.outline.json`), no motifs.
+
+**Do this.** Unchanged, and the placement helper is cheaper than the auditor claims: `ShankStyle::head_at(...)` already returns the table span as `HeadAt::face` and `HeadAt::x` (profile.rs ~1562-1590, 2103), so `place_on_table` is a read of an existing return value, not new geometry. Ship the helper before the asset set — a live-tracking placement is what makes a crest survive a change to `length_mm` or `rise_mm`, and asset curation can follow. Keep the assets in `library::` user dirs, per the project's standing rule that nothing derived from proprietary material enters the repo.
+
+<details><summary>The auditor's original recommendation</summary>
+
+A `crests/` sibling of `outline_dir()` carrying SVG devices, and a `place_on_table(design, head, alpha)` helper that reads the head's own table extent (`ShankStyle::head_at(...).face`, already computed) and returns a `Decal` centred and sized to fit inside it with a stated margin — so the motif tracks the head when its length or rise changes. Ship a starter set (a shield charge, a lion, a wreath, a fleur-de-lis) as user assets under the same rule the CG plans follow.
+
+</details>
+
+**Castability.** Same as the monogram: post-cast, or lost wax if cast. The placement helper should ask the stage.
+
+**Verified.** Verified. `library.rs` declares `bundled_alpha_dir`, `user_alpha_dir`, `alpha_dirs`, `default_alpha_dir`, `default_design_dir`, `gem_mesh_dir`, `profile_dir`, `outline_dir` (library.rs:106-161) — no crest/motif directory. `assets/` holds alphas (README only), decoded, fonts, GH, User; no motif set. grep for `place_on_table`, `crest_dir`, `motif`: nothing.
+
+#### F108 The paint brush refuses the table, and can only raise — `high` / `M` / signet-heads
+
+**Problem.** Drawing directly on the head is the most natural gesture a signet user has, and the shared brush actively prevents it twice over. `paint::ceiling_mm` reads the *reference* band profile's local draft; on any signet (all templates use `Flat` + `flatten_sides`) the entire crown — which is the whole table — reads below `CREST_DRAFT_DEG`, so the ceiling is `CREST_RELIEF_MM` = 0.05 mm. And the brush only ever adds: `bite` returns a positive depth and `ensure_band_layer` creates a raising `TilingLayer` at `MAX_RELIEF_MM`. There is no carve mode, which is the only mode a table wants.
+
+**Evidence.** crates/ringdesign-core/src/paint.rs:47-62 (`ceiling_mm` — `ctx.surface.draft_deg(v)`, `CREST_RELIEF_MM = 0.05` below 20°, `MAX_RELIEF_MM = 1.6` above `SIDE_FACE_MIN_DRAFT_DEG`); 100-105 (`bite` — `depth_mm: wanted.min(ceiling)`, no sign, no mode); 108-150 (`ensure_band_layer` — a one-cell `TilingLayer` at `MAX_RELIEF_MM`, default blend). `ctx` comes from `design.field_context()`, built from the unmodulated `BandProfile` (crates/ringdesign-core/src/lib.rs), so it describes the shank's section, not the head's.
+
+**Do this.** Keep both halves, with the reasoning corrected. The carve mode is the substantive ask and it is uncontested: a graver removes metal, so `PaintMode::{Raise, Carve}` with a `Blend::Subtract` layer at `Stage::PostCast` (finding F1) is the only way to draw on a table at all — the 0.05 mm raise ceiling is *right* and should stay. The theta-awareness fix is separately worth doing but for the opposite case from the one stated: the ceiling currently describes the head's own section everywhere, so it is optimistic on the narrowed shank (down to 0.16 of the width), which is the unsafe direction. Route it through `design.modulation_at(theta, inner_r, crest_r)` — the function every modulated-section consumer already goes through — and this becomes the same correction finding F17 needs for tilings.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Two changes. (1) Make the ceiling station-aware: take a theta, read `design.modulation_at(theta, ...)` — the function every modulated-section consumer already goes through — and evaluate the draft on *that* section, so the head's flanks read as flanks and the table reads as a table. (2) Add `PaintMode::{Raise, Carve}`; a carve stroke creates a `Blend::Subtract` layer at `Stage::PostCast` with a graver-appropriate ceiling (0.3–0.8 mm) and a wall-angle limit for wax release. Show the mode in the brush bar next to the existing live mm readout.
+
+</details>
+
+**Castability.** The station-aware ceiling is strictly more honest than the current one — it can only tighten where the modulated section is flatter than the reference and loosen where the head's flank is a real face. The carve mode inherits the post-cast stage's rules.
+
+**Verified.** Both mechanisms verified; one supporting claim is inverted. Confirmed: `paint::ceiling_mm(ctx, v_mm)` (paint.rs:47-62) takes no theta and reads `ctx.surface.draft_deg(v_mm, ..)`, returning `CREST_RELIEF_MM = 0.05` below `CREST_DRAFT_DEG = 20.0` and `MAX_RELIEF_MM = 1.6` above `FREE_DRAFT_DEG = SIDE_FACE_MIN_DRAFT_DEG`. Confirmed: `bite` (paint.rs:100-105) returns `depth_mm: wanted.min(ceiling)` with no sign and no mode, `wanted_mm` is unsigned, and `ensure_band_layer` (paint.rs:108-150) creates a raising one-cell `TilingLayer` at `MAX_RELIEF_MM`. WRONG in the parenthetical: on a signet the unmodulated `BandProfile` *is* the head's cross-band extent (`profile.width_mm` is the head's width across the band, profile.rs:1321-1322) — the shank is the narrowed one — so the reference ctx misdescribes the *shank*, not the head. And the 0.05 mm table ceiling is correct for raised relief: the table's normal is radial, i.e. perpendicular to the ±Z pull, so proud relief there genuinely can undercut.
+
+**Merged into a canonical finding above:** F77 (There is no bench-work stage, so hand engraving is permanently inexpressible) -> F93.
+
+### M15 — The inside of the ring is a surface (L, 6 findings)
+
+**Done when:** v runs through the bore; a 0.15 mm inside inscription leaves a web the verdict reports; the bore still reads as vertical wall; both bore edges carry a >=0.2 mm break by default.
+
+#### F41 The bore is not displaceable, and the design file has nowhere to put an inside inscription — `high` / `M` / ring-typology *(also found as F78, F111, F220, F224)*
+
+**Problem.** Nothing can exist on the inside of the ring. Sizing beads, an arthritic bar, an inner comfort ridge, cast inner relief — all impossible — and, more immediately, the single most-ordered personalization in the trade, the inside engraving, has no field in the design file at all. Every wedding-band order carries one and it currently lives only in the customer's email.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:1156 `ProfileSample::surface` is "whether this vertex lies on the displaceable outer surface"; crates/ringdesign-core/src/mesh.rs:338 `let h = if p.surface && p.weight > 0.0 { ...soft_height... } else { 0.0 };` — the layer stack is never evaluated on bore samples. The one bore control is `ShankMod::bore_lift_mm` (profile.rs:2321) and profile.rs:831 clamps it `.clamp(0.0, ...)`, so the bore can only widen. crates/ringdesign-core/src/lib.rs:68 `RingDesign` has `name, size, profile, shank, layers, build, draft, drawn, embedded, texts, svgs, recipes, graph` — no inscription field, and spec.rs's sheet has no place to print one.
+
+**Do this.** Unchanged, and the split is the right one. (1) `RingDesign::inside_inscription: String` with `#[serde(default)]` (no format_version bump needed — an absent key reads empty, exactly as `graph` does at lib.rs:99), printed in `spec.rs::html` and on the stone map header. This is the cheap half and closes a real order-management hole; the configurator's order folder (`compose::Config`) should carry it too so the kiosk can sell it. (2) A `bore: bool` on `LayerEntry` gating evaluation on `!p.surface` samples, with the displacement clamped inward. Note the clamp at mesh.rs:356 is `r = r.max((inner_r + min_wall).min(p.r))` and is guarded by `if p.surface` — a bore layer needs its own opposing clamp against the *outer* surface, and it should reuse whatever comes out of finding 8's axial wall measure rather than inventing a second one.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Two separable pieces, smallest first. (1) `RingDesign::inside_inscription: String` (plus font/depth hints), printed on the casting sheet in `spec.rs::html` and on the stone map header, so the bench instruction travels with the file — this is a day's work and closes a real order-management hole. (2) Longer: a `bore: bool` on `LayerEntry` that lets the stack be evaluated on `!p.surface` samples with the displacement clamped inward against `MIN_WALL_MM`, unlocking cast sizing beads and inner relief. The bore is already reported as a vertical wall at any radius, so a bore feature costs nothing at the pull.
+
+</details>
+
+**Castability.** None for (1). For (2), the bore's normal is radial at any radius so a bore feature can never undercut a ±Z pull — the same argument that lets `hollow_mm` scoop the head. The only guard needed is the existing `MIN_WALL_MM` floor, applied inward instead of outward.
+
+**Verified.** Both halves confirmed. mesh.rs:338 `let h = if p.surface && p.weight > 0.0 { ...soft_height... } else { 0.0 };` — the layer stack is never evaluated on bore samples, and refine.rs:297-308 does the same. The only bore control is `ShankMod::bore_lift_mm` (profile.rs:2321), clamped non-negative at profile.rs:831, plus `BandProfile::comfort_fit_mm` — both widen only. On the file side: `RingDesign` (lib.rs:69-101) carries name, size, profile, shank, layers, build, draft, drawn, embedded, texts, svgs, recipes, graph — no inscription and no free-text/notes field of any kind. `grep -rn "inscription" crates/` finds only `text::TextAlpha` (a *relief* inscription rasterized into the alpha library, always applied to the outer surface) and the configurator's `engraving` which compose.rs:151 documents as "Raised inscription on the side face". `spec.rs::html` (spec.rs:29) prints the field verdict's notes (spec.rs:86) but has no author-supplied text.
+
+#### F135 The inside edge of the bore is a hard arris — there is no edge break where the ring meets the finger — `high` / `M` / sizing-fit
+
+**Problem.** The cross-section closes the bore span and starts the side wall at the same point with no fillet or chamfer between them. `side_b_start = [bore_r(b_lo), b_lo]` is pushed into `surface` and the flank runs radially outward from it; the only fillets built are at `corner_b`/`corner_t`, the *outer* edge. With `comfort_fit_mm = 0` that junction is exactly 90°; with the 0.25 default the bore's parabola meets it at about 80°. Every real ring has that corner broken — it is the edge that bites the finger and the edge that catches on a knuckle. Worse, the code already assumes the break exists: `FieldContext::side_faces` documents that "Each run starts where the fillet rolling out of the bore edge finishes" and skips `MIN_SIDE_FACE_MM` of `v` for a fillet the section never builds. The repo's own reference measurement contradicts the geometry too: the bought heart signet's STEP has 0.2 mm edge breaks, and its dihedral census finds "0.0 mm of ≥15° creases anywhere except its bore edge break".
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:863-864 (`side_b_start`, `side_t_end`), 1069-1080 (`surface.push(side_b_start)` … `surface.push(side_t_end)`, fillets pushed only at `corner_b`/`corner_t`), 923-931 (`er` is the crown/side fillet); profile.rs:548-551 (`flatten_sides` zeroes side draft and shrinks the outer fillet — and is what the configurator's WideBand, Split and both signet bases call, compose.rs:214, 241, 249); crates/ringdesign-core/src/field.rs:203-223 and the constant `MIN_SIDE_FACE_MM = 0.45` at field.rs:147; CLAUDE.md's reference census section "The head has one edge, and it is the face outline".
+
+**Do this.** Unchanged, and note it is a doctrine correction as well as a feature: `field.rs:203-207`'s comment is currently false and should be fixed either way. Add `BandProfile::bore_break_mm` (serde-default 0.15, range 0-0.5) built in `sample_spaced` as a quarter-arc between the bore span's last point and `side_b_start`/`side_t_end`, capped by `(edge_t - comfort - MIN_EDGE_MM)` exactly as `lift` already is at profile.rs:831. Push both tangency points into `feats` (the vec at profile.rs:880) so a sample row snaps onto them the way the outer fillet's do at profile.rs:1077. Then make `FieldContext::side_faces`' `skip` read the real break width instead of the `MIN_SIDE_FACE_MM` placeholder. Under a head, crossfade it away with `head_w` the way `er` does at profile.rs:926, since a lofted head's bore is already the loft's own four-row dip.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `BandProfile::bore_break_mm` (default 0.15, range 0–0.5) and build it in `sample_spaced` as a quarter-arc between the bore span's last point and the flank's first, on both edges, clamped by `(edge_t − comfort − MIN_EDGE_MM)` the way the hollow's `lift` already is. Push both tangency points into `feats` so `sample_spaced` snaps a sample row onto them (the same treatment the outer fillet gets), and make `side_faces`' `skip` read the real break width instead of `MIN_SIDE_FACE_MM`. Under a head, blend it with `head_rim_mm` the way `er` already does.
+
+</details>
+
+**Castability.** None, and it slightly improves the pull. The break's surface normals rotate from radial (bore, reported as vertical wall) toward axial (side face, perfect draft), passing only through angles that already exist on the section; it removes metal at a convex corner and cannot create a ceiling. It costs a sliver of side-face width, which `side_faces` should account for rather than assume.
+
+**Verified.** Verified in the section assembly. `profile.rs:863-864` builds `side_b_start = [bore_r(b_lo), b_lo]` and `side_t_end = [bore_r(b_hi), b_hi]`, and `profile.rs:1068-1078` pushes `side_b_start` straight into `surface` then the flank, with `push_fillet` called only at `corner_b`/`corner_t` using `er_b`/`er_t` (profile.rs:923-931) — the OUTER edge. No arc, no chamfer at the bore junction. Grepped `--include="*.rs"` for `bore_break|edge_break|chamfer` across all crates: the only hits are `Remap::chamfer` (a relief profile remap in field.rs:1487), alpha.rs's distance-transform helper, and prose comments. The auditor's second point is confirmed too: `field.rs:203-207` documents "Each run starts where the fillet rolling out of the bore edge finishes" and `field.rs:222` skips `MIN_SIDE_FACE_MM = 0.45` (field.rs:147) of v for a fillet the section never builds — the code comment describes geometry that does not exist.
+
+**Merged into a canonical finding above:** F78 (Nothing can be engraved inside the shank) -> F41, F111 (There is no inside surface, so hallmarks and inside engraving are impossible) -> F41, F220 (A ring cannot carry a hallmark, a fineness stamp or an inside inscription — in the model or on the order) -> F41, F224 (Bring the bore into the chart so a ring can be engraved inside) -> F41.
+
+### M16 — Patterns get knobs and a seed (L, 14 findings)
+
+**Done when:** All 28 builtins expose their defining parameter plus a seed; the same seed rebuilds byte-identical geometry; a rope rail measures a real over/under stroke >= min_detail_mm at 2.7 mm cells.
+
+#### F75 Unfreeze the builtin patterns: per-pattern parameters and a seed — `critical` / `M` / ornament
+
+**Problem.** All 28 builtin patterns have their defining parameter hardcoded inside the generator function, and the only knobs a user gets are a whole-number multiplier, a quarter turn, gamma and invert. Rope is always 3 cords with 6 twists, Rosette always 9 rings and 12 lobes, Starburst always 24 rays, Florentine always 24 hatch lines, GuillocheWeave always 4 rows x 4 cycles, Honeycomb always 4x4 cells, Beads always 8x8. The noise-based patterns (Hammered, Bark, Nugget, Voronoi, Feather) call hash01/fbm with literal seed constants (11, 23, 37, 101, 301, 5501...), so there is exactly one Hammered texture in existence — absurd for a finish whose entire appeal is that no two pieces are alike. Worse, ProcRecipe::rasterize does `self.kind.at(frac(x*reps), frac(y*reps))` with `reps = repeats.clamp(1,6)`, so a recipe can only ever pack MORE periods into a tile. There is no way to make any builtin coarser than its author wrote it, which is exactly the operation the sand's detail floor demands.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/alpha.rs — `Procedural` enum (l.619-648, 28 arms); `ProcRecipe` (l.800-811: name/kind/repeats/quarter_turns/gamma/invert only); `ProcRecipe::rasterize` (l.827-853, `let reps = self.repeats.clamp(1, 6)`); generator fns `rope` (`let cords = 3.0; let twists = 6.0;`), `rosette` (`let rings = 9.0; let lobes = 12.0;`), `starburst` (`let rays = 24.0;`), `florentine` (`let n = 24.0;`), `guilloche_weave` (`let rows = 4.0; let k = 4.0;`), `honeycomb` (`let (cols, rows) = (4i64, 4i64);`), `hammered` (`hash01(mx, my, 11)`/`37`). GUI: /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/panels/library.rs `recipe_window` slider `1..=6`. Graph: /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-graph/src/nodes/alpha.rs l.111 documents "Periods per tile, 1..64" — the core clamps at 6, so the node's own doc is wrong.
+
+**Do this.** Add `ProcParams { primary: f64, secondary: f64, seed: u64 }` with a `Procedural::defaults()` table, change the generator signature to `fn rope(x, y, p: &ProcParams)`, and add `params: ProcParams` (serde-defaulted) to `ProcRecipe`. Replace the `repeats: u32` clamp with a `periods` figure that can go BELOW 1 for the non-lattice patterns (the coarsening direction the sand floor needs) while staying integer for the lattice ones (Honeycomb, Beads, Lattice, Trellis, Pyramids, Argyle, Diamonds) where the count is the seamlessness guarantee. Fix `nodes/alpha.rs::proc_`'s 1..=64 validation in the same change — today it accepts values the core silently clamps to 6. Extend `every_pattern_tiles_seamlessly` to sweep the parameter ranges, and re-run `examples/pattern_floor.rs` per parameter so the sand table is per-setting, not per-pattern.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `Procedural` a per-kind parameter block. Concretely: change the generator signature from `fn rope(x, y) -> f64` to `fn rope(x, y, p: &ProcParams) -> f64` where `ProcParams { primary: f64, secondary: f64, seed: u64, .. }` carries defaults per kind from a `Procedural::defaults()` table, and add `params: ProcParams` to `ProcRecipe` (serde-defaulted so existing files stay byte-identical). Replace `repeats: u32` with a rational `periods: f64` clamped to a range the seamlessness argument still permits — for the lattice patterns (Honeycomb, Beads, Lattice, Trellis, Pyramids, Argyle, Diamonds) the period count IS the integer that makes the tile close, so exposing it directly is both the coarsening knob and the seamlessness guarantee in one field. For the non-lattice ones (Rosette, Starburst, Florentine, Moire) the count is an angular or hatch count that periodicity does not constrain. `every_pattern_tiles_seamlessly` must then sweep the parameter ranges, not just the defaults.
+
+</details>
+
+**Castability.** Neutral to positive. Nothing here touches h(u,v)'s composition or the base profile, so the superellipse drop guarantee and every side-face 0.000% result are untouched. What must be preserved is tile seamlessness: keep the lattice patterns' period counts integral, keep quarter turns as turns, and extend `every_pattern_tiles_seamlessly` to sweep the parameter ranges. Coarsening a pattern strictly IMPROVES castability — it raises the finest feature above the detail floor and widens every wall.
+
+**Verified.** Verified. `Procedural` (alpha.rs l.617-648) is 28 arms; `Procedural::at` dispatches to zero-argument `fn kind(x, y)` generators, and every defining constant is a literal inside them: `rope` l.953 `cords = 3.0; twists = 6.0`, `rosette` l.1360 `rings = 9.0; lobes = 12.0`, `starburst` l.1395 `rays = 24.0`, `florentine` l.1410 `n = 24.0`, `guilloche_weave` l.1423 `rows = 4.0; k = 4.0`, `honeycomb` l.1288, `hammered` l.1123 with `hash01(mx, my, 11)` / `23`. `ProcRecipe` (l.800-811) carries only name/kind/repeats/quarter_turns/gamma/invert, and `rasterize` l.828 does `self.repeats.clamp(1, 6)` then `self.kind.at(frac(x*reps), frac(y*reps))` — periods can only be multiplied, never divided. No seed field anywhere. NEW FACT the audit only half-caught: the divergence is a live bug, not just a stale doc — `nodes/alpha.rs::proc_` l.33-36 *rejects* `repeats` outside `1..=64` with an error, so a graph author can set 40, pass validation, and silently get 6.
+
+#### F76 Wire `dfm::fit_to_floor` into the app — the fix for the finding the app already prints — `high` / `S` / ornament
+
+**Problem.** `dfm::findings_in` measures every tiling and stamp by granulometry and tells the user "they will cast as mush. Coarsen the pattern, use fewer repeats, or accept the softness." The solver that computes the correct repeat count in closed form — `dfm::fit_to_floor` returning `FloorFit::{Repeats, NeedsTallerCell, Unmeasurable}` — exists in the working tree and is called from nothing but two examples. No GUI button, no MCP argument, no graph node, no CLI flag. The user is told the problem and handed no lever; the panel's neighbouring control (`side_face_fit`) proves the pattern for exactly this kind of one-click fitter.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/dfm.rs — `FloorFit` (l.385-394), `fit_to_floor` (l.396+), message text at l.111-117 and l.155-160. `grep -rn 'fit_to_floor|FloorFit' crates/` finds callers only in /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/examples/pattern_floor.rs and .../examples/patternbands.rs (both untracked). Contrast: /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/panels/layers.rs l.804 `side_face_fit(ui, t, fctx)` — the existing one-click fitter.
+
+**Do this.** Add a `Fit to sand` button beside `side_face_fit` in `panels/layers.rs::tiling`, dispatching on the `FloorFit` result: `Repeats(n)` sets the count and reports it in the status line; `NeedsTallerCell { min_cell_h_mm }` says "this mask needs a %.1f mm face — widen the band or drop a row" without touching the layer. Add the same as a graph node `layer.fit_to_floor(tiling, floor_mm) -> tiling`, as a boolean argument on the MCP `add_tiling`/`set_layer` path, and as a line in `ringdesign check`. Make the DFM warning badge itself the button.
+
+**Castability.** None — it only ever coarsens a pattern or refuses to act. Fewer repeats means larger features and wider walls, which strictly improves the two-part pull. The layer's placement, v-span and relief are untouched, so no side-face guarantee moves.
+
+#### F80 The graph has alpha sources but no alpha operators — `high` / `M` / ornament
+
+**Problem.** `nodes/alpha.rs` registers six nodes and all six are SOURCES: proc, text, svg, drawn, png, library. There is not one operator — no crop, levels, mirror, rotate, resize, flip, auto-trim, edge-fade, make-seamless, distance-field, draft-limit, and no boolean or arithmetic between two masks. Every one of those either exists in core (`Alpha::crop/levels/rotated/flipped/mirror_tile/edge_fade/resized/auto_trim/normalized/make_seamless/signed_distance_px/draft_limited`) or is a few lines from it. So the app's programmable authoring layer — the thing that is supposed to make composition repeatable — cannot process a mask at all. Mask work is trapped inside one modal GUI window.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-graph/src/nodes/alpha.rs `register` (l.104-162): exactly `alpha.proc`, `alpha.text`, `alpha.svg`, `alpha.drawn`, `alpha.png`, `alpha.library`. The core ops sit unused by the graph in /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/alpha.rs l.2651-2851 (`crop`, `content_bounds`, `auto_trim`, `flipped`, `rotated`, `mirror_tile`, `edge_fade`, `levels`, `resized`, `renamed`, `seam_error`).
+
+**Do this.** Register an `alpha.*` operator family taking `AlphaRef` in and `AlphaSource` + `AlphaRef` out, one node per existing core method — the `AlphaSource` value kind and `design.assemble`'s baking already carry it, so this is registry work with no new machinery. Order the work by payoff: `alpha.levels`, `alpha.crop`, `alpha.rotate`/`flip`, `alpha.mirror_tile`, `alpha.edge_fade`, `alpha.make_seamless` (finding 7), then the three that need core work first — `alpha.offset_mm`, `alpha.outline_mm`, `alpha.boolean` (finding 14). Ship a bundled cluster that does the sand-safe import chain end to end (import, trim, seamless, offset to clear the floor, tile on the side face), since that is the sequence every imported ZBrush alpha needs and nobody should re-wire it.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add an `alpha.*` operator family taking `AlphaRef` in and `AlphaSource`+`AlphaRef` out, one node per existing core method, plus three that do not exist yet and should: `alpha.offset(mm)`, `alpha.outline(mm)`, `alpha.boolean(a, b, op)`. The `AlphaSource` value kind already exists and `design.assemble` already bakes sources, so the plumbing is in place — this is registry work, not new machinery. Once it lands, "take the Greek Key, dilate it 0.2 mm so it clears the sand floor, subtract a border mask, tile it on the side face" is a graph, and a cluster anyone can reuse.
+
+</details>
+
+**Castability.** None directly; these are mask operations upstream of the height field. The one to be careful with is `alpha.offset`/`outline`, whose output must still go through the layer's own `edge_mm`/`draft_limited` path or it can raise a vertical wall — the same caution that already applies to any imported texture.
+
+**Verified.** Verified exactly. `grep -n 'NodeSpec::new("alpha' crates/ringdesign-graph/src/` returns six lines, all in nodes/alpha.rs: proc, text, svg, drawn, png, library — every one a source. No operator node in any other file either. The core methods sit unused by the graph: alpha.rs l.2658 `crop`, 2679 `content_bounds`, 2707 `auto_trim`, 2715 `flipped`, 2733 `rotated`, 2756 `mirror_tile`, 2781 `edge_fade`, 2808 `levels`, 2825 `resized`, 2844 `renamed`, 2852 `seam_error`, plus 260 `normalized`, 282 `make_seamless`, 334 `signed_distance_px`, 375 `draft_limited`. MCP has no alpha-op tool either (resources.rs only reads `ring://alpha/{name}`).
+
+#### F82 Draft-limiting a texture is a destructive one-shot bake instead of a layer property — `medium` / `S` / ornament
+
+**Problem.** `Alpha::draft_limited` — the operation that opens every wall in an imported texture to a chosen angle so no cliff locks in the sand — is invoked from the layer panel as a bake: it computes the drafted copy at the CURRENT cell size and relief, inserts it into the library under "<name> drafted", and repoints the layer at it. The bake does not track later edits, so the moment the user changes `repeats_around`, `v_span_mm` or `height_mm` the drafted alpha is limiting to the wrong angle, silently. It also litters the shared library with derived copies that then appear in every picker.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/panels/layers.rs l.708-726: `if let Some(deg) = bake_draft { ... a.draft_limited(deg, mm_per_px, t.height_mm.max(1e-6)) ... app.library_mut().insert(baked); t.alpha = name; }`. /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/alpha.rs `draft_limited` (l.375-449) takes `mm_per_px` and `relief_mm` — both derived from the layer, both mutable after the bake. Contrast the SDF, handled correctly as a derived product: layers.rs l.699-707 re-derives `signed_distance_px` "the moment the control moves".
+
+**Do this.** Replace the bake with `TilingLayer::max_wall_deg: Option<f64>` (serde-defaulted `None`), derived and cached exactly where the SDF is at panels/layers.rs l.699-707 — keyed by content like `sdf_name`, never persisted, so it re-derives whenever cell size or relief moves and the library stays free of `"<name> drafted"` copies that pollute every picker. That also makes it a graph pin and an MCP field for free. Add the same field to `DecalLayer`, where the risk is higher: an imported stamp is the likeliest source of a vertical wall and today has no limiter of any kind.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Replace the bake with `TilingLayer::max_wall_deg: Option<f64>` (serde-defaulted `None`) applied where the SDF is applied — derived on load and whenever the layer changes, keyed by content like `sdf_name`, never persisted. That makes the drafted texture track cell size and relief automatically, keeps the library clean, and lets the value be a graph pin and an MCP field. Extend the same knob to `DecalLayer`, which today has no draft limit at all even though an imported stamp is the likeliest source of a vertical wall.
+
+</details>
+
+**Castability.** This IS a castability mechanism, and today it degrades silently under editing. Making it live is a strict improvement: the wall angle stated on the layer becomes the wall angle in the metal at any cell size, which is the same guarantee `edge_mm` makes for bevel width.
+
+**Verified.** Verified. panels/layers.rs l.708-726: `if let Some(deg) = bake_draft` computes `mm_per_px` from `t.cell_size(&fctx)` and `t.height_mm`, calls `a.draft_limited(deg, mm_per_px, ...)`, inserts the result into the shared library and repoints `t.alpha` at it. `draft_limited` (alpha.rs l.375) takes both figures as arguments, and both change freely afterwards via `repeats_around`, `rows`, `v_span_mm` and `height_mm` — nothing re-bakes. The correct pattern is 9 lines above it, l.699-707: the SDF is re-derived on every dirty edit precisely so it tracks. `grep -rn 'draft_limited|max_wall_deg' crates/` outside alpha.rs finds only that one call site. Confirmed too that `DecalLayer` (field.rs l.1539-1547: alpha, decals, feather_mm, invert) has no draft limit and no `edge_mm`/SDF mode at all.
+
+#### F84 Milgrain is one bead in one row, with no pitch check — `medium` / `S` / ornament
+
+**Problem.** `MilgrainLayer` is `{ v_mm, bead_diameter_mm, beads_around, height_mm, mirror }`, and `mirror` only mirrors to the opposite side of the band. There is no double row (the standard finish on a bezel or a wide band edge), no twisted milgrain, no bead-on-a-rail (a bead wire on a raised edge — the commonest real construction). The DFM footprint reads only the bead DIAMETER: `FeatureFootprint::round(l.bead_diameter_mm, ...)`. The GAP between beads — `circumference/beads_around - bead_diameter` — is never measured, so a 0.45 mm bead at 400 around on a 55 mm ring has a negative gap, merges into a plain rail, and the checker says nothing. The count is also chart arc, so on a side face at k≈0.85 the real pitch is 15% tighter than the panel implies.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/field.rs — `MilgrainLayer` (l.1993-2000), `beads_at` (l.2023-2039, `let pitch = ctx.circumference_mm / n;` with no arc scale), `feature_footprints` Milgrain arm (l.586-591, `FeatureFootprint::round(l.bead_diameter_mm...)`). The arc-scale mechanism it should use is `FieldContext::arc_scale` (same file, l.115+).
+
+**Do this.** Add `rows: u32` and `row_pitch_mm: f64` (serde-defaulted 1 and 0 — no file migrates) and place `rows` lines at `v_mm + (i - (rows-1)/2) * row_pitch_mm`, each still mirrored by the existing flag. Emit a second `FeatureFootprint` for the bead gap so the merge flags — note the merge is a fill finding, not a draft one: overlapping hemispheres just become a scalloped rail, they do not lock. Show the metal pitch in the panel as `circumference * arc_scale(v) / beads_around`. Add a `Milgrain on rail` add-menu preset (a Group of a `BorderLayer` plus a milgrain row at the same `v`) — that is the standard bead-wire edge and today it takes two manual layers to build.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `rows: u32` and `row_pitch_mm: f64` to `MilgrainLayer` (serde-defaulted 1 and 0, so nothing migrates) and place `rows` bead lines at `v_mm + (i - (rows-1)/2) * row_pitch_mm`, each mirrored as today. Emit a second `FeatureFootprint` for the bead gap so the merge case flags, and show the metal pitch in the panel as `circumference * arc_scale(v) / beads_around` rather than the chart figure. Separately, a `Milgrain-on-rail` add-menu preset emitting a Group of a `BorderLayer` rail plus a milgrain row at the same `v` gives the standard bead-wire edge in one click.
+
+</details>
+
+**Castability.** Beads on the crest line are already measured safe and beads off-crest are the measured 4.8%/−37° hazard the showcase recorded, so extra rows must not wander off the parting line on a domed band. Guard it the way the app already does: default the added rows onto a side face when one exists, and let the field verdict speak. The gap check is a fill rule, in the `min_section_mm` voice, not a draft rule.
+
+**Verified.** Verified. `MilgrainLayer` (field.rs l.2011-2017) is exactly `{ v_mm, bead_diameter_mm, beads_around, height_mm, mirror }`; `height` (l.2032-2038) places one row and, if `mirror`, one copy at `band_v_len_mm - v_mm` — no second row on the same edge, no twist, no rail. `beads_at` (l.2042) computes `let pitch = ctx.circumference_mm / n` with no `arc_scale`, so the panel's pitch is the chart figure and the metal one is ~15-20% tighter on a side face (the measured k table). The footprint (l.589-594) is `FeatureFootprint::round(l.bead_diameter_mm.max(0.1), ...)` — diameter only; the gap `circumference/beads_around - bead_diameter` is never computed, and dfm.rs's own test (`fine_beads_flag_and_coarse_ones_pass`, l.255-276) only ever varies the diameter, so nothing pins the merge case.
+
+#### F85 `BorderProfile::Rope` is a fake rope, and the rail vocabulary is thin — `high` / `S` / ornament *(also found as F232)*
+
+**Problem.** `BorderProfile::Rope` is a single round rail whose crest migrates side to side as `u` advances — the comment says so outright: "A round rail whose crest spirals: the bead migrates across the rail as u advances, giving a twisted-wire read." It has one continuous crest, so it never shows the parting between strands that makes a rope read as rope, and at any real relief it looks like a wavy wire rather than a twist. CLAUDE.md's own shelf lists "honest rope rail" as outstanding. Beyond that, the rail family is Round / Flat / Knife / Step / Rope — missing the wires a bench actually solders on: twisted 2- and 3-strand, beaded wire, gallery wire, square wire, half-round wire, and a coin-edge rim.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/field.rs — `BorderLayer::rail_at`, `BorderProfile::Rope` arm (l.959-967): one `dome(xr)` with `offset = 0.45 * phase.sin()`. `BorderLayer` fields (l.911-921). CLAUDE.md M9 shelf, l.190-192: "honest rope rail".
+
+**Do this.** Promote the shelved item and give it the construction: replace the Rope arm with `BorderProfile::Twist { strands: u32 }` taking the max over `strands` cords whose centres orbit the rail axis at `TAU * (twists * u / C + s / strands)`, each shaded by its own `cos` phase so the front strand reads in front — exactly what `alpha::rope` (l.953-964) and `alpha::braid` (l.967+) already do in 2D, lifted onto the rail. Seamlessness is unchanged because `rope_twists` is already `u32`. Then add `Beaded` (the `MilgrainLayer` bead law along the rail — this is the same one-click bead-wire edge finding 10 asks for), `Square`, `HalfRound` and `Gallery`; each is a two-line `shape(x)` on machinery that already exists. Check each new arm on a domed crest as well as a side face — the off-crest-rail lesson in the templates test applies to every one of them.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Replace the Rope arm with `BorderProfile::Twist { strands: u32 }`: take the max over `strands` round cords whose centres orbit the rail's axis in `v` at `2*pi*(twists*u/C + s/strands)`, each cord shaded by its own `cos` phase so the strand in front reads in front — exactly the construction `alpha::rope` and `alpha::braid` already use in 2D, lifted onto the rail. It stays seamless because `rope_twists` is already `u32`. Then add `Beaded` (the `MilgrainLayer` bead law along the rail), `Square`, `HalfRound` and `Gallery` as further arms; each is a two-line `shape(x)` on the same rail machinery.
+
+</details>
+
+**Castability.** Low and checkable. A multi-strand twist has real valleys between the strands, and a valley between two proud crests is the two-flange case the doctrine warns about — so it must go on a side face, or stay shallow enough on a crest that each strand's flanks are still monotone drops from the rail's own crest. Use round cords (never circular sections, per the `WireProfile::Round` cosine-dome lesson) and pin it with a field-verdict test at several strand counts and reliefs, the way the Wave swing cap was calibrated.
+
+**Verified.** Verified. `rail_at`'s Rope arm (field.rs l.962-970) is one `(1 - xr*xr).sqrt()` dome whose centre is displaced by `0.45 * phase.sin()` — a single continuous crest that wanders across the rail, with the comment saying so. There is no second strand and therefore no parting between strands. `BorderProfile` is Round/Flat/Knife/Step/Rope (labels at l.902-909); `BorderLayer` (l.914-925) carries v_mm, width_mm, height_mm, profile, mirror, rope_twists. ALREADY ON THE SHELF: docs/ROADMAP.md l.191 lists "honest rope rail" among the M9 Shelf items — keep it, but it is planned, not unnoticed.
+
+#### F87 The pattern vocabulary's real holes, named — `high` / `M` / ornament
+
+**Problem.** The 28 builtins cover the woven, cellular and engine-turned families well. What is missing is commercially significant, and each item is a self-contained generator. Mokume-gane / damascus grain: absent, and it is a top-selling look; it is a contour of the fbm the file already has. A TRUE Celtic knot: `celtic_knot` is two diagonal band families with parity-swapped over/under — a plait, not a knot; there is no closed interlace, no triquetra, no Dara or Trinity knot, and a customer ordering a Celtic band expects exactly those. Norse/Urnes interlace and a runic alphabet: absent. Islamic/Moorish star tessellation (8- and 12-fold): absent, and it tiles on a square lattice by construction. Western ramshorn and bright-cut scroll: absent. Filigree curl: absent. Wriggle/wiggle line: absent. Sunburst/fan Art Deco: absent (Argyle, Lattice and GreekKey cover only the rectilinear half of deco).
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/alpha.rs — the full `Procedural::ALL` (l.651-680): Rope, Braid, Basketweave, Chevron, Herringbone, Scales, GreekKey, CelticKnot, Floral, Hammered, Waves, Diamonds, Beads, Feather, Bark, Nugget, Rosette, Barleycorn, Moire, Starburst, Florentine, GuillocheWeave, Voronoi, Trellis, Honeycomb, Pyramids, Argyle, Lattice. The `celtic_knot` fn is documented "Two diagonal band families interlacing, the under band ducking at crossings" — a plait. `fbm`/`value_noise`/`hash01` already exist (l.1072-1105) and are periodic by construction.
+
+**Do this.** Add them as `Procedural` arms, and make every one carry its period count and seed as `ProcParams` from day one (finding 1) rather than shipping more frozen generators. Order by commercial value: Mokume first — `1 - |2*frac(fbm(x, y, px, py, 4, seed) * layers) - 1|` gives laminated contour bands, periodic because `value_noise` already wraps at its lattice, and the seed makes every billet unique, which is the whole appeal; then CelticKnot proper (keep the existing plait as strand geometry, add a per-crossing break table — the three- and four-strand ring knots are a small fixed table each); then `IslamicStar { fold }`, `Scrollwork` (which is also the alpha the finding-12 swell makes read correctly), `Wriggle`, `Fan`. Gate each on `every_pattern_tiles_seamlessly` AND a `pattern_floor` sand table before it ships — several of the existing fine-line generators would have been caught by that second gate.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add as `Procedural` arms, in value order: (1) `Mokume` — `(1 - |2*frac(fbm(x,y,px,py,4,seed) * layers) - 1|)` gives laminated contour bands, periodic because `value_noise` wraps at its lattice, so seamlessness is inherited; pair with the seed knob so every ring's billet is unique. (2) `CelticKnot` proper — keep the existing plait as the strand geometry and add a per-crossing break table so strands close into a knot; the classic three- and four-strand ring knots are a small fixed table each. (3) `IslamicStar { fold }` — a k-fold rosette of chords on a square lattice, 8-fold being the standard. (4) `Scrollwork` — a ramshorn spiral instanced on a lattice, also the alpha the CurveLayer swell makes read correctly. (5) `Wriggle` — a zigzag walked along a line, the classic wiggle cut. (6) `Fan` — the deco sunburst. Every one carries its period count as a parameter from day one, and every one goes through `every_pattern_tiles_seamlessly` and the `pattern_floor` sand table before it ships.
+
+</details>
+
+**Castability.** Each must be judged on the sand table before shipping. Mokume is a contour field with gentle slopes and is a natural side-face texture; Islamic star and Fan are convex-cell reliefs like Honeycomb and Pyramids, already proven safe; Wriggle and Scrollwork are fine-line patterns that will very likely land below the detail floor in sand and belong on the Bench stage or on lost wax — which is the honest answer, not a reason to omit them.
+
+**Verified.** Verified against the full `Procedural::ALL` (alpha.rs l.651-680) — 28 arms, and none of mokume/damascus, a closed Celtic knot, Norse/Urnes interlace, runes, Islamic star tessellation, ramshorn/bright-cut scroll, filigree curl, wriggle, or a deco fan is among them. The CelticKnot read is craft-accurate: `celtic_knot` (l.1075-1090) is two diagonal band families `(x+y)*4` and `(x-y)*4` with over/under chosen by `(a.floor() + b.floor()).rem_euclid(2)` — a plait, exactly as its own doc says, with no closure and no break table. The noise machinery mokume needs is present and periodic: `hash01` l.887, `value_noise` l.901 (takes `px`/`py` lattice periods), `fbm` l.920.
+
+#### F88 No mm-true mask morphology and no booleans between masks — `high` / `M` / ornament
+
+**Problem.** The alpha editor's fixed op chain is `crop -> auto_trim -> rotate -> flip -> mirror_tile -> edge_fade -> levels -> resize`. Two operations pattern work actually needs are absent everywhere: (a) morphology — dilate, erode, open, close, and an offset/outline stated in MILLIMETRES on the band, the operation that turns a mask whose strokes measure 0.06 mm into one whose strokes measure 0.35 mm and therefore casts; (b) booleans between two library alphas — union, intersect, difference — the only route to composing a motif from parts. Both are close to free: `Alpha::signed_distance_px` already computes an exact, x-wrapped EDT, so a mm-true dilate is `threshold(sdf, +r)` and an outline is `threshold(|sdf| < r)`. CLAUDE.md's own shelf lists "mm-true mask morphology" as outstanding.
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-gui/src/alpha_editor.rs module doc l.1-9 and `Ops` (l.50-62) — the complete list of available operations. /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-core/src/alpha.rs `signed_distance_px` (l.334-366, exact EDT over a 3x-wide buffer) and `min_feature_px` (l.472+, already bisecting on that distance field for granulometry). CLAUDE.md M9 shelf l.190-192. Note the EDT tiles 3x in x only (`let w3 = w * 3`), so a `rows > 1` tiling's v-seam is not wrapped.
+
+**Do this.** Promote the shelved item, and wire it to the DFM finding rather than shipping it as a standalone editor toy — that is the difference between a nicety and the fix. Add `Alpha::offset_mm(r_mm, mm_per_px)` and `outline_mm` as thresholds on the existing SDF, plus `Alpha::boolean(&other, op)` with nearest-resample onto the larger grid. Then offer `offset_mm` as the SECOND fix beside `fit_to_floor` (finding 2) in the DFM chip: "bolden the art by 0.14 mm" preserves a motif where "use fewer repeats" destroys it, and the exact figure falls straight out of the granulometry measurement the finding already made. Surface all three in the editor chain and as `alpha.*` nodes (finding 6). Add an opt-in y-wrap to `signed_distance_px` while in there, so a multi-row tiling's bevel is correct at the v seam.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `Alpha::offset_mm(r_mm, mm_per_px)` and `Alpha::outline_mm(r_mm, mm_per_px)` on the existing SDF, plus `Alpha::boolean(&other, op)` with nearest-resample onto the larger grid. Surface all three in the editor's op chain, as `alpha.*` graph nodes, and — the payoff — wire `offset_mm` into the DFM finding as a second offered fix beside `fit_to_floor`: "bolden the art by 0.14 mm" is often the right answer where "use fewer repeats" would destroy the motif. While in there, make the EDT wrap in y as well when the caller asks, so a multi-row tiling's bevel is correct at the v seam.
+
+</details>
+
+**Castability.** Directly improves it — a dilated mask has thicker strokes and wider gaps, exactly what the sand's detail floor asks for. Morphology preserves the mask's topology at small radii, so nothing new is introduced that `draft_limited` and the field verdict were not already watching.
+
+**Verified.** Verified. The complete `Alpha` operation set is crop/content_bounds/auto_trim/flipped/rotated/mirror_tile/edge_fade/levels/resized/renamed/seam_error (alpha.rs l.2658-2852) plus normalized/make_seamless/signed_distance_px/draft_limited/min_feature_px — no dilate, erode, open, close, offset, outline, or any two-alpha operation. The editor's chain is the fixed eight (alpha_editor.rs l.1-9). The enabling machinery is confirmed present: `signed_distance_px` (l.334-366) is an exact EDT, and `min_feature_px` (l.472) already bisects on it for granulometry. The 3x-in-x claim is exact — l.340 `let w3 = w * 3` tiles x only, so a `rows > 1` tiling's v-seam is genuinely unwrapped. ALREADY ON THE SHELF: docs/ROADMAP.md l.190-191 lists "mm-true mask morphology".
+
+#### F177 The tiling editor never says how big a cell is in millimetres, which is the number the sand cares about — `high` / `S` / ux-workflow
+
+**Problem.** `dfm::findings_in` measures each tiling's mask by granulometry at the layer's own mm-per-texel and reports things like "Greek Key on 2.7 mm cells measures 0.06 mm strokes". That finding surfaces as a warning triangle on the layer row and a line in the report — after the fact. While the user drags "Around" from 24 to 60 the editor shows only the integer count. Neither the cell size in mm, nor the measured finest stroke, nor the sand's detail floor is anywhere near the control that decides them.
+
+**Evidence.** crates/ringdesign-gui/src/panels/layers.rs:807-825 (the "Around" DragValue, tooltip is about seamlessness only) and :1897-1957 (`side_face_fit`, which reports face widths but not cell size); the badge at layers.rs:420 `dfm.iter().find(|f| f.layer == i)`; `TilingLayer::cell_size` and `Alpha::min_feature_px` both exist in core; CLAUDE.md's own worked examples are all stated as "X mm strokes on Y × Z mm cells".
+
+**Do this.** Unchanged. The plumbing is one line short: `t.cell_size(&fctx)` at layers.rs:711 already computes what the readout needs, and layers.rs:712 already derives mm-per-texel the same way `dfm::findings_in` does. Put the live line under the lattice grid (after layers.rs:819) and multiply the `u` figure by `FieldContext::arc_scale(v_center)` so it reads metal rather than chart — the same correction `bridge_at` and `pave::fill` already apply. Cache the `Alpha::min_feature_px` call by content, as dfm.rs does, so a DragValue drag does not re-run granulometry per frame.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Under the lattice grid, print one live line: `cell 2.71 × 1.83 mm · finest stroke 0.06 mm · sand floor 0.30 mm`, coloured by whether it clears `design.draft.min_detail_mm`, using `arc_scale` so the figure is metal and not chart. Badge the library's tile thumbnails the same way against the selected layer's current cell size, so the choice is informed at pick time rather than judged afterwards. Cache the granulometry by content as `dfm` already does.
+
+</details>
+
+**Castability.** n/a — a fill/detail matter, not a pull matter, but it is the difference between a crisp pattern and mush.
+
+**Verified.** Confirmed. `t.cell_size(&fctx)` appears exactly once in the whole GUI — layers.rs:711 — and there it feeds `Alpha::draft_limited`'s mm-per-px for the draft-limit bake; it is never displayed. The "Around" DragValue (layers.rs:807-819) has a tooltip about seamlessness only. `side_face_fit` (:1896-1955) reports face widths in mm but no cell size. Grepping `min_feature_px|min_detail_mm` across the GUI returns only app.rs:530 (the as-cast soften radius) and design.rs:1301 (the DraftSettings slider) — the granulometry measurement never reaches a control, only the after-the-fact DFM badge at layers.rs:420.
+
+#### F233 Hatch patterns at a true millimetre pitch, instead of resolution-dependent strokes — `high` / `M` / competitor-parity
+
+**Problem.** Every imported texture is a raster whose stroke width in millimetres is an accident of how it was drawn and how big the cell is — which is precisely why the shipped templates measure 0.04–0.10 mm strokes against a 0.3 mm floor. CrossGems drives its whole hatch family from AutoCAD `.pat` files, which are vector definitions carrying real spacing in drawing units. Our own converter throws that scale away.
+
+**Evidence.** tools/harvest/pat_convert.py:24-33 — it takes the *median* dash spacing, invents `world = min(max(4*s_med, 2.0), 40.0)` millimetres for the tile, and rasterizes with `stroke = max(2, px // 170)` — a pixel count, not a width. crates/ringdesign-core/src/tiling.rs:151-155 — `edge_mm` is mm-true precisely because it reads the SDF, which shows the pattern is already available but only for the bevel, not the stroke. CLAUDE.md records Greek Key at 0.15 mm strokes as "simply not usable on narrow faces in sand".
+
+**Do this.** Unchanged, and lead with the pairing: `dfm.rs`'s granulometry already *reports* sub-floor strokes on the shipped templates (Waves 0.10 mm, Chevron 0.07 mm, Braid 0.04 mm), so a mm-true hatch source is the other half of a loop that is currently open — measure, but never able to fix. Rasterize at the owning layer's own mm-per-texel at bake time so `stroke_mm` is a manufacturing parameter; keep the tile world-size from the `.pat`'s own drawing units rather than the `4*s_med` invention. Note the licensing angle explicitly: `.pat` is an open documented format with large free public libraries, so this is the legitimate route to a big texture catalogue that owes the archive nothing — which makes it the natural partner to finding 17.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `AlphaSource::Hatch { pat: String, angle_deg: f64, pitch_mm: f64, stroke_mm: f64 }` that rasterizes at the owning layer's own mm-per-texel at bake time, so the stroke is a manufacturing parameter rather than an artifact. `.pat` is an open, documented format with large free public libraries, so this is also the legitimate route to a big texture catalogue that owes nothing to the archive.
+
+</details>
+
+**Castability.** Strictly improving: the DFM granulometry check keeps working unchanged, and the strokes it measures now match what was asked for.
+
+**Verified.** Verified. `tools/harvest/pat_convert.py:27-33` does exactly what is claimed: `s_med` is the median of `abs(f[4])` across families, `world = min(max(4.0*s_med, 2.0), 40.0)` invents a tile size in mm from it, and `stroke = max(2, px // 170)` is a pixel count with no mm meaning — the drawing-unit scale in the `.pat` is discarded. `tiling.rs:151-155`'s `edge_mm` is the proof the mm-true machinery already exists but is spent only on the bevel, reconstructing height from the exact x-wrapped EDT; nothing does the equivalent for the stroke itself. `ProcRecipe` (alpha.rs:800-811) carries `repeats`, `quarter_turns`, `gamma`, `invert` — no stroke or pitch in mm. `docs/ROADMAP.md:190` lists "mm-true mask morphology" on the Shelf, which is adjacent but not the same thing (that measures an existing mask; this authors one at a known scale). `dfm::findings_in`'s granulometry already measures the consequence, so the app can already tell you the stroke is 0.06 mm — it just cannot let you ask for 0.35 mm.
+
+#### F234 The cluster library loop is dead code — nothing can publish a cluster or a preset — `high` / `S` / competitor-parity
+
+**Problem.** Reusable clusters with parameter panels are the reason a Grasshopper or Matrix power user stays. The runtime supports them properly — a cluster carries its graph, exposed pins are typed from the inner spec, presets set them, user files shadow bundled ones — and the editor can even fold a selection into a cluster node. But the final step, saving that cluster to the library so it appears in the palette next time, is unreachable from every frontend.
+
+**Evidence.** crates/ringdesign-graph/src/file.rs:118-125 and 213-220 define `save_cluster_in`/`save_cluster`/`save_preset_in`/`save_preset`; a grep across `crates/` for those names finds no caller outside that one file. crates/ringdesign-graph/src/graph.rs:402 `Graph::collapse` makes a node in the current graph only. crates/ringdesign-mcp/src/graph_tools.rs:568-591 exposes `graph_list_clusters`, `graph_add_cluster`, `graph_apply_preset` — read and use, never write. graphs/clusters holds two entries; graphs/presets holds two.
+
+**Do this.** Unchanged. The one-line framing for the roadmap: collapse-to-cluster already ships and is reachable from two places in the GUI; the only missing edge is collapse-to-*library*, which is a call to a function that already exists and is already tested. Wire `save_cluster` to a "Save as cluster…" item next to the existing Collapse button at `gui/panels/graph.rs:26`, and add `graph_save_cluster`/`graph_save_preset` beside the three read-only cluster tools at `mcp/graph_tools.rs:568-591`. Then seed `graphs/clusters` from `templates.rs` builders the way `build_signet_cluster` was built — eternity run, gypsy pavé field, cabochon bezel band, keyframed lobed band, side-face engraving, hollowed signet, bypass solitaire — and pin each to its code builder byte-for-byte like the nine template graphs already are.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Wire `save_cluster`/`save_preset` to a "Save as cluster…" item on the graph pane's node menu (taking the current selection through `collapse`, then writing it) and to `graph_save_cluster`/`graph_save_preset` MCP tools. Then seed `graphs/clusters` with a first-party set built from `templates.rs` builders the way the signet cluster was: eternity run, gypsy pavé field, cabochon bezel band, keyframed lobed band, side-face engraving, hollowed signet, bypass solitaire.
+
+</details>
+
+**Castability.** n/a — the SandRing mode gate already refuses `NotCastable` on file-writing sinks and validates Free-only nodes through a cluster boundary.
+
+**Verified.** Verified. Grepping `save_cluster|save_preset` across all of crates/ returns eight hits, all inside `ringdesign-graph/src/file.rs` itself: the four definitions (118, 124, 213, 220) and two test call sites (287, 302). No frontend caller anywhere. The rest of the loop is genuinely complete: `Graph::collapse` is wired to a real GUI button (`gui/panels/graph.rs:26-27`, `app.collapse_nodes`) and to a node context-menu item (`graph-ui/editor.rs:949-950` "Collapse with upstream into a cluster"), and reading is wired on MCP (`graph_list_clusters`, `graph_add_cluster`, `graph_apply_preset`). `graphs/clusters` holds exactly two files (signet, vine-semi-mount); `graphs/presets` exactly two (cushion-signet, heart-signet). So a user can fold a selection into a cluster and use it in that one graph, and then it dies with the file.
+
+#### F235 No node in the graph can produce a Path — `high` / `M` / competitor-parity
+
+**Problem.** Four node pins take a `Path` — a wire's guide, a custom outline's boundary, an extrusion polygon, a revolve section — and not one node anywhere emits one. Every path in every graph must therefore be typed in as a literal list of pairs. A power user cannot compute a guide, sweep a family of outlines, or drive a wire from a measurement, which is most of what a dataflow tool is for.
+
+**Evidence.** grep for `ValueKind::Path` across crates/ringdesign-graph/src/nodes returns five hits, all `input(...)` or `field(...)`: layer.rs:275 (wire points), layer.rs:527, shank.rs:206 (custom outline boundary), solid.rs:294 and solid.rs:300. A grep for `output(PinSpec::item(..., ValueKind::Path` returns nothing.
+
+**Do this.** Keep, and add the cheap unblock first: `value.rs`'s coercion table already turns `Json` into `Path` (value.rs:253) but not `List<List<Number>>`, and `ringdesign-script`'s `from_dynamic` returns nested `List` for a rhai array-of-arrays — so adding that one coercion arm makes every existing `series`/`math`/`script` node a path source overnight, before a single new node exists. Then add the `path.*` family as proposed (`from_xy`, `circle`, `arc`, `sine`, `polygon`, `resample`, `offset`, `transform`) — `path.resample` should reuse `CustomOutline::from_points`'s arc-length densify so an imported and a computed outline get the same treatment. This unblocks four pins at once, including `outline.custom`, which is how a computed signet plan would ever be authored.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a `path` family: `path.from_xy` (two number lists to a path — the implicit-list idiom makes this the workhorse), `path.circle`/`path.arc`, `path.sine`, `path.polygon`, `path.resample` (arc-length, the same densify the outline importer uses), `path.offset`, `path.transform`. Ten small nodes, all pure, all list-native.
+
+</details>
+
+**Castability.** n/a — paths feed existing constructions whose guarantees are unchanged; `CustomOutline::from_points` already fairs and contains whatever it is given.
+
+**Verified.** Verified. `ValueKind::Path` appears at exactly five pin sites across `ringdesign-graph/src/nodes/`, all inputs: `layer.rs:275` (wire guide), `layer.rs:527` (curve preset points), `shank.rs:206` (custom outline boundary), `solid.rs:294` (extrude polygon), `solid.rs:300` (revolve section). Dumping every registered node kind (~150 of them) confirms no `path.*` family and nothing whose output could be one. One route the finding missed, and it is worth stating because it changes the fix: `value.rs:218/253` DOES coerce `Json -> Path` via `serde_json::from_value::<Vec<[f64;2]>>`. But `List -> Path` is not in the coercion table, and a rhai array-of-arrays comes back from `from_dynamic` (script/lib.rs:127-131) as a nested `Value::List`, not `Json` — so a script node still cannot hand a computed path to a Path pin. The negative stands.
+
+#### F236 No randomness anywhere, and no scatter generator — `medium` / `M` / competitor-parity
+
+**Problem.** There is no seeded random number, no noise, and no scatter generator in the entire product. Organic pavé, jittered hammering, irregular nugget fields and blue-noise stone scatters are all impossible, and the CrossGems catalogue has a whole cluster (Random_Positions, Random_Gem_Sizer) and a solver stack devoted to exactly this. The shelf already carries a blue-noise scatter measured clean on a side face and it has not been picked up.
+
+**Evidence.** The full registered node list (grep of `NodeSpec::new` across crates/ringdesign-graph/src/nodes) has no `random`, `noise` or `scatter` entry. crates/ringdesign-core/src/pave.rs:556-560 — `GenRecipe` is `Pave | Halo | Channel` only. docs/ROADMAP.md:190 lists "blue-noise scatter generator" on the Shelf; the batch6-8 note records it as verified BUILD, measured 0.0000% on a side face.
+
+**Do this.** Drop "no randomness anywhere" — `alpha::hash01` already seeds the Hammered/Nugget/Voronoi family. Reframe as two concrete gaps. (a) `ProcRecipe` has no `seed` field, so the existing noise is frozen: one `u32` added at alpha.rs:800 and threaded into the `hash01` calls gives every procedural texture a variation knob, and it is the smallest change in this whole audit with a visible result. (b) The real absence is placement randomness: no `random.number`/`random.points` node with an explicit seed pin, and `GenRecipe::Scatter(ScatterSpec)` doing Poisson-disc in the chart with `bridge_mm` as the disc radius, emitting the same live `Group` of seats `pave::fill` does. Take `PinnedSeat`'s lock semantics unchanged and keep the wrap-exact rule for a full-ring scatter; explicitly do not import their relaxation solver, per the doctrine note. On the Shelf as "blue-noise scatter generator".
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `random.number` and `random.points` with an explicit `seed` pin (so a graph is deterministic and a design file reproduces), and `GenRecipe::Scatter(ScatterSpec)` doing Poisson-disc placement in the chart with `bridge_mm` as the disc radius, emitting the same live `Group` of seats the pavé packer does. Take the lock semantics from `PinnedSeat` unchanged and, as CLAUDE.md already warns, do not import their relaxation — a scatter that must close round the ring keeps the wrap-exact rule.
+
+</details>
+
+**Castability.** A scattered gypsy mound is the same monotone mound the packer already places, so the guarantee is inherited; the wrap must stay exact at `u`'s seam or the scatter reads as a visible join.
+
+**Verified.** "No randomness anywhere" is overstated: `alpha.rs:887` `hash01(ix, iy, seed)` is a deterministic value-noise hash and it drives Hammered, Nugget, Voronoi and the jittered lattices (alpha.rs:1133-1141 uses it for both position jitter and per-cell depth). So irregular hammering and nugget fields *are* available as textures. Everything else in the finding checks out and is more damaging than the headline: `ProcRecipe` (alpha.rs:800-811) exposes `repeats`, `quarter_turns`, `gamma`, `invert` and **no seed**, so every user gets the same hammering forever and two rings in a collection cannot differ; the full registered node list has no `random`, `noise` or `scatter` kind; `GenRecipe` (pave.rs:556-560) is `Pave | Halo | Channel` only. `docs/ROADMAP.md:190` lists "blue-noise scatter generator" on the Shelf.
+
+**Merged into a canonical finding above:** F232 (An honest rope rail, instead of a raster rope the sand cannot hold) -> F85.
+
+### M17 — Many combinations, one grid (L, 7 findings)
+
+**Done when:** A variant grid renders with stones in the chosen metal, each cell carrying its own field verdict encoded by shape as well as hue, with the size ladder as an axis.
+
+#### F168 There is no variant explorer at all — the owner's "many combinations" has no tool — `critical` / `L` / ux-workflow
+
+**Problem.** The stated goal is "many different variations — patterns, signet shapes, many combinations of things". The app offers exactly one comparison affordance: the Ghost, a single manually-pinned snapshot drawn translucent. There is no randomise, no fork, no A/B/C, no favourites, no variant grid, no gallery of N renders, no way to sweep a parameter. A jeweller exploring "which of my six outlines, on which of my four profiles" must edit, look, undo, edit, look — twenty-four round trips through a 90 ms debounce and a mental note.
+
+**Evidence.** grep for `variant|randomi[sz]e|shuffle` across crates/ringdesign-gui/src returns only `egui_phosphor::Variant` and an alpha-editor local; `app.pinned` (crates/ringdesign-gui/src/app.rs:163) is the whole comparison story; docs/ROADMAP.md:195 parks "comparison views beyond the ghost" in the M9 Niceties list.
+
+**Do this.** Unchanged in substance, with the sweep axes grounded: `SignetOutline::ALL` and the outline library (`library::list_outlines`), `ProfileStyle`, `ShankKind`, `app.lib.names()` for the alpha, and `Graph::exposed` on a driven design. Model the batch on examples/gallery.rs, which already builds N designs, renders each via `render_parts_ss` and judges each with `attributed_field_report` — lift that loop into a `PaneKind::Variants` rather than writing it again. Promote it off the M9 Niceties line: it is the direct answer to the owner's stated goal, not a nicety.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a `PaneKind::Variants` grid. It needs no new geometry: snapshot the design, enumerate a sweep over one or two axes (a `ShankKind`/`ProfileStyle`/`SignetOutline` enum, an alpha name from the library, or — on a graph-driven design — an exposed parameter's range via `Graph::exposed`), build each on the existing worker at preview resolution, and draw each as a `render::render_ss` thumbnail with its `analyze_field` verdict dot. Click adopts; shift-click pins as the ghost; a star writes the design into `designs/favourites/`. Every piece — the pure `compose`-style design construction, off-thread building, the software rasterizer, the field verdict — already exists and is already used together in `examples/showcase.rs` and `examples/collection3.rs`, which are literally this feature run from the command line.
+
+</details>
+
+**Castability.** Each variant carries its own field verdict, so the grid can grey out or badge the ones that will not pull — turning exploration into a teaching surface rather than a hazard.
+
+**Verified.** Confirmed. Grepped `variant|randomi|shuffle|favourite|compare|a/b` across crates/ringdesign-gui/src — the only hits are `egui_phosphor::Variant`, an alpha-editor test-local `variants` array, and unrelated prose. `app.pinned: Option<RingDesign>` (app.rs:165-168, set at :349, cleared at :338) is the entire comparison story. Already parked on the roadmap: docs/ROADMAP.md:195-197 lists "comparison views beyond the ghost" under M9 Niceties — keep it, but it is a known want, not a discovery. The audit's claim that every ingredient already exists is correct: `render::write_png_parts`/`render_parts_ss` are used together with `gems::preview_mesh` and `attributed_field_report` in examples/gallery.rs:199-214, collection3.rs:87-92 and sketches.rs:67-75.
+
+#### F169 Hero renders and turntables leave the stones out, though core is built to include them — `high` / `S` / ux-workflow
+
+**Problem.** `render.rs` was deliberately given a `Part` list "because a finished piece is metal *and* stones and the stones are never in the `Mesh`", with `render_parts_ss` / `write_png_parts` and `gems::preview_mesh` promoted to core for exactly this. The desktop's File ▸ Render PNG and File ▸ Turntable GIF call the single-mesh `write_png` / `write_turntable_gif` on `out.mesh` alone. So a jeweller renders a graduated diamond eternity band and gets a row of bare metal bumps. The viewport shows the stones; the exported picture does not.
+
+**Evidence.** crates/ringdesign-gui/src/export.rs:167-205 (`write_png(&path, &out.mesh, ...)`, `write_turntable_gif(&path, &out.mesh, ...)`); crates/ringdesign-core/src/render.rs:108 `render_parts_ss`, :125 `write_png_parts`, :20 doc comment; crates/ringdesign-core/src/gems.rs:38 `preview_mesh`; crates/ringdesign-core/examples/collection3.rs renders with stones already.
+
+**Do this.** As proposed, plus: add `render::turntable_gif_parts` / `write_turntable_gif_parts` beside the existing `_parts` functions (they do not exist), and fix `nodes/sink.rs:310-314` the same way so a graph-driven render is not a second silently-stoneless path. In `export_render`/`export_turntable` (export.rs:180,200) build `vec![Part::metal(&out.mesh, tint)]` and push `Part::stone` from `gems::preview_mesh(&job.design, &job.lib)`, gated on `app.show_gems` (app.rs:38, already snapshotted into the job at app.rs:97). Same in the configurator's `order_files` (main.rs:311-313).
+
+<details><summary>The auditor's original recommendation</summary>
+
+In `export_render` and `export_turntable`, build `vec![Part::metal(&out.mesh, tint)]` plus `gems::preview_mesh(&job.design, &job.lib).map(Part::stone)` and call the `_parts` writers, gated on `app.show_gems` so the toolbar toggle governs the render the way it governs the viewport. Add a `turntable_gif_parts` alongside `turntable_gif_bytes`. Do the same in the configurator's `order_files` for `hero.png` and `turntable.gif`.
+
+</details>
+
+**Castability.** n/a — stones are render-only and never enter the mesh or the verdict.
+
+**See also.** F213 is the same defect at the order pipeline's five render sites (M23).
+
+**Verified.** Confirmed and wider than reported. `export_render` (export.rs:180) calls `render::write_png` on `out.mesh`; `export_turntable` (export.rs:200) calls `write_turntable_gif` on `out.mesh`. `render::Part` (render.rs:21-46), `render_parts_ss` (:108) and `write_png_parts` (:125) exist and are used *only* by examples (gallery, collection3, sketches, patternbands, obj_render). There is no `turntable_gif_parts` — confirmed by reading the `pub fn` list of render.rs. Two more offenders the audit did not name: the graph's `sink.render` (crates/ringdesign-graph/src/nodes/sink.rs:310-314) renders `mesh` alone, and `ExportJob::snapshot` already carries both design and lib, so `gems::preview_mesh` is available inside the job closure at no extra cost.
+
+#### F170 The casting sheet has no picture of the ring — `high` / `M` / ux-workflow
+
+**Problem.** `spec::html` is the one document that goes to the caster and the bench — dimensions, weights, verdict, notes, stones, DFM, provenance. It is entirely text and tables. There is no view of the ring, no cross-section, no parting-line diagram. The parting line and the stone map exist as separate SVG exports the user must remember to run and staple on, and the section view cannot be exported at all.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:29 `pub fn html(design, report, field, stones, dfm, generator)` — no mesh, no image; the file contains no `img`, `svg` or `base64`; File ▸ Parting line… and File ▸ Stone map… are separate commands in crates/ringdesign-gui/src/panels/mod.rs.
+
+**Do this.** Unchanged. Two implementation notes from the code: `spec::html` should take `Option<&[render::Part]>` rather than `&Mesh`, so the sheet's hero carries the stones the same fix as finding 4 adds; and a "Job packet" command must build all four documents inside *one* `spawn_export` closure, because `spawn_export` (export.rs:52) refuses concurrent jobs and would otherwise need queueing it does not have.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `spec::html` an optional `&Mesh` (or a prepared `Vec<Part>`) and embed three data-URI figures: a `render::png_bytes` hero, the parting-line SVG (`castability::parting_line` already draws it), and the section at the design's own hot spot drawn from `castability::section_at` — the same polyline the Section pane paints, with the parting plane and the min-wall dimension called out. The sheet is already self-contained HTML, so data URIs cost nothing structurally. Then make one File ▸ "Job packet…" that writes sheet + STL + stone map + hero into one folder, since `spawn_export` refuses concurrent exports and a jeweller currently walks four dialogs for one job.
+
+</details>
+
+**Castability.** Improves it: the parting line and the thin-wall station reach the flask instead of staying on screen.
+
+**Verified.** Confirmed. `spec::html` (crates/ringdesign-core/src/spec.rs:29) takes `(design, report, field, stones, dfm, provenance)` — no mesh, no image parameter. Grepped the file for `img`, `svg`, `base64`, `data:` — no hits. `castability::parting_line` (castability.rs:666) and `stonemap` are separate exports driven by separate File-menu commands. There is no section export of any kind: grepped `export_section|write_svg` across export.rs and core — nothing. And `spawn_export` (export.rs:52-58) genuinely refuses a second job ("An export is already running — one at a time"), so the four-dialog walk the finding describes is real and serialised.
+
+#### F182 The verdict is carried by colour alone, in red and green — `medium` / `M` / ux-workflow
+
+**Problem.** Every judgement channel in the app is hue-coded and nothing else: the 3D Draft shading paints `FaceClass::rgb` — Good (0.32,0.78,0.45) against Undercut (0.93,0.27,0.36), which converge under deuteranopia — the report's class bar is four coloured segments, the section view draws undercut runs in the same red, and the wall heatmap is a red-under-floor ramp. The verdict banner does carry a distinguishing glyph, which is the exception. There is also no light theme (`theme::install` forces dark for both `Theme::Dark` and `Theme::Light`) and no text-size control.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:173-180 `FaceClass::rgb`; crates/ringdesign-gui/src/theme.rs:44-47 GOOD/WARN/BAD and the comment pinning them to the core colours; report.rs:405 `class_bar` (colour segments, tooltip only); section.rs:529 `draw_undercuts`; theme.rs:56-58 `set_theme(ThemePreference::Dark)` then the same style for both themes.
+
+**Do this.** Unchanged. The theme.rs:39-42 comment is the argument for doing this in core rather than the GUI: the words, the legend swatches and the baked mesh colours all read one table, so swapping `FaceClass::rgb` for a colour-blind-safe set fixes all four surfaces at once. Rank the hatch on the Draft-view undercut faces first — it is three lines in the fragment shader and it is the surface a caster actually looks at; the light theme is the weakest limb and can wait.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Keep the hues but separate them by luminance and add a second cue: hatch the undercut faces in the 3D view (a screen-space stripe in the fragment shader keyed on `u_mode == 1 && class == Undercut` costs three lines), stipple the undercut segment of the class bar, and draw the section's undercut runs as a dashed heavier stroke as well as red. Add a colour-blind-safe palette option in a Preferences dialog that swaps `FaceClass::rgb` (core owns the table, so all four surfaces follow), alongside a UI scale slider. A light theme is a second `theme.json`, since the style is already loaded as data.
+
+</details>
+
+**Castability.** n/a to the geometry; substantial to whether the verdict is legible to the person reading it.
+
+**Verified.** Confirmed. `FaceClass::rgb` (castability.rs:172-179): Good [0.32,0.78,0.45], Marginal [0.95,0.76,0.24], Vertical [0.36,0.60,0.92], Undercut [0.93,0.27,0.36] — Good and Undercut converge under deuteranopia. theme.rs:43-46 pins GOOD/WARN/BAD/INFO to those core values with a comment saying they must not be recoloured independently, which is exactly why the core table is the right place to fix it. `class_bar` (report.rs:411-435) paints `rect_filled` segments with `theme::class_color` and no pattern. `theme::install` (theme.rs:49-57) calls `ctx.set_theme(ThemePreference::Dark)` and then `set_style_of` with the *same* style for both `Theme::Dark` and `Theme::Light` — there is genuinely no light theme. Grepping `zoom_factor|pixels_per_point|UI scale` across the GUI returns nothing.
+
+#### F183 The size run lives only in the CLI, so the most common production job cannot be done in the app — `medium` / `S` / ux-workflow
+
+**Problem.** `ringdesign export ring.json --sizes 5:9:0.5 --formats stl,3mf --shrink sterling` builds each size, field-checks it, writes the files and a manifest CSV with verdict, thinnest wall and volume per size — one flask, one command. The desktop app has no equivalent: the size slider changes the one design, and every export is a single file through a single dialog, with `spawn_export` refusing a second job while one runs. A jeweller filling a size run must leave the app and remember the CLI's syntax.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:116-256 (`--sizes`, `parse_sizes`, the per-size loop and manifest); grep for `sizes|size_run|manifest` across crates/ringdesign-gui/src returns nothing; crates/ringdesign-gui/src/export.rs:54-60 `spawn_export` refuses concurrent jobs.
+
+**Do this.** Unchanged. Add the shared helper to core (a `sizes::run` taking design, lib, formats, shrink and an out dir, returning the manifest rows) and have both the CLI's `export()` at cli/src/main.rs:110 and the new File ▸ Export size run… call it, so the manifest that doubles as the export-regression diff cannot drift between the two. Run it inside one `spawn_export` closure for the reason above. Worth adding an MCP tool of the same name while the helper is fresh — the tool list at tools.rs:3216 has no batch export at all.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add File ▸ Export size run… — the same dialog the CLI parses (from:to:step or a list, formats, shrink metal), running the CLI's own loop on the export thread with a progress line and the manifest written beside the files. Reuse the CLI's code by lifting the loop into `ringdesign-core` or a shared helper so the two cannot drift. Fold the per-size verdict into the status and refuse to write a `NotCastable` size the way `sink.export` does in the graph.
+
+</details>
+
+**Castability.** Improves it: each size is field-checked separately, and thin-wall and detail margins do change with size — a design clean at 9 can be under `min_section_mm` at 5.
+
+**Verified.** Confirmed. The loop is `export()` in crates/ringdesign-cli/src/main.rs:110+, parsing `--sizes` (`parse_sizes`), `--formats` (stl/obj/3mf/glb/ply/stonemap) and `--shrink`, and it lives entirely in the CLI binary crate — nothing in core exposes it. Grepping `sizes|size_run|manifest` across crates/ringdesign-gui/src returns nothing. Checked MCP too: crates/ringdesign-mcp/src/tools.rs:3216-3220 lists `export_stl`, `export_obj`, `export_3mf`, `export_glb`, `export_stone_map` — all single-file, no size run. And `spawn_export` (export.rs:52-58) refuses concurrent jobs, so today's app cannot even be driven into a size run by hand without four sequential dialogs per size.
+
+#### F213 The order's hero render, turntable and GLB all show a bare ring in gold — `high` / `S` / product-business
+
+**Problem.** Every image the customer receives ignores two of their choices. `order_files` renders `out.mesh` alone — the stones are never in the `Mesh` and `gems::preview_mesh` is not called — so a solitaire customer gets a picture of an empty mound. And every render is hardcoded `render::GOLD`, so a platinum or rose-gold order is pictured in yellow gold. The live preview in the kiosk has the same two defects.
+
+**Evidence.** crates/ringdesign-configurator/src/main.rs:311-313 — `gltf::to_glb(&out.mesh, &d.name, render::GOLD)`, `render::png_bytes(&out.mesh, ..., render::GOLD)`, `render::turntable_gif_bytes(&out.mesh, ..., render::GOLD)`; and Worker::run:136 `render::render_ss(m, ..., render::GOLD)`. The machinery to fix it exists and is used by the examples: `render::Part::metal` / `Part::stone` and `render::write_png_parts` (render.rs:21-45, 108-133), `gems::preview_mesh` (used at examples/collection3.rs:87, examples/gallery.rs:199), and the alloy tints already tabulated in crates/ringdesign-gui/src/viewport.rs:531 `FINISHES`.
+
+**Do this.** Sharpened: three pieces, not two. (1) Add `render::png_bytes_parts` and `render::turntable_gif_bytes_parts` alongside the existing file writers — the parts renderer exists but has no in-memory output, and the browser order path can only use bytes. (2) Move FINISHES into core as a *colour* table and add an explicit alloy→colour default map, because the two vocabularies do not line up: METALS has Gold 10k/14k/18k/22k/24k with no colour and FINISHES has rose/white with no karat, so a straight name key would fail for most rows. (3) Then build `parts = [Part::metal(&mesh, tint), Part::stone(&gems::preview_mesh(&d, &lib)?)]` in `order_files` and in Worker::run, and pass the tint to `to_glb`. Note `Part::metal` sets `smooth: true` and `Part::stone` `smooth: false` already, so the shading is right by construction.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Move `FINISHES` from the GUI's viewport.rs into core (beside `metal::METALS`, keyed by metal name) so every frontend tints the same way. In the configurator, build `parts = [Part::metal(&mesh, tint_for(cfg.metal))]` plus `Part::stone(&gems::preview_mesh(&d, &lib))` and render through `render_parts_ss` / `write_png_parts`; pass the tint to `to_glb` too. Do the same for the live preview so what the customer approves is what they are shown.
+
+</details>
+
+**See also.** F169 is the same defect at the GUI's hero render and turntable (M17).
+
+**Verified.** Confirmed on both counts. main.rs:311-313: `gltf::to_glb(&out.mesh, &d.name, render::GOLD)`, `render::png_bytes(&out.mesh, 0.55, 1.12, p.hero_px, render::GOLD)`, `render::turntable_gif_bytes(&out.mesh, ...)` — one mesh, one hardcoded tint; and Worker::run (main.rs:136) `render::render_ss(m, ..., render::GOLD)` for the live preview. `gems::preview_mesh` (gems.rs:38) exists and is never called in the configurator. One thing the finding understates: `render_parts_ss` (render.rs:108) and `write_png_parts` (render.rs:125) exist, but `png_bytes` (render.rs:138) and `turntable_gif_bytes` (render.rs:159) both take `&Mesh` — there is no bytes-returning parts path, which is exactly what wasm needs since it cannot write files. FINISHES (viewport.rs:531) is a 7-entry colour table whose names ("Yellow gold", "Rose gold", "White gold") do not correspond to METALS' ten karat/fineness entries.
+
+#### F214 The renderer cannot produce a product listing image — `high` / `L` / product-business
+
+**Problem.** `render.rs` is an orthographic single-directional-light z-buffer over a flat #121212 field: no perspective, no shadow, no ground plane, no environment reflection, no depth of field. On polished metal, which is almost entirely reflection, this reads as a matte plastic ring. There is also no crop set (square 1:1, 4:5 portrait, 9:16 story), no scale reference, and no on-hand or in-context shot. A listing needs six to eight images; the app makes one attitude and a 36-frame spin.
+
+**Evidence.** crates/ringdesign-core/src/render.rs:193-260 `draw_parts` — `let scale = w / (ext * 1.25)` (orthographic), a single normalised `light` vector, background initialised as `vec![18u8; w*h*3]`, and shading is `n·l` with a specular term; no shadow or environment term anywhere. `write_png`/`turntable_gif` are the only outputs; the examples reuse them at fixed yaw/pitch (`0.55, 1.12`, called "the catalog three-quarter view" at examples/showcase.rs:38).
+
+**Do this.** Unchanged, ordered as given. One concrete note: the shading is already funnelled through a single `shade_of(nn)` closure inside `draw_parts`, so a matcap/latlong lookup is a substitution at one call site rather than a rewrite — and the closure already receives the view-space normal, which is exactly the matcap lookup key. The contact shadow is the bigger change (it needs a second pass and a ground plane in the framing, which currently frames tight on `first.mesh.bounds()` with a fixed 1.25 margin). Make `background` and the margin fields on a small `Frame`/`ShotSet` struct at the same time, since both are literals today.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Two separate steps, and take them in this order. (1) Cheap and inside the existing rasterizer: add a matcap/environment-latlong lookup keyed on the view-space normal in place of the single `n·l` term (a 64×32 baked studio strip is a few kB and turns metal from plastic into metal), a soft contact shadow from a downward ortho depth pass onto a ground plane, and a `background: [u8;3]` on the frame. (2) A `render::ShotSet` describing the listing: three-quarter hero, top plan, side profile, a macro crop on the ornament, and the turntable, each at 1:1 / 4:5 / 9:16, written as one call from the configurator and the GUI. Keep `GOLD`-flat as the fast preview path.
+
+</details>
+
+**Verified.** Confirmed by reading `draw_parts` (render.rs:209-300): background is `vec![18u8; w*h*3]` (a literal, not a parameter), framing is orthographic (`let scale = w as f64 / (ext * 1.25)`, and the projection `px` is a plain scale with no divide by depth), lighting is one normalised constant `[-0.35, -0.5, 0.79]` with an `n·l` term plus a specular, and there is no second depth pass, ground plane, environment lookup or ambient-occlusion term anywhere in the module. Outputs are `write_png`/`png_bytes` (one attitude) and `turntable_gif`/`turntable_gif_bytes` (36 frames); no crop-set or shot-list type exists. The module doc at render.rs:1-5 says so itself: "Orthographic, one directional light, gold by default."
+
+### M18 — The sand is a recipe, not three numbers (L, 17 findings)
+
+**Done when:** SandProcess is a serde field with a source per number, pattern_scale differs by process, the design carries its intended metal, and the sheet's subtitle is derived.
+
+#### F6 The shop's sand is not part of the design record — `medium` / `S` / sand-process
+
+**Problem.** `SandProcess` is a picker that writes three numbers and evaporates. It is not a field on `DraftSettings`, it does not derive serde, and nothing downstream can name it. Reopen a saved design and neither the app nor the caster can tell whether it was ranged for Delft clay or Petrobond — only that the detail floor happens to read 0.30 or 0.40. The casting sheet, which is the document the caster holds, never names the sand at all.
+
+**Evidence.** castability.rs:118 `#[derive(Clone, Copy, Debug, PartialEq, Eq)] pub enum SandProcess` — no Serialize/Deserialize. `DraftSettings` (castability.rs:42) carries `process: CastProcess` but no sand. crates/ringdesign-gui/src/panels/design.rs:1244-1253 renders it as a plain `ui.button` (not a `selectable_label`), so it does not even show which one is active. spec.rs prints `min_draft_deg` and `min_detail_mm` but no sand name.
+
+**Do this.** Unchanged. Two notes that make it cheaper than it looks: `spec::html` already receives `design` (spec.rs:30), so printing the sand and the process is a field access, not a signature change; and `SandProcess::apply` writing `d.sand = self` makes the round-trip self-consistent with zero migration, since `#[serde(default)]` on an added field reads every existing `.ring.json` unchanged.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `#[serde(default)] pub sand: SandProcess` to `DraftSettings` with `SandProcess: Serialize + Deserialize + Default`, set it in `SandProcess::apply`, render the picker as a `selectable_label` group like the `CastProcess` row above it, and print "Sand: Delft clay (draft 3.0°, fill 0.80 mm, detail 0.30 mm)" in the sheet's Cast check table and the CLI `check` header.
+
+</details>
+
+**Castability.** n/a.
+
+**Verified.** Verified line by line. `SandProcess` (castability.rs:118) derives `Clone, Copy, Debug, PartialEq, Eq` — no Serialize/Deserialize, no Default. `DraftSettings` (castability.rs:41-61) has `process: CastProcess` and no sand field. The GUI picker at gui/panels/design.rs:1243-1252 is `ui.button(p.label())` inside a plain horizontal — no `selectable_label`, so nothing shows which sand is active, and clicking re-applies unconditionally. `spec.rs` prints `min_draft_deg` and `min_detail_mm` (spec.rs:74) and never names the sand; a grep of spec.rs for process/SandProcess/CastProcess returns nothing. The CLI `check` header (cli/src/main.rs:83-95) prints name, size, verdict and the three field numbers — no sand, no process.
+
+#### F7 The sand model is three unsourced scalars — `high` / `M` / sand-process
+
+**Problem.** The whole sand is `(min_draft_deg, min_section_mm, min_detail_mm)`, and the two presets' values are asserted without a measurement in a codebase whose own standard is to cite one for every constant (SIDE_FACE_MIN_DRAFT_DEG is documented as "calibrated, not guessed"; BODY_FAIR_R has a table). Real detail resolution is grain fineness plus ram pressure plus whether the mould was dusted with graphite or talc; real fill is grain plus permeability plus alloy plus flow length. None of that exists, so the app cannot tell a jeweller ramming hard into fine Delft clay that they can hold 0.15 mm, nor warn one ramming loose Petrobond that 0.35 mm is optimistic.
+
+**Evidence.** castability.rs:139-147 `SandProcess::apply`: `DelftClay => (3.0, 0.8, 0.30)`, `Petrobond => (2.5, 0.6, 0.40)` — bare tuples with no derivation and no citing comment, against the doc-comment style used everywhere else in the file. `CastProcess::apply` (castability.rs:90) similarly hard-writes `(0.5, 0.15)` for lost wax. `default_min_detail()` returns 0.35 with no rationale.
+
+**Do this.** Keep the finding, shrink the fix. A full `Sand { afs_grain, binder, ram, coating }` model is more machinery than a two-sand shop can calibrate, and this codebase's own rule is that a constant is worth what its measurement is worth. The high-value version: (a) write the provenance comment on the two tuples — where each number came from, in the SIDE_FACE_MIN_DRAFT_DEG voice — which is the actual defect; (b) add one `ram: Ram { Loose, Normal, Hard }` multiplier on `min_detail_mm` only, since ram pressure is the one variable the jeweller changes pour to pour and the one that visibly moves detail; (c) leave grain and permeability out until a pour is measured. Then cite it in CLAUDE.md.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Replace the tuple with a `Sand { afs_grain: f64, binder: Binder, ram: Ram, coating: Coating }` whose `floors()` derives the three numbers, keeping `DelftClay`/`Petrobond` as named instances so nothing migrates. Detail ≈ k·(grain diameter), draft from binder plasticity, fill from grain plus permeability. Expose grain and ram in the casting panel as "how fine is your sand / how hard do you ram", and let the sheet print the derivation so the numbers are arguable rather than magic. Cite the calibration in CLAUDE.md the way SIDE_FACE_MIN_DRAFT_DEG is cited.
+
+</details>
+
+**Castability.** Neutral. Floors move, the pull guarantee does not — but a shop reporting finer sand will be allowed finer relief, so the DFM checks must move with it, which they will since they read `min_detail_mm`.
+
+**Verified.** Verified. `SandProcess::apply` (castability.rs:139-147) is a bare match on tuples — `DelftClay => (3.0, 0.8, 0.30)`, `Petrobond => (2.5, 0.6, 0.40)` — with no derivation and no citing comment, in a file whose other constants (VERTICAL_TOL_DEG, DRAG_FRACTION, FIELD_NOISE_FRACTION at castability.rs:19-38) all carry one, and against the house standard CLAUDE.md sets for SIDE_FACE_MIN_DRAFT_DEG and BODY_FAIR_R. `CastProcess::apply` (castability.rs:90) hard-writes 0.5/0.15 for lost wax the same way; `default_min_detail()` (castability.rs:96) returns 0.35 with no rationale. No grain, ram, binder or permeability term exists anywhere.
+
+#### F8 metal.rs models weight and shrink, not casting behaviour — `high` / `M` / sand-process
+
+**Problem.** Sterling, bronze and platinum are three densities and three shrink percentages. In a sand mould they are not remotely equivalent: bronze runs thin sections beautifully, sterling absorbs hydrogen and gasses, 950 platinum needs a torch nobody's Delft frame will survive, 14k white is stiff and short-running. `min_section_mm` is a property of the *sand* only, so the app tells a user the same 0.7 mm fill floor whether they pour bronze or 18k. The picker offering Platinum 950 alongside the Delft clay preset is itself misleading.
+
+**Evidence.** crates/ringdesign-core/src/metal.rs:6-14 — `Metal { name, density, shrink_pct }`, and METALS at :16 lists ten alloys with nothing else. `analyze_field` (castability.rs:1174) compares `thinnest` against `settings.min_section_mm` with no alloy term. No liquidus, pour temperature, fluidity index, or flow-length figure exists in the workspace.
+
+**Do this.** Unchanged, with the ordering flipped: ship `sand_castable: bool` + `caution: Option<&str>` + `pour_c` FIRST, because they are facts that need no calibration and they immediately fix the misleading picker and give the caster the one number the app is the only place to learn. Hold `fluidity` until it is measured — dividing `min_section_mm` by an invented index would put an unsourced constant into the verdict, which is the exact defect finding 7 is about.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Extend `Metal` with `liquidus_c`, `pour_c`, `fluidity` (a relative index, bronze ≈ 1.0, sterling ≈ 0.8, 14k ≈ 0.7, Pt ≈ 0.3), and `sand_castable: bool` with a `caution: Option<&str>`. Make the fill floor `sand.min_section_mm / metal.fluidity` so the verdict's note reads "0.62 mm at 210° is under the 0.88 mm 18k reliably fills in Delft clay". Grey out or footnote the alloys nobody sand-casts in a jewellery shop, and print the pour temperature on the sheet — a caster needs it and the app is the only place the alloy is chosen.
+
+</details>
+
+**Castability.** n/a — fill, not pull.
+
+**Verified.** Verified. `Metal` (metal.rs:6-14) is `{ name, density, shrink_pct }` and METALS (metal.rs:16-27) lists ten alloys with nothing else — including Platinum 950 and Palladium 950, offered on equal footing with Bronze under a Delft clay preset. `analyze_field`'s fill check (castability.rs:1184-1192) compares `thinnest` against `settings.min_section_mm` with no alloy term, so the same floor is quoted for bronze and for 18k. No liquidus, pour temperature, fluidity or flow-length figure exists in the workspace. Craft check: the platinum point is right — 950 Pt melts around 1770 C, far past what clay- or oil-bonded sand survives, so listing it under a sand preset is genuinely misleading, not pedantry.
+
+#### F9 No finishing stock: shrink is the only allowance, and the ring comes out of the polish loose — `high` / `M` / sand-process *(also found as F117)*
+
+**Problem.** `pattern_scale` compensates solidification shrink and nothing else. A real cast ring then loses metal everywhere it is touched: the sprue witness is filed flat, the parting flash is filed off the whole silhouette, the bore is reamed to size, and the surface is sanded and polished. Typical total is 0.1–0.3 mm off the outer surface and a quarter to half a size gained in the bore. The app has no allowance for any of it, and the only place the loss is mentioned is a disclaimer next to the weight table.
+
+**Evidence.** metal.rs:44 `pattern_scale` = `1/(1-s)`, applied as a uniform `Mesh::scaled` in crates/ringdesign-cli/src/main.rs:177 and crates/ringdesign-gui/src/export.rs:36-42. A workspace grep for ream/finish/cleanup/polish/tumble in ringdesign-core/src finds only castability.rs:560's bore note and spec.rs:131's disclaimer. `DraftSettings` has no finishing field; `RingSize` (sizing.rs) has no as-cast vs as-finished distinction.
+
+**Do this.** Add `finish_stock_mm: f64` to `DraftSettings` (default ~0.15) and apply it at export as an outward normal offset alongside `pattern_scale`, with the bore offset *inward* by the reaming stock so the cast ring reams down to nominal rather than up past it. Report both on the sheet: "cut at ×1.0194 for sterling shrink plus 0.15 mm finishing stock; bore casts at 8.50 mm and reams to 8.65". `Layer::height` is where surface stock could be added most cheaply, but a profile-level offset is honest enough and does not touch the field.
+
+**Castability.** An outward stock offset thickens walls and adds draft nowhere; it cannot introduce an undercut. The inward bore offset is a straight through-hole either way. Both are safe, but the field verdict should be re-run on the offset geometry so the sheet judges what is actually cast.
+
+#### F12 No venting, permeability or blind-pocket reasoning anywhere — `medium` / `M` / sand-process
+
+**Problem.** Delft clay is dense, fine and close to impermeable; Petrobond is better but not free. A pocket in the metal that is blind and sits high in the cope traps its own gas and comes out with an unfilled dome — a bezel cup, a deep openwork pocket, a recessed channel floor, a hollow head's scoop. Nothing in the app identifies a blind pocket, nothing scores permeability, and nothing tells the user to vent-wire the cope over it.
+
+**Evidence.** A workspace grep for vent/venting/permeab/gas returns nothing in ringdesign-core. `SandProcess` (castability.rs:118) has no permeability term. `OpenworkLayer` (field.rs:640) carves to a floor with no gas note; `SeatStyle::Bezel`'s pocket (stones/field) is a cup with no note; `SignetHead::hollow_mm` is documented purely as a pull-and-wall question in CLAUDE.md. spec.rs's Cast check table has no venting line.
+
+**Do this.** Split it and do the cheaper half first. The sand-rib aspect check needs no new analysis at all — it is `depth / width` on data `FeatureFootprint` will carry once finding 10 lands, so fold it into that DFM pass. `blind_pockets` is the larger piece; scope it to what matters: a local height minimum enclosed on all sides AND above `parting_z`, since a pocket in the drag fills and vents normally. Report it as a sheet line and a mark on the parting-line SVG. Leave `permeability` on the sand model out until finding 7's provenance work decides whether the sand model grows at all.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `castability::blind_pockets(design, lib, parting_z) -> Vec<Pocket>` reading the field: a region whose height is a local minimum enclosed on all sides, with its depth, plan area and — critically — its height above the parting plane, since only pockets in the cope trap gas. Emit a sheet line per pocket ("bezel cup at 90°, 1.2 mm deep, 3 mm above the plane — vent-wire the cope over it") and mark them on the parting-line SVG. Add `permeability` to the sand model so the threshold moves with the sand. Pair it with the carve aspect-ratio check: a carve deeper than it is wide leaves a tall thin sand rib in the mould that shears off during ram-up or breaks on the pull — that is a mould-fragility finding the app has all the numbers for and makes none.
+
+</details>
+
+**Castability.** n/a — reporting. The sand-rib aspect check is a mould-strength constraint that sits alongside the pull, not inside it.
+
+**Verified.** Verified by grep across all crates, examples and tools: no vent, venting, permeab or gas identifier exists in ringdesign-core (the only 'vent' hits in the workspace are unrelated egui `i.events` matches). `SandProcess` (castability.rs:118) has no permeability term. `OpenworkLayer` (field.rs:640) carves to a floor with no gas note; the bezel pocket and `SignetHead::hollow_mm` are documented purely as pull-and-wall questions. `spec.rs`'s Cast check table (spec.rs:68-75) has four rows and no venting line. Craft check: the mechanism is real, though it is two effects not one — a cup facing up in the cope traps air ahead of the rising metal, and the sand projection filling it also has the least path to vent its own gas. The paired sand-rib fragility point (a carve deeper than it is wide leaves a tall thin sand projection that shears on ram-up or on the pull) is correct and is genuinely computable from data the app already has.
+
+#### F15 The casting sheet hardcodes "sand-cast pattern" and carries no drawing — `medium` / `S` / sand-process *(also found as F26)*
+
+**Problem.** The sheet is the one document that leaves the app and reaches the bench. It asserts the process in its subtitle regardless of what the design was judged for — a lost-wax design, whose verdict deliberately does not gate on the pull, prints a header telling the caster it is a sand-cast pattern, next to a pattern-scale column computed from metal shrink alone (wrong for investment, where mould expansion offsets it). And the page is text-only: no plan view, no section, no parting line, no gate mark, on a page rendered by a crate that already has a software rasterizer and a draft-coloured render mode.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:62 — `<div class="dim">Size {size} • sand-cast pattern • all lengths mm</div>`, a literal. `spec::html` never reads `design.draft.process`; grep of spec.rs finds no `process`, no `SandProcess`, no `CastProcess`. The page contains no `<img>` and asserts `!page.contains("src=")` in its own test (spec.rs test at the file's end). Meanwhile `render::png_bytes` (render.rs:138) and `render::render_classed` (render.rs:58) already exist and are already used for GLB/hero exports.
+
+**Do this.** Unchanged. Split by cost: the header fix and the pattern-scale caption are a handful of lines against data already in scope and should go with finding 6's sand line — that is the correctness half. The embedded drawings are the bigger, higher-value half; note the finding's own test-assertion advice is right, and the draft-coloured view is the cheapest of the three since `render_classed` already exists and the GUI's ShadeMode::Draft path proves the classification.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Print the actual process and sand in the header and switch the pattern-scale column's caption and value accordingly (metal shrink for sand; a combined wax-plus-investment allowance, or an explicit "set by your investment" note, for lost wax). Embed three base64 data-URI PNGs from `render`: a plan view with the parting line and the gate mark overlaid, a section at the hot-spot angle, and a draft-coloured view. The sheet is self-contained by design and data URIs keep it so — the test's `!contains("src=")` assertion should become `!contains("http")` only.
+
+</details>
+
+**Castability.** n/a.
+
+**Verified.** Verified exactly. spec.rs:62 is the literal `<div class="dim">Size {size} • sand-cast pattern • all lengths mm</div>`, with only `size` interpolated. A grep of spec.rs for process/SandProcess/CastProcess returns nothing, even though `spec::html` (spec.rs:29-36) already receives `design` — so `design.draft.process` is one field access away. The page contains no `<img>` and its own test asserts `!page.contains("src=")` (spec.rs:248). `render::png_bytes` and `render::render_classed` do exist in core and are already used for the hero/GLB exports. Also confirmed: the pattern-scale column (spec.rs:120-131) is `metal::pattern_scale(shrink_pct)` unconditionally, so a lost-wax design gets a metal-shrink-only figure, which is the wrong allowance for investment.
+
+#### F20 State plainly what LostWax changes, because today it is four lines — `high` / `L` / lost-wax
+
+**Problem.** Picking Lost wax changes the verdict from gating on undercut to never gating, sets two floors, gives the halo generator proud mounds instead of flat markers, and suppresses one prong warning. That is the entire behavioural difference. The mesh analyzer, the DFM checks, the shrink, the casting sheet, the stone map, the size-run CLI, the configurator, the parting-line SVG and the modulus scan are all identical and worded for sand. A jeweller who picks Lost wax expecting a second process gets a sand tool with the alarm disabled.
+
+**Evidence.** Exhaustive grep of `CastProcess::LostWax` across the workspace yields only: crates/ringdesign-core/src/castability.rs:1142-1170 (verdict + notes), :88-96 (`apply`), crates/ringdesign-core/src/pave.rs:434,478,496,526-528 (halo), crates/ringdesign-core/src/stones.rs:253 (prong warning), plus four `examples/` authoring sites. crates/ringdesign-core/src/dfm.rs, spec.rs, metal.rs, mesh.rs, stonemap.rs, sizing.rs contain no reference to `process` at all.
+
+**Do this.** Introduce `ProcessRules` returned by `CastProcess` — `{ min_section_mm, min_detail_mm, min_edge_mm, min_wall_mm, undercut_gates: bool, vocabulary }` — modelled on the existing `SandProcess::apply` triple, and make `castability::analyze`, `dfm::findings_in`, `stones::report`, `mesh::BuildParams::default` and `spec::html` read it. Keep `SandProcess` as the sand-side preset that fills the sand arm. The compile-time win is that every hard constant that is really a sand rule becomes a named field rather than silence.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Make the process a first-class axis rather than a boolean on `DraftSettings`. Introduce a `ProcessRules` value carried by `CastProcess` — `{ min_section_mm, min_detail_mm, min_edge_mm, min_wall_mm, undercut_gates: bool, pattern_scale, vocabulary }` — and have `castability`, `dfm`, `stones`, `mesh::BuildParams`, `spec` and the CLI read it instead of hard constants. Every rule that is genuinely a sand rule then becomes visibly one, and every gap where lost wax needs its own number becomes a compile-time hole rather than silence.
+
+</details>
+
+**Castability.** None to the sand guarantee: the sand path keeps its own rules verbatim. The risk runs the other way — today lost-wax numbers leak into sand designs (see the `apply` finding).
+
+**Verified.** Re-ran the exhaustive grep. Every non-test, non-example read of the process in the workspace: castability.rs:1142 (analyze_field's verdict/notes arm), castability.rs:91-95 (CastProcess::apply), pave.rs:434 (halo), stones.rs:253 (prong warning), design.rs:1221/1234/1242 (the GUI picker). That is all of it. dfm.rs, spec.rs, metal.rs, mesh.rs, stonemap.rs, sizing.rs contain no `process` reference at all (the only hits in those files are `std::process::id()` in tests). DraftSettings (castability.rs:42-61) carries five fields; `process` is the fifth and nothing derives numbers from it except `apply`. SandProcess::apply (castability.rs:139-148) is the shape a ProcessRules value would take, but it only writes three numbers and only for sand.
+
+#### F24 The process can only be chosen from one collapsed section of the desktop GUI — `high` / `M` / lost-wax
+
+**Problem.** `CastProcess` appears in exactly one UI: a pair of `selectable_label`s inside the "Casting" collapsing header of the desktop design panel, which defaults closed. MCP's `set_casting` tool has no `process` field (nor `min_detail_mm`). The CLI has no `--process`. The graph has no draft/casting node at all — draft settings travel only as opaque `design.set` JSON-pointer patches. The configurator never touches it, so the customer kiosk is sand-only. Python has no typed setter. Every automated or scripted path is locked to sand.
+
+**Evidence.** crates/ringdesign-gui/src/panels/design.rs:1217-1241; the section is registered `section(ui, "Casting", false, ...)` at :26 (the `false` is default-open). `SetCastingParams` at crates/ringdesign-mcp/src/tools.rs:470-480 has four fields, none of them process. `grep -rn CastProcess` across ringdesign-cli, -configurator, -graph, -py returns nothing. crates/ringdesign-graph/src/lift.rs:7 confirms the draft settings are carried as patches, not nodes.
+
+**Do this.** Add `process: Option<String>` and `min_detail_mm: Option<f64>` to `SetCastingParams` (parse via a `CastProcess::from_label`-style helper so MCP and a CLI `--process sand|lostwax` share it), and a `design.casting` StructNode over `DraftSettings` in the graph registry — `coverage()` will then hold it to the struct's serialized keys, which is how a future sixth field cannot go unnoticed. Surface the current process as a chip on the report panel header, not only in a closed collapsing section.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `process` and `min_detail_mm` to `SetCastingParams`, a `--process sand|lostwax` flag to `ringdesign check`/`export`, and a `design.casting` struct node in the graph registry so `coverage()` holds it to `DraftSettings`' serialized keys. Surface the process on the report panel header rather than burying it in a closed section.
+
+</details>
+
+**Castability.** None. It widens access to a setting that already exists.
+
+**Verified.** All five surfaces checked. GUI: design.rs:1216-1240, inside `section(ui, "Casting", false, ...)` at :26 — the third arg is `open` passed to `.default_open()`, so `false` means default-closed (the auditor's parenthetical is garbled but the claim is right). MCP: `SetCastingParams` (tools.rs:471-480) has exactly parting_z_mm, min_draft_deg, auto_parting, min_section_mm — no process, no min_detail_mm; the handler at :1656-1659 writes only those four. CLI: `--shrink`, `--sizes`, `--formats` only (main.rs:51, 118-140); no `--process`. Graph: no draft/casting node — grep of nodes/*.rs finds `d.draft` read only by sinks and layer.rs's side-face helper; lift.rs carries draft settings as `design.set` patches. Configurator and ringdesign-py: zero `CastProcess` hits.
+
+#### F27 The shrink applied to an export is the sand patternmaker's allowance, and on a wax it is about one ring size of error — `critical` / `M` / lost-wax
+
+**Problem.** `metal::pattern_scale(shrink_pct) = 1/(1−s)` is the patternmaker's allowance: for a sand pattern, cut oversize so the metal cools to nominal. Every export path applies it blind to the process — the GUI's Shrink combo, the CLI's `--shrink`, and the graph's `sink.export` — including exports of a lost-wax design or a Free-mode solid. In investment the pattern is wax or resin and the chain has three terms, not one: the wax contracts on cooling in the mould, the investment expands on set and again on burnout (which is what compensates most of the metal shrink), and a printed resin pattern has its own machine-specific shrink. Applying +1.94% for sterling to a wax is roughly a full ring size on a size-7 bore — 1.94% of a 17.3 mm inner diameter is 0.34 mm, and a ring size is about 0.34 mm of inner diameter.
+
+**Evidence.** crates/ringdesign-core/src/metal.rs:46-49 and its doc at :10-13 ("the patternmaker's allowance"). Applied at crates/ringdesign-gui/src/export.rs:36-42, crates/ringdesign-cli/src/main.rs:166,181, crates/ringdesign-graph/src/nodes/sink.rs:270-279. None of the three reads `design.draft.process`. `Metal` has no wax or investment fields.
+
+**Do this.** Split the scale into `PatternScale { pattern_material_pct, mould_expansion_pct, metal_shrink_pct }` and give `CastProcess` a `pattern_scale(metal)`: sand returns today's `1/(1−metal)` bit-identically so no existing export moves; lost wax composes the wax/resin and investment-expansion terms, which are shop constants and must be settings rather than literals (investment expansion largely offsets metal shrink, which is why many shops print at nominal). Cite the honest magnitude — about half a US size on a size 7 for sterling — and warn on the three export paths when a lost-wax design is scaled with the sand allowance.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Split the scale into a `PatternScale { pattern_material_pct, mould_expansion_pct, metal_shrink_pct }` and give `CastProcess` a `pattern_scale(metal)`: sand returns today's `1/(1−metal)`, lost wax returns the composed factor with the wax and investment terms exposed as editable shop constants (they are wax- and shop-specific, so they must be settings, not literals). Refuse, or warn loudly, when a lost-wax design is exported with the sand allowance.
+
+</details>
+
+**Castability.** None to the pull — it is a dimensional error, not a release one, which is exactly why nothing in the app catches it today.
+
+**Verified.** The code claim is exactly right: metal.rs:46-49 `pattern_scale(s) = 1/(1-s)` with the doc at :10-13 naming it "the patternmaker's allowance", applied process-blind at gui/export.rs:36-42 (`pattern(&self, mesh)`), cli/main.rs:166 and graph/nodes/sink.rs:270-279 — none of the three reads `design.draft.process`. The magnitude claim is overstated by ~2x and should be corrected before it reaches the roadmap: sizing.rs:1 defines `size = (inner circumference mm − 36.5) / 2.55`, so one US size is 2.55 mm of circumference = 0.81 mm of inner diameter. 1.94% of a size-7 bore (17.35 mm ID) is 0.336 mm ≈ 0.41 of a US size, i.e. about half a size, not a full one. Still a real, wearer-visible error.
+
+#### F31 Only one generator has a lost-wax branch, and it is cosmetic — `medium` / `M` / lost-wax
+
+**Problem.** `pave::halo` is the sole generator that reads the process, and all it does is drop the plate and give the accent markers 0.5 mm of height and a 0.3 mm blend — still a gypsy mound in the same height field. A real lost-wax halo is a seat with a drilled gallery, prongs or beads, and an open back. Meanwhile `channel_set` refuses a thin or domed band outright because a channel's walls must stand parallel to the pull — a sand rule that does not apply to investment, so the generator refuses a perfectly castable lost-wax design. `pave::fill` has no branch at all: it emits gypsy mounds under both processes, on the reasoning that they are "the measured-safe row on curved ground" — measured safe for sand. Under investment the same row wants cut-down, fishtail or bead settings.
+
+**Evidence.** crates/ringdesign-core/src/pave.rs:431-534 (halo; the only `process` read at :434, effects at :478,:496,:526-528); :285-330 `channel_set` returns `None` at :290-292 with no process check; `fill` has no `process` reference. The GUI tooltip at crates/ringdesign-gui/src/panels/design.rs:1231 promises "Generators switch to their free-form variants" — plural, and only one does.
+
+**Do this.** Two changes worth the roadmap. (1) Give `channel_set` a lost-wax arm that drops the `side_faces_std()?` gate and the `hi - lo < stone + 2*rail_w` refusal — a channel on a domed crown is perfectly castable in investment, and today the generator refuses a design it should build. (2) Extend `SeatStyle` with the investment settings a bench actually uses (cut-down, fishtail, bead) and make `pave::fill`'s default follow the process rather than the caller's memory. Fix the tooltip's plural until it is true.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `channel_set` a lost-wax arm dropping the side-face gate and the width refusal (a channel on a domed crown is fine for investment). Give `fill` a `SeatStyle` that follows the process — gypsy under sand, cut-down or bead under lost wax. Correct the tooltip until the plural is true.
+
+</details>
+
+**Castability.** Each new arm must stay behind the process check so no sand path changes; `lost_wax_frees_the_halo_and_the_verdict_says_which_is_which` is the test pattern to copy for each.
+
+**Verified.** Two corrections, and the core stands. (a) The halo's branch is not cosmetic: pave.rs:497-500 omits the Plate layer entirely under lost wax, :477-482 sizes the fit from the accent ring instead of the plate, and :526-528 gives accents real height (0.5 mm) and blend (0.3) where sand gives 0.0/0.2. That is a different construction, not a restyle — call it what it is. (b) `pave::fill` is not hard-coded to gypsy: `PaveSpec` carries `style: SeatStyle` (pave.rs:46) and `fill` uses it (pave.rs:144). What is genuinely missing is that `SeatStyle` has only Boss/Bezel/GypsyMound — no cut-down, fishtail or bead — and no process-driven default. Confirmed missing: `channel_set` (pave.rs:285-330) reads no process; it returns `None` at :287-292 when there is no side face and at :293 when the face is too narrow, both sand rules, applied to investment too. Confirmed: the GUI tooltip (design.rs:1231) says "Generators switch to their free-form variants", plural, and exactly one does.
+
+#### F50 Nothing names a metal for a region: two-tone and mokume have no representation — `medium` / `M` / ring-typology
+
+**Problem.** A two-tone ring — white rails on a yellow band, a rose centre stripe, a mokume-look banded band — is a real and premium category. The metal is a single global choice made at export, so a design cannot say "this stripe is white gold", the casting sheet cannot break the weight down per part, and the pattern-shrink allowance (which differs 1.0–1.9% between platinum and silver) cannot differ per part.
+
+**Evidence.** crates/ringdesign-core/src/metal.rs:16 `pub const METALS: &[Metal]` with one `shrink_pct` each; the metal is chosen at the export call site (`sink.export`'s `shrink_metal` input, crates/ringdesign-graph/src/nodes/sink.rs:270) and `spec.rs::html` prints the whole `metal_table(volume)` for the one body. Nothing in `RingDesign`, `LayerEntry` or `BandProfile` carries an alloy. `two-tone` and `mokume` appear nowhere in crates/.
+
+**Do this.** Unchanged, and the advice to keep the alloy off `LayerEntry` is correct — a layer is relief, a region is a piece of band. `Region { name, window: Window, metal: String }` on `RingDesign` with `#[serde(default)]`. Two consumers, in order: `spec.rs::html` gains a per-region weight and shrink breakdown (this needs the region's volume, which is an integral over the gated footprint, not a mesh split — the easiest honest first cut is region *area* × local thickness, flagged as an estimate); and finding 7's multi-object 3MF emits one object per region so the two colours cast separately and are joined at the bench. Note that a genuine two-tone ring is usually cast as two parts and soldered, not cast bi-metal — so the region's real deliverable is the split export, and the sheet's job is to say which part is which alloy and at what shrink.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Introduce `Region { name, window: Window, metal: String }` on `RingDesign` — an arc × v-gate naming an alloy, reusing the `Window`/`VGate` gating the layer stack already has. Feed it into `spec.rs` as a per-region weight and shrink breakdown, and into the assembly export above so each region can come out as its own 3MF object for separate casting and joining. Do not put the alloy on `LayerEntry` — layers are relief, and a region is a piece of band.
+
+</details>
+
+**Castability.** None geometrically; the parts are cast separately and joined, so each is judged by the existing verdict on its own. The shrink allowance becoming per-region is a manufacturing *correction*, since two alloys in one pattern currently share one wrong scale.
+
+**Verified.** Confirmed. metal.rs:16-27 is a flat `METALS` table of ten alloys each with one `shrink_pct` (Platinum 1.0 to Silver 1.9 — the finding's 1.0-1.9 spread is exact). The alloy is chosen only at the export call site (`sink.export`'s `shrink_metal`, nodes/sink.rs:270; the CLI's `--shrink`) and `spec.rs::html` prints `metal_table(volume)` for one body. Nothing in `RingDesign`, `LayerEntry` or `BandProfile` carries an alloy. `grep -rni "two.tone|mokume"` across crates/ returns nothing. The `Window`/`VGate` gating machinery the recommendation wants to reuse is exactly as described (field.rs:345-375).
+
+#### F129 MCP cannot reach the casting process or the detail floor — `medium` / `S` / dfm-verdict
+
+**Problem.** `min_detail_mm` gates every DFM finding in the app, and `process` decides whether the pull statistics gate at all. Neither is settable through MCP. An agent driving the app can set the parting plane, the min draft and the min section, then read a `castability.dfm` block whose threshold it cannot see or change — and cannot judge a design for lost wax at all, which is the whole point of the second process. The tool description does not mention either omission.
+
+**Evidence.** crates/ringdesign-mcp/src/tools.rs:1649-1665 `set_casting` writes `parting_z_mm`, `min_draft_deg`, `auto_parting`, `min_section_mm` and stops; `SetCastingParams` (tools.rs:475-485) declares no `process` or `min_detail_mm` field. grep for `process` in tools.rs returns nothing.
+
+**Do this.** Widen beyond MCP: the same two settings are unreachable from the graph and the CLI, so an agent, a graph and a batch run are all locked out of half the casting model. Add `process: Option<String>` (routed through `CastProcess::apply` once finding 1 makes it symmetric — do these two together or MCP will ship the same one-way trapdoor), `min_detail_mm: Option<f64>` (0.05..2.0) and `sand: Option<String>` to `SetCastingParams` at mcp/src/tools.rs:471; add a `design.casting` struct node to crates/ringdesign-graph/src/nodes/ so a graph can carry its own process; and add `--process` to `ringdesign check`/`export`. State in the tool description that `min_detail_mm` is the floor every `castability.dfm` finding is measured against.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `process: Option<String>` (routed through `CastProcess::apply`, once it is symmetric — see the first finding) and `min_detail_mm: Option<f64>` (range 0.05..2.0) to `SetCastingParams`, plus a `sand: Option<String>` selecting Delft or Petrobond so the presets are reachable as a unit. Say in the description that `min_detail_mm` is the floor every DFM finding is measured against.
+
+</details>
+
+**Castability.** None.
+
+**Verified.** Verified and the gap is wider than stated. `SetCastingParams` (mcp/src/tools.rs:471-480) declares exactly four Options: parting_z_mm, min_draft_deg, auto_parting, min_section_mm; the handler (tools.rs:1651-1668) writes those four and stops. `grep -rn "min_detail_mm"` outside core returns only tools.rs:245 (a doc string *mentioning* the floor in the castability output), gui/app.rs:530, gui/panels/design.rs:1301 (the slider) and three examples — so the GUI slider is the only way to set it anywhere. `grep -rn "CastProcess|LostWax"` outside castability.rs shows the process is settable only from gui/panels/design.rs:1213-1242 and directly in examples; there is no graph node for `DraftSettings` at all (checked all 17 files in crates/ringdesign-graph/src/nodes/ — `draft` appears only as `side_draft_deg` on the band profile and `min_draft_deg` as a side-face threshold input), and the CLI has no such flag. An MCP agent can therefore neither judge for lost wax nor see the threshold its DFM findings are measured against.
+
+#### F192 The design file cannot say what metal the ring is — `high` / `S` / interop *(also found as F209)*
+
+**Problem.** `RingDesign` carries name, size, profile, shank, layers, build params, draft settings and the asset payloads — and no metal, no finish, no order metadata. The alloy lives only in GUI state (`app.shrink_metal`, the finish tint). So a `.ring.json` handed to a caster does not say whether it is sterling or 14k; the shrink allowance the pattern needs is a menu choice the file forgets; the CLI hardcodes `render::GOLD` for GLB regardless of `--shrink`; and the cost JSON has to list all ten alloys because nobody knows which one is meant.
+
+**Evidence.** crates/ringdesign-core/src/lib.rs:70-101 — the full `RingDesign` field list. crates/ringdesign-gui/src/panels/mod.rs:664-690 — "Shrink for" is an `app.shrink_metal` combo, app state. crates/ringdesign-cli/src/main.rs — `"glb" => gltf::write_glb(&file, &mesh, &name, ringdesign_core::render::GOLD)` with `--shrink` handled independently. crates/ringdesign-gui/src/export.rs:318-346 — the cost JSON emits `report.metals` (all ten).
+
+**Do this.** Add to RingDesign (lib.rs:69): `metal: Option<String>` (a metal::METALS name, not an index — an index breaks the moment the table is reordered), `finish: Option<Finish>`, and `provenance: Option<Provenance> { customer, order_ref, notes, created }`, all serde-default. Move viewport.rs:523's FINISHES table into core first (as `metal::Finish` with its rgb tint) — the GLB writer, render.rs, the configurator and the section view all need it and today three of them guess. Bump FORMAT_VERSION 1 -> 2 with a no-op migration step so library.rs:312's `every_version_has_a_migration_step` still passes. Then the shrink default in panels/mod.rs:664, the GLB tint in cli main.rs and configurator main.rs:311, the sheet's headline weight, the cost document and the configurator's order all read one field instead of four places guessing GOLD.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add to `RingDesign`: `metal: Option<String>` (a `metal::METALS` name), `finish: Option<Finish>`, and a small `provenance: Option<Provenance> { customer, order_ref, notes, created }`. The migration ladder is already built for exactly this (library.rs:36-48, `MIGRATIONS`, `every_version_has_a_migration_step`): bump `FORMAT_VERSION` 1 to 2 with a no-op step. Then the shrink default, the GLB tint, the sheet's headline weight, the cost document and the configurator's order all read one field instead of four different places guessing.
+
+</details>
+
+**Castability.** None — metal affects shrink scaling and reported weight, never the geometry the verdict judges. `metal::pattern_scale` already scales the mesh after analysis, which is the correct order and must stay so.
+
+**Verified.** Confirmed field by field: crates/ringdesign-core/src/lib.rs:69-101 lists name, size, profile, shank, layers, build, draft, drawn, embedded, texts, svgs, recipes, graph — no metal, no finish, no customer or order metadata. The alloy is app state (crates/ringdesign-gui/src/app.rs:41 `shrink_metal: Option<usize>`, persisted only in Workspace). One correction that changes the recommendation's shape: there is NO `Finish` type in core — the GUI's `finish: usize` (app.rs:45) is a bare index into crates/ringdesign-gui/src/viewport.rs:523's FINISHES table, so `finish: Option<Finish>` cannot be added without first moving that table into core. Two further supporting facts the audit did not name: the configurator carries `Config::metal: usize` (compose.rs:143) and still hardcodes render::GOLD for both the GLB and the hero PNG in order_files (main.rs:311-312), so even the crate that KNOWS the metal renders the wrong one; and library.rs:38-43 confirms the ladder is one step (FORMAT_VERSION 1, MIGRATIONS = [migrate_v0_to_v1]) with library.rs:312 asserting MIGRATIONS.len() == FORMAT_VERSION, so a bump needs a no-op step added there or that test fails.
+
+#### F217 The kiosk cannot sell the lost-wax half of the range — `high` / `M` / product-business
+
+**Problem.** `compose` never touches `d.draft.process`, so every kiosk ring is judged as `SandTwoPart` and the offered range is limited to what sand can pull. The engine already supports `CastProcess::LostWax` with investment floors, and `pave::halo` already switches construction between the sand plate-and-markers form and the classic proud melee ring on that flag. A halo, a proud four-claw solitaire and a shared-prong eternity — the three best-selling engagement forms in the trade — are simply not offerable.
+
+**Evidence.** crates/ringdesign-configurator/src/compose.rs `compose` sets profile, shank, layers and stones; no `draft` assignment anywhere. crates/ringdesign-core/src/castability.rs:103-114 `DraftSettings::default` uses `CastProcess::default()` (SandTwoPart). CLAUDE.md records `lost_wax_frees_the_halo_and_the_verdict_says_which_is_which` and `pave::halo` branching on the process; `SeatRunLayer::shared_prong_mm` is documented as lost-wax stock in sand.
+
+**Do this.** Unchanged. Add the caveat that a process choice changes what `reconcile()` must strip, not just what `compose` builds: `Base::takes_stones` and the pattern/milgrain gates are all curated against the sand verdict today, so `reconcile` needs a process arm too or a lost-wax halo will be offered on a base that refuses stones. And extend `every_offered_combination_is_castable` (compose.rs:379) to sweep `CastProcess::ALL` (castability.rs:78 already provides the slice) — that test is the whole reason the curation is safe, and it currently proves nothing about the lost-wax half.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `Config::process: CastProcess` and a `Stone::Halo { centre_mm, melee_mm }` / `Stone::ProngSolitaire` arm. Present it to the customer as a choice of *make* rather than a process — "Sand cast (our house method: one-off, hand-finished, textured)" vs "Investment cast (fine detail, claw settings)" — with the price difference from the cost model and the verdict judged against whichever is selected. Extend `every_offered_combination_is_castable` to sweep both processes.
+
+</details>
+
+**Castability.** Direct and intentional: under LostWax the pull statistics are reported but do not gate, so the offered set must be gated on the *selected* process, not on sand. The existing test sweep is the guard.
+
+**Verified.** Confirmed. `compose` (compose.rs:196 onward) never touches `d.draft`; the only `draft` reference in the whole file is compose.rs:404, inside the castability test. So every kiosk ring inherits `DraftSettings::default` → `CastProcess::default()` → `SandTwoPart` (castability.rs:71-111). The engine-side support the finding cites is real: castability.rs:1142 `let lost_wax = settings.process == CastProcess::LostWax`, pave.rs:434 branches the halo's construction on it, stones.rs:253 branches the prong warning on `process == SandTwoPart`, and both crates carry LostWax tests (pave.rs:1178, stones.rs:1015). The offered `Stone` enum (compose.rs:97) is None | Solitaire | Eternity — no halo, no proud-prong solitaire.
+
+**Merged into a canonical finding above:** F26 (The casting sheet is a sand document and says so on every lost-wax print) -> F15, F117 (No finishing stock allowance: the verdict judges as-designed, the shop polishes 0.1 mm off) -> F9, F209 (The casting sheet never says which metal to pour) -> F192.
+
+### M19 — Gate it, sprue it, ram it up (XL, 13 findings)
+
+**Done when:** The app names a sprue diameter, gate angle and riser from the modulus scan; states pour weight including sprue and button; and records an actual pour against its predicted verdict.
+
+#### F1 Turn the Chvorinov scan into an actual gating plan — `critical` / `L` / sand-process *(also found as F124, F242)*
+
+**Problem.** There is no sprue, gate, runner or riser anywhere in the model. The app tells a jeweller the ring releases and freezes last at some angle, then stops. A foundry hand still has to guess where to cut the sprue, how big to cut it, and whether the heavy section needs a riser. Gate a signet at the shank and the head — which the app already knows freezes last — draws its shrinkage from the last liquid metal in the head itself and comes out spongy under the engraving.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:631 `modulus_scan` returns Vec<(theta, area/perimeter)> and nothing else. Its only consumer in the whole workspace is crates/ringdesign-gui/src/app.rs:990, which takes `.max_by()` and renders one grey label at crates/ringdesign-gui/src/panels/report.rs:73-83 ("Freezes last at 92° (section modulus 1.02 mm)") whose hover text says "feed it with the gate or a riser" without saying where or how big. A workspace-wide grep for sprue/gate/riser/feeder/runner/basin finds only a hand-written sentence in an MCP prompt string (crates/ringdesign-mcp/src/prompts.rs:238) and the unrelated `Remap::Terrace { riser }` field. `FieldReport` (castability.rs:977) has no gating field; spec.rs prints none.
+
+**Do this.** Unchanged in substance, with three sharpenings. (a) It is already shelved as "gate & sprue advisor" (ROADMAP.md:195) — promote it, do not re-file it. (b) `modulus_scan` currently rebuilds a 128-point `section_at` per bin, so a `gating_plan` should take the scan as an argument rather than re-running it; the GUI worker already computes it once per settled pass. (c) `ringdesign-py` already hands the whole curve out, so the Python probe scripts in tools/harvest can calibrate the gate-modulus ratio (0.6-0.8x) against real pours before the number is hard-coded — do that first, in the house style of citing every constant.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `castability::GatePlan` and `castability::gating_plan(design, lib, &DraftSettings) -> GatePlan` in castability.rs, built from the existing `modulus_scan` plus `Report.volume_mm3`: `gate_theta_deg` (the modulus maximum, i.e. feed the hot spot directly), `alt_gate_theta_deg` (the cleanest witness site — the modulus minimum on the palm side, 180° from the crest ornament, with the note that this needs a riser over the hot spot instead), `gate_area_mm2` sized off the casting's own modulus (gate modulus ≈ 0.6–0.8 × casting modulus for a hand pour), `sprue_dia_mm` from that area, and `riser: Option<{theta_deg, dia_mm, height_mm}>` emitted when max/min modulus over the sweep exceeds ~1.3. Carry it on `FieldReport`, print it in spec.rs's Cast check table, add it to the CLI `check` output and the MCP `castability` payload, and mark the gate angle on the parting-line SVG (`write_parting_svg`, castability.rs:704) as a filled triangle so the drawing the caster holds says where to cut.
+
+</details>
+
+**Castability.** None — additive analysis over the existing field sections. It reads the same sections `analyze_field` reads, so it cannot disagree with the pull verdict.
+
+**Verified.** Verified. `castability::modulus_scan` (castability.rs:631) returns `Vec<(f64,f64)>` and nothing else. Consumers workspace-wide: `ringdesign-gui/src/app.rs:990` (takes `.max_by()` into `app.hot_spot`, rendered as one dim label at panels/report.rs:73-83 with the hover text quoted in the finding) and `ringdesign-py/src/lib.rs:352` (returns the raw curve to Python — so the curve IS already exposed there, which the finding missed). `FieldReport` (castability.rs:977) has no gating field. Greps for sprue/riser/feeder/runner/basin/gating across all crates find only `Remap::Terrace { riser }` (an unrelated relief-terrace parameter) and one prose sentence in `ringdesign-mcp/src/prompts.rs:238` telling the model to budget 1.5-2x part weight. NOTE: docs/ROADMAP.md:195 already lists "gate & sprue advisor" under M9 Niceties — this is a shelved item deserving promotion, not an unknown.
+
+#### F2 Size the pour: sprue, button and yield are named as missing and never computed — `high` / `M` / sand-process
+
+**Problem.** The app reports the finished ring's weight in ten alloys and then explicitly disclaims everything a caster actually has to melt. A hand-poured Delft clay ring runs roughly 45–60% yield; a jeweller who cuts 8.4 g of sterling because the sheet said 8.4 g gets a short pour and a scrapped mould.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:131 — `"Casting weight only — no sprue, button, or finishing loss."`; crates/ringdesign-gui/src/panels/report.rs:637 repeats the same sentence. `metal::metal_table` (metal.rs:60) maps volume → grams and nothing more; `Metal` (metal.rs:6) carries only `name`, `density`, `shrink_pct`. The CLI's own module doc (crates/ringdesign-cli/src/main.rs:3) says "Sand casters pour size runs in one flask" yet the manifest at main.rs:168 has no grams column and no run total.
+
+**Do this.** Unchanged, plus: the 1.5-2x rule already written into `ringdesign-mcp/src/prompts.rs:238` is the number to formalize — make `pour_weight` reproduce it and delete the prose, so there is one figure rather than a computed one and an advisory one. `Metal` is a `&'static` table with `Serialize` only, so adding fields costs nothing in migration.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add to metal.rs: `pub struct Pour { part_g, sprue_g, button_g, total_g, yield_pct }` and `pour_weight(volume_mm3, metal, &GatePlan) -> Pour`, with the sprue volume taken from the gate plan's tapered sprue geometry and the button sized as a multiple of the sprue's own section (a button whose modulus exceeds the casting's is what makes the sprue a feeder rather than a plug). Put the chosen alloy's Pour on the sheet's Casting weight table as a fourth row group, add `pour_g` to the CLI manifest and a printed run total (`N sizes × total_g = X g to melt`), and let the configurator's price step multiply by `total_g` instead of `grams` with the yield shown.
+
+</details>
+
+**Castability.** n/a — reporting only.
+
+**See also.** F125 and F210 turn this into a quote, in M23.
+
+**Verified.** Verified exactly. `metal::Metal` (metal.rs:6-14) carries only `name`, `density`, `shrink_pct`; `metal_table` (metal.rs:60) maps volume to grams/dwt and stops. The disclaimer is literal at spec.rs:131 and repeated at gui/panels/report.rs:637. No `Pour`, `yield`, `sprue_g` or `button_g` identifier exists anywhere in the workspace. The CLI manifest header (cli/src/main.rs:168) is `size,file,format,bytes,triangles,watertight,verdict,undercut_pct,thinnest_wall_mm,volume_mm3` — no grams, no run total, and the loop at main.rs:232 writes no summary line. The only figure that exists anywhere is the prose "1.5 to 2 x the part weight" in the MCP prompt string (prompts.rs:238), which no code reads.
+
+#### F13 The export is a ring, not a pattern: no sprue stub, no parting register, no handling boss — `high` / `L` / sand-process *(also found as F201)*
+
+**Problem.** What comes out of the app is a bare torus. What a two-part sand mould wants is a *pattern*: something that beds to a definite depth on the parting plane, that can be pulled without fingers in the cavity, and whose gate is cut in the same place every time. Today the caster eyeballs the equator into the drag, guesses the bedding depth, and cuts a freehand sprue in whatever spot the pattern let go of. The parting-line SVG is a paper aid to a job that could be built into the printed pattern itself.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:209-214 and crates/ringdesign-gui/src/export.rs write `built.mesh` (optionally `.scaled()`) straight to STL/OBJ/3MF. `Mesh` (mesh.rs) is the swept torus and nothing else — grep finds no code that adds any feature to it after build. The only pattern-practice affordance is `write_parting_svg` (castability.rs:704), a separate printed sheet.
+
+**Do this.** Add a `pattern.rs` module producing a pattern variant of the mesh at export time, off a `PatternOptions { register_flange, sprue_stub, handling_boss, extra_draft_deg }`: a thin flat skirt in the parting plane around the silhouette (a positive stop for bedding, and it prints the flash line into the mould where it is meant to be), a short tapered sprue stub at the gate plan's angle, and a small pull boss on the flange opposite it. Name the file `*_pattern.stl` as the shrink export already does. Its own field verdict must be re-run — the flange is on the plane and pulls both ways, so it is safe by the same argument as a side face, but the app should prove it rather than assume it.
+
+**Castability.** A flange lying exactly in the parting plane has perfect draft in both directions — the same guarantee as a side face. The sprue stub must be drafted; a straight stub is the classic vertical wall and should be tapered off the gate plan's own cone.
+
+#### F14 Flask and ram-up numbers are never reported, including for the size run that exists to fill one flask — `medium` / `S` / sand-process
+
+**Problem.** To ram up you need to know how deep the pattern sits below the plane and how tall it stands above it — that sets the drag and cope depths and whether the ring fits the frame you own. The app reports total Z extent and the parting height separately, so the user does the subtraction, and only if they think to. The CLI's whole reason for existing is "sand casters pour size runs in one flask", and it never says how many rings fit one, or what the run weighs.
+
+**Evidence.** `Report.bounds_mm[2]` (mesh.rs:268) is total Z; `FieldReport.parting_z_mm` (castability.rs:986) is the plane. Neither `Report` nor `FieldReport` carries the split. spec.rs's Cast check row prints "Parting plane z = ±x; cope pulls +Z, drag −Z" and no depths. crates/ringdesign-cli/src/main.rs:3 states the flask premise; main.rs:168 defines the manifest columns with no weight, no footprint and no run total, and main.rs:232 writes it with no summary line.
+
+**Do this.** Add `cope_depth_mm` and `drag_depth_mm` to `FieldReport` (max and min sample z relative to `parting_z`) plus `plan_extent_mm` (the silhouette's bounding circle diameter, which is the footprint on the sand), and print all three on the sheet. In the CLI, add a `--flask <dia>x<height>` option that packs the size run's plan extents with a bedding gap and prints "7 rings fit a 100 mm frame; 62 g of sterling to melt at 55% yield", plus the same as a manifest summary row.
+
+**Castability.** n/a — reporting.
+
+#### F16 The parting line and the parting plane are two different rules, and nothing bounds their disagreement — `medium` / `S` / sand-process
+
+**Problem.** The verdict assumes a flat mould split at one height for the whole ring — that assumption is the entire castability guarantee. The drawing handed to the caster is built by a different rule: the widest point of each slice, tie-broken toward the plane. On a plain band these coincide; on a keyframed, waved, bypass or upright-signet band the widest point wanders in z, and the SVG's own second panel exists precisely to show that wander. Nothing states which is authoritative, nothing measures the maximum deviation, and nothing warns that a caster who rams to the drawn line has made a contoured parting the flat-pull verdict never judged. Separately, the auto-parting doc comment and the GUI hover both say "widest silhouette", which is the line's rule, not the plane's.
+
+**Evidence.** castability.rs:666-703 `parting_line` selects `p.r > max_r - 0.02` then breaks ties by `|p.z - parting_z|`. castability.rs:259-296 `best_parting_z` / `scan_parting_z` minimise undercut area with ties toward the mid-height — a different objective. `DraftSettings::auto_parting` doc (castability.rs:50) reads "Put the parting plane at the widest silhouette of the ring", and crates/ringdesign-gui/src/panels/design.rs:1260 repeats it; neither matches the code. The only test, castability.rs:1414 `the_parting_line_rides_the_widest_silhouette_and_the_svg_writes`, runs on `RingDesign::default()` — a plain band, where the answer is trivially the crest circle on the plane.
+
+**Do this.** Return `parting_line`'s maximum |z − parting_z| alongside the points, report it on `FieldReport` as `parting_line_deviation_mm`, and put it on the sheet and the SVG ("the line rises 0.31 mm off the plane at 118° — ram to the plane, not to the line"). Fix the two stale doc strings to say what `best_parting_z` actually does. Add a test over the modulated shanks — Wave, Twist, Keyframes, Bypass, an upright heart signet — asserting the deviation stays under a stated bound, which is exactly the kind of measured constant this codebase pins everywhere else.
+
+**Castability.** Direct. A contoured ram invalidates the flat-plane analysis the verdict is built on; this finding is about making that boundary explicit rather than implicit.
+
+#### F18 No metal economy: yield, scrap and cost-per-pour are absent from a tool that prices rings — `medium` / `S` / sand-process
+
+**Problem.** The app prices metal by multiplying the finished ring's grams by a per-gram figure. That is the cost of the ring, not the cost of making it. A hand pour puts roughly as much metal into the sprue and button as into the part; that metal is recovered, but it is capital tied up, it work-hardens and picks up oxides across remelts, and a shop needs to know how much of the crucible is part and how much is return. None of this exists.
+
+**Evidence.** crates/ringdesign-gui/src/panels/report.rs:598-625 `metals_priced` — `prices.get(m.metal)` × `m.grams` from `report.metals`, which is `metal_table(volume_mm3)` of the finished ring only. crates/ringdesign-configurator/src/main.rs:603 does the same. `Metal` (metal.rs:6) has no cost, scrap or remelt field. No `yield`, `scrap` or `reclaim` identifier exists in the workspace.
+
+**Do this.** Once `pour_weight` exists (see the pour-weight finding), price the *pour* and show both figures: "ring 8.4 g · pour 17.1 g · 49% yield · $20.50 melted, $10.10 in the ring". Add a `remelt_notes` string per alloy for the alloys that need fresh metal added on each remelt (sterling in particular loses zinc/copper balance and gasses more each cycle). In the CLI size run, print the total for the flask so the shop knows what to weigh out.
+
+**Castability.** n/a.
+
+**See also.** F125 and F210 are the quote-engine half of this, in M23.
+
+#### F28 There is no investment DFM: no feed path, no gate, no sprue, no tree — `high` / `M` / lost-wax
+
+**Problem.** The app has the exact input a gate advisor needs and does nothing with it. `castability::modulus_scan` computes Chvorinov's area-over-perimeter per slice and the report panel already tells the user which slice freezes last — then stops. Nothing says where to attach the sprue, what diameter it should be, whether the run from gate to the far side will freeze off before it fills, or whether a thin section sits downstream of a thick one (the classic isolated-hot-spot / shrinkage-porosity trap). "Gate & sprue advisor" is parked on the M9 "Niceties" shelf; it is the shortest path from current code to real manufacturing confidence in both processes.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:631-658 `modulus_scan`. crates/ringdesign-gui/src/panels/report.rs:82 — the tooltip already says "feed it with the gate or a riser, or shrinkage porosity collects there", advice with no tool behind it. docs/ROADMAP.md:195 lists "gate & sprue advisor" under Niceties. No `sprue`, `gate`, `feeder` or `riser` symbol exists anywhere in crates/.
+
+**Do this.** Promote it off the M9 Niceties shelf (ROADMAP.md:195). `castability::feed_plan(design, lib) -> FeedPlan` built on the existing `modulus_scan`: modulus round the ring, recommended gate angle (max-modulus slice, biased toward the shank so the scar files off), sprue diameter from the modulus rule (gate modulus ≳ 1.1× local part modulus), gate count for two hot spots, and a monotonicity flag where a thin run feeds a thick one. Print it on the sheet and mark the gate on the existing parting-line SVG (`castability::parting_line`). Add tree spacing under lost wax. This is the single shortest path in the whole list from code that already exists to manufacturing confidence, and it pays in both processes.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Promote it off the shelf. `castability::feed_plan(design, lib) -> FeedPlan`: the modulus profile round the ring, a recommended gate angle (the maximum-modulus slice, biased toward the shank so the gate scar lands where it is filed off), a sprue diameter from the modulus rule (gate modulus ≥ ~1.1× the part's local modulus), the number of gates for a piece with two hot spots, and a monotonicity check flagging a thin run feeding a thick one. Print it on the sheet and mark the gate on the parting-line SVG. Under lost wax add tree spacing from the ring's outer diameter.
+
+</details>
+
+**Castability.** None. It is additive analysis, extending the parting-line export that already exists.
+
+**Verified.** Confirmed by grep for sprue|gate|riser|feeder|chvorinov|modulus across crates/ and docs/: the only hits are `castability::modulus_scan` (castability.rs:631-658) and its three consumers (app.rs:990 → `hot_spot`, report.rs:75-82, py lib.rs:350), plus one *prose* mention in an MCP prompt (prompts.rs:238, "needs a sprue and a feeder on top of the part, so budget roughly 1.5 to 2 x the part weight") — advice with no tool behind it. No `sprue`, `gate`, `feeder`, `riser` or `FeedPlan` symbol exists. The report tooltip at report.rs:82 does already say "feed it with the gate or a riser, or shrinkage porosity collects there". docs/ROADMAP.md:195 lists "gate & sprue advisor" under M9 Niceties, so this is a shelved item — keep it, but flag it as a promotion rather than a discovery.
+
+#### F29 Nothing about the 3D-printed pattern, which is how lost wax is actually made today — `high` / `L` / lost-wax
+
+**Problem.** Almost every lost-wax ring now starts as a printed resin or wax pattern, and none of that reality is modelled: no print orientation, no marking of surfaces that will carry support-contact scars, no hollowing with drain holes for a heavy signet, no layer-line direction warning on a visible flat table, no minimum printable feature per printer class (a 0.05 mm DLP pixel versus a 0.25 mm FDM nozzle). The app's only feature floor is `min_detail_mm`, which describes the mould medium, not the machine that makes the pattern.
+
+**Evidence.** `grep -rni "orientation|support structure|printer|resin|layer line|drain hole"` across crates/ returns only camera and render hits. `DraftSettings` (castability.rs:41-60) has five fields, none about the pattern. `CastProcess::apply` sets a detail floor of 0.15 mm with no reference to how the pattern is produced.
+
+**Do this.** Add `PatternSource { Carved, PrintedResin { min_feature_mm, layer_mm }, PrintedWax { .. }, Milled }` alongside the process and derive the effective floor as `max(process_detail, pattern_min_feature)` — that alone tightens every existing DFM chip for a coarse machine at near-zero cost, since dfm.rs already reads one number. Then two concrete tools: a print-orientation suggestion that keeps the table and any engraved side face off supports (the app already knows the ornament face via `FieldContext::side_faces`), and a hollow check on `SignetHead::hollow_mm` reporting whether the scoop leaves resin-trapping geometry wanting a drain hole.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a `PatternSource { Carved, PrintedResin { min_feature_mm, layer_mm }, PrintedWax { .. }, Milled }` to the process settings and derive the effective detail floor as `max(process_detail, pattern_min_feature)` so a coarse printer tightens the existing DFM chips. Then two concrete tools: a print-orientation suggestion putting the table and any engraved side face away from supports (the app already knows the ornament face via `FieldContext::side_faces`), and a signet hollowing check — `SignetHead::hollow_mm` already scoops the belly, so report whether the scoop leaves a closed void that would trap resin and want a drain hole.
+
+</details>
+
+**Castability.** None to sand — and it would improve sand too, since a printed sand pattern has the same feature ceiling.
+
+**Verified.** Grepped orientation|support structure|printer|resin|layer line|drain hole|3d print across crates/ and docs/: the only hits are camera orientation (camera.rs:72), render orientation (render.rs:47) and a tiling-orientation UI string (layers.rs:1112). Nothing about pattern production. `DraftSettings` (castability.rs:42-61) has no pattern field; `CastProcess::apply` sets a 0.15 mm detail floor with no reference to what makes the pattern. `SignetHead::hollow_mm` does exist and scoops the belly from the finger hole, so the geometry the drain-hole check would examine is already there.
+
+#### F119 The parting surface is one flat z, though `parting_line` already computes the contoured one — `high` / `XL` / dfm-verdict
+
+**Problem.** `best_parting_z` searches a single height; `draft_angle` assigns every point to cope or drag by `centroid_z >= parting_z`. A real jobbing sand mould is routinely parted on a *contoured* surface cut with a follow board — and this codebase already computes that curve, per angle, in `parting_line`. Because the verdict cannot use it, the whole Wave/Twist/Bypass family had to be constructed around the constraint: the doctrine records that Wave's "edges slide along the finger while the crest stays on the parting plane", swing capped at 0.6 of the half-width, and Bypass's crest "rides the parting plane by Wave's mechanism". Those caps are artefacts of the *measure*, not of the sand.
+
+**Evidence.** crates/ringdesign-core/src/castability.rs:216-228 (`draft_angle`'s scalar `parting_z`), :242-276 (`best_parting_z`/`scan_parting_z` scan height only), :1107-1115 (analyze_field's single `parting_z`). Against that, castability.rs:657-700 `parting_line` already returns one `[x,y,z]` per angle, and `write_parting_svg` already prints its height unrolled — the curve exists and is exported, but no verdict reads it.
+
+**Do this.** Generalize the parting height to `parting_z(theta)`: an `enum Parting { Flat(f64), Contoured(Vec<f64>) }` on `DraftSettings`, with `Contoured` seeded from `parting_line`'s own z per slice and smoothed (a contoured parting board must itself be a manufacturable curve — cap its slope, and report the maximum slope so a moulder knows what they are cutting). `draft_angle` takes the local height; `analyze_field` and `attribute_undercuts` pass it per slice. Report both verdicts side by side: "flat parting: 1.4% undercut; contoured parting: 0.0% — needs a follow board with 3.2 mm of rise".
+
+**Castability.** Directly changes what the two-part guarantee means, so it must be additive: the flat verdict stays the default and stays reported, and the contoured verdict is a second, explicitly-labelled column with the follow-board rise stated. Never silently relax the flat number.
+
+#### F221 The moat is real but unwitnessed — nothing records an actual pour against a predicted verdict — `critical` / `M` / product-business
+
+**Problem.** The defensible advantage over Matrix, RhinoGold, Jewelcad and CrossGems is that this app *proves* a ring pulls from a two-part sand mould — an analytic field verdict that converges with resolution, plus measured per-layer DFM. Those competitors are modellers and compute none of it. But the claim is entirely internal: nothing in the repo records what happened when a ring was actually poured. The comparison machinery exists (`examples/scan_signet.rs` reads bought STEP/STL, `tools/harvest/deviation.py` does exact point-to-surface, `examples/edge_probe.rs` does the crease census) and is shelved as a script-only nicety.
+
+**Evidence.** docs/ROADMAP.md:195 — "Niceties: ... reference-mesh import + deviation report as a core feature (the exact point-to-triangle measure and the crease census, today script-only)". crates/ringdesign-core/examples/scan_signet.rs and examples/common/scan.rs exist and are used to validate against bought CAD, never against a cast piece. CLAUDE.md's measured tables are all model-vs-model or model-vs-reference-CAD.
+
+**Do this.** Unchanged. Sequence it after finding 1: a cast log has nowhere to live until an `Order` with a stable id exists, and the `--outcome` CLI verb needs that id as its argument. The deviation half is already on the Niceties shelf; the new argument for promoting it is that it becomes the evidence behind the tally, not just a probe. Store the predicted verdict and undercut fraction *at order time* (from the `attributed_field_report` already computed in `order_files`), because re-deriving it later from a rebuilt design would silently re-predict rather than record.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Close the loop and make it the marketing. (1) Promote the deviation measure into core as `deviation::compare(reference_mesh, built_mesh) -> DeviationReport` (mean, p90, worst, and where), which the shelf note already scopes. (2) Add a `cast_log` to the order record: predicted verdict and undercut fraction at order time, then the actual outcome after the pour (`Filled | ShortFill | Locked | Scrapped`), a photo, and optionally a scan for the deviation report. (3) Report the running tally — "N rings poured, M predicted castable, zero locked moulds" — on the sheet, on the site, and in the README. Ship a `ringdesign log <order-id> --outcome filled` CLI verb so recording it costs the caster ten seconds.
+
+</details>
+
+**Castability.** This is the castability guarantee's own validation loop — the only finding here that directly strengthens the two-part sand pull claim rather than merely respecting it.
+
+**Verified.** Confirmed. Greps for cast_log, outcome-as-a-pour, poured, short fill across crates/ and docs/ find only `PaveOutcome` (pave.rs:127, a packing result) — nothing about a physical casting. The comparison machinery is script-only exactly as claimed: tools/harvest/deviation.py is a Python script (README: "Exact point-to-triangle deviation between our exported ring and a factory mesh, by region"), fed by tools/harvest/py_build.py through the Python module; docs/ROADMAP.md:195 shelves "reference-mesh import + deviation report as a core feature (the exact point-to-triangle measure and the crease census, today script-only)" under Niceties, and M6.3 (line 150) only made the probes module-backed, not core. examples/scan_signet.rs compares against bought CAD, never against a cast piece. So both halves — no core deviation type, no pour record — hold.
+
+**Merged into a canonical finding above:** F124 (The hot-spot scan finds the global maximum but never an isolated one, and nothing recommends a gate) -> F1, F201 (No sprue, no gate, no print orientation — the pattern is not print-ready) -> F13, F242 (No gate and sprue advice, although every input is already computed) -> F1.
+
+### M20 — A stone is stock with a species (XL, 22 findings)
+
+**Done when:** A stone has a species with its own density and hardness; calibrated stock is quoted LxW; a pear's seat follows its own girdle; the setter's sheet gives a bur size per seat.
+
+#### F42 A windowed seat run fades its end stones' stock instead of ending the row — `high` / `M` / ring-typology
+
+**Problem.** A half-eternity is authored as a full-ring `SeatRun` cropped by a `Window`. The window mask multiplies the layer's height, so the outermost surviving stations build at a fraction of their seat height while the stones report and the setter's map credit them at full size. The bench gets a row that ends in two or three shallow mounds with nothing to cut a seat into.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:811-818 `let w = e.mask_at(uv, ctx, lib); ... let h = e.remap.apply(...) * e.opacity * w;` — the mask scales the relief. crates/ringdesign-core/src/setstone.rs:54 `pub fn kept(...) -> bool { entry.window.mask(uv, ctx) > 0.5 }` — a station is counted whole whenever its centre is over half strength. So a station at mask 0.6 records a full 2.5 mm stone on a seat that actually stands 0.6 × `height_mm`, and `stones::report` reads the recorded seat, not the built one.
+
+**Do this.** Unchanged in substance. In `LayerStack::height_d` (field.rs:802) split the mask: for entries whose layer is `Layer::SeatPad`/`Layer::SeatRun`, or a `Layer::Group` whose `recipe` is `GenRecipe::Pave`/`Halo`, use `if w > 0.5 { 1.0 } else { 0.0 }` instead of multiplying — matching `setstone::kept` exactly, since that is the function that decides what the bench is told exists. The pad's own `blend_mm` skirt then fairs the row's end, which is what a real half-eternity does. Add a test asserting `stones::report`'s carat total equals the sum of the seats actually built at full height on the sketches.rs half-eternity, since that design is the reproducer.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Make the gate binary for seat-bearing layers: in `LayerStack::height_d`, when the entry's layer is `SeatPad`/`SeatRun` (or a group whose recipe is Pavé/Halo), threshold the window mask at 0.5 rather than multiplying it, matching `setstone::kept`. The fade then lands on the pad's own skirt, which is what fairs a real row's end. Alternatively give `SeatRunLayer` its own arc (next finding) and reserve windows for ornament.
+
+</details>
+
+**Castability.** A binary gate raises a step in the height field at the window edge, but the pad's own `blend_mm` skirt already fairs the mound to zero within its own footprint, so the step is at the outside of the skirt where relief is already zero. No new wall.
+
+**Verified.** Confirmed, and it is live in a shipped example. field.rs:770-783 `mask_at` returns the window mask times the painted alpha, and field.rs:811-818 multiplies it into the height (`e.remap.apply(...) * e.opacity * w`). setstone.rs:54 `kept()` thresholds the same mask at `> 0.5`, so the two disagree over the whole fade band. `Window::around` (field.rs:440) sizes the fade at a fifth of the span, so examples/sketches.rs:146-147 — `LayerEntry::new("Half eternity", Layer::SeatRun(run)); entry.window = Window::around(TOP_DEG, 200.0)` on ~24 stations of 2 mm rounds — puts a 40° fade at each end, i.e. roughly two to three stones per end standing at 0.5-1.0 of `height_mm` while `stones::report` and `stonemap` credit them whole. The doc on `SeatRunLayer::shared_prong_mm` (field.rs:1729) already concedes the behaviour: "an arc window fades boundary posts with everything else".
+
+#### F43 SeatRun has no arc of its own — every row is solved over the full 360° — `high` / `M` / ring-typology
+
+**Problem.** `count` and `bridge_mm` are always solved against the whole circumference, so a half-eternity of eleven stones has to be authored as twenty-two with a 180° window. The number the jeweller types is not the number of stones, `solve_spacing` optimizes a pitch for metal that will be windowed away, and the sheet's count only becomes right after the window is applied elsewhere.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1833 `pub fn theta_of_station(&self, k: f64, ctx) -> f64 { let n = self.count.clamp(1,200) as f64; if self.taper <= 0.0 { return k * 360.0 / n; } ... }` — the lattice is unconditionally the full turn. `solve_spacing` (field.rs:1786) takes "the most stations of that seat plus the bridge that fit the ring". `SeatRunLayer` has no start/end or arc field at all.
+
+**Do this.** Unchanged. Add `arc_deg: f64` (serde default 360) and `start_deg: f64` to `SeatRunLayer`; when `arc_deg < 360` place stations at `start + k·arc/(count−1)` (both ends carrying a stone) and have `solve_spacing` fit the arc's metal length `circumference·k·arc/360` rather than the circle's. Keep the exact `k · 360/n` branch at field.rs:1836 for `arc_deg == 360` so every saved design is bit-identical — the same no-migration discipline `taper <= 0.0` already gets. `theta_of_station`, `station_of_theta`, `bridge_at` and `spacing_c` are the four call sites; the graded `eccentric_warp` path needs its own thought since the warp is a reparameterization of the *circle* and an open arc is not one — the honest first cut is to refuse or ignore taper on an open row and say so.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `arc_deg: f64` (default 360) and `start_deg: f64` to `SeatRunLayer`. When `arc_deg < 360` the stations are `start + k·arc/(count−1)` (open row, both ends carrying a stone) and `solve_spacing` fits the arc's own metal length; keep the wrap-exact integer lattice for the 360 case so no saved design moves. `bridge_at`, `station_of_theta` and the graded `eccentric_warp` all already take a length — they need the arc's, not the circle's.
+
+</details>
+
+**Castability.** None — an open row is the same mounds on the same lattice over a shorter arc. Only the full-ring case needs the integer-count seamlessness guarantee, and that path is unchanged.
+
+**Verified.** Confirmed. `SeatRunLayer` (field.rs:1708-1743) has seat, count, gem, bridge_mm, taper, taper_theta_deg, shared_prong_mm, tilt_deg — no start or arc. `solve_spacing` (field.rs:1786) computes `count = floor(circumference·k / sqrt(near·far))` over the whole circumference; `theta_of_station` (field.rs:1833) returns `k · 360/n` ungraded and the eccentric warp over TAU graded; `bridge_at` (field.rs:1879) divides `circumference·k` by count. Nothing takes an arc. `grep -rn "arc_deg"` finds nothing anywhere in crates/. The half-eternity idiom is confirmed to be exactly the windowed workaround the finding describes (examples/sketches.rs:146).
+
+#### F44 No pearl stock: the model refuses the easiest ring a bench sets — `high` / `S` / ring-typology *(also found as F230)*
+
+**Problem.** There is no pearl. A half-drilled pearl on a cup and peg is a whole catalogue section and one of the commonest jobs at the bench, and the app cannot even record one — a pearl entered as a Cabochon gets charged pavilion clearance and carat weight it does not have, and there is no cup-and-peg stock to cast.
+
+**Evidence.** crates/ringdesign-core/src/gem.rs:11 `pub enum GemCut { Round, Oval, Cushion, Princess, Emerald, Baguette, Pear, Marquise, Trillion, Heart, Radiant, Asscher, Hexagon, HalfMoon }` — no pearl. gem.rs:189 `pub enum GemForm { Faceted, Cabochon }`. crates/ringdesign-core/src/field.rs:977 `pub enum SeatStyle { Boss, Bezel, GypsyMound }` — no cup. `pearl` appears nowhere in crates/ringdesign-core/src. docs/ROADMAP.md:191 lists "pearl stock" on the M9 Shelf, unpromoted.
+
+**Do this.** Promote off the Shelf. Add `GemForm::Pearl`: `pavilion_mm()` returns `BED_CLEARANCE_MM` like a cabochon, weight computed from a sphere at nacre density and reported in mm and momme rather than carats (the report's carat rollups in stones.rs need a non-carat column, which is the only invasive part). Add `SeatStyle::PearlCup` — a shallow dish whose rim is the pearl diameter less a burnish allowance, with the existing `SeatPadLayer::dimple_mm` sized to the peg drill. Keep the peg a bench operation and say so: a radial post on the crest is the same undercut as the shared prong that `SeatRunLayer::shared_prong_mm` measured at 2.8-3.0% / −62°, so `stones::report` should print peg wire Ø, projection and drill depth as bench stock exactly the way it prints claw stock today.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `GemForm::Pearl` (density-correct weight — pearls are sold by mm and by momme, not carats; `pavilion_mm` returns 0 like a cabochon) and `SeatStyle::PearlCup`: a shallow dished cup whose rim is the pearl's own diameter less a burnish allowance, with a centre `dimple_mm` sized to the peg drill. The peg itself is a bench operation and must stay one — a radial post on the crest is a genuine undercut in a ±Z pull, exactly like a prong — so `stones::report` should print the peg spec (wire Ø, projection, drill depth) as bench stock the way it already prints claw stock for shared prongs.
+
+</details>
+
+**Castability.** The cup is a dished pad — on a side face it is a straight-walled pocket (castable by construction, like the bezel), on the crest its walls turn to ceilings, so it inherits the bezel's existing side-face warning verbatim. The peg is never cast.
+
+**Verified.** Confirmed, and already on the roadmap Shelf. `GemCut` (gem.rs:11) has no pearl; `GemForm` is `{ Faceted, Cabochon }` (gem.rs:189); `SeatStyle` is `{ Boss, Bezel, GypsyMound }` (field.rs:977). `grep -rni "pearl"` across the whole repo returns exactly one hit: docs/ROADMAP.md:191, where "pearl stock" sits on the M9 Shelf line between "`stones::probe_seat`" and "flat-edged seat plans", unpromoted and undated. The craft half of the finding is also right — a pearl entered as a Cabochon would be charged `BED_CLEARANCE_MM` for pavilion (correct) but weighed by the cabochon's 0.0176 ct/mm³ half-ellipsoid, which is nacre priced as gemstone.
+
+#### F52 Channel setting produces no stones — a channel eternity is either rails or seats, never both — `medium` / `M` / ring-typology *(also found as F63)*
+
+**Problem.** `channel_set` emits two rails and a recess sized from one gem, but no stations and no stone records. A channel-set eternity — one of the four canonical eternity constructions — therefore cannot be represented: choosing the channel loses the stones from the report, the setter's map and the gem preview; choosing a `SeatRun` loses the channel.
+
+**Evidence.** crates/ringdesign-core/src/pave.rs:285-330 `channel_set` returns a Group of three `BorderLayer`s ("Low rail", "High rail", "Channel") and nothing else; `ChannelSpec` carries only `{ gem, recess_mm }`. crates/ringdesign-core/src/setstone.rs:83 `walk` matches only `Layer::SeatPad`, `Layer::SeatRun` and `Layer::Group`, so a channel group contributes zero `SetStone`s and `stones::report` counts none.
+
+**Do this.** Unchanged. Give `ChannelSpec` a `count: u32` (or arc + pitch, ideally the same `arc_deg` finding 4 adds to `SeatRunLayer` so the two agree) and have `channel_set` push, into the same group, a `SeatRunLayer` of flat bearing stations at the channel's floor — `SeatStyle::Boss` at near-zero crown with `dimple_mm` marking each bur centre — so `set_stones` picks them up for free through the existing `Layer::Group` recursion. The rails are the stock the setter hammers over; the stations are what he drills, and they must be at the *channel floor's* v and depth or the section view will draw girdles floating above the recess. `live_groups_regenerate_with_the_band_and_bake_detaches` already covers the regeneration lifecycle, so add the stone count to `every_consumer_counts_the_same_stones`.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `ChannelSpec` a `count` (or an arc plus pitch) and have `channel_set` emit, inside the same group, a `SeatRunLayer` of flat bearing stations at the channel's floor — `SeatStyle::Boss` with near-zero crown and a `dimple_mm` marking each bur centre — so `setstone::set_stones` picks them up and the report, the stone map and the preview all show a channel eternity's stones. The rails are the stock the setter hammers over; the stations are what he drills.
+
+</details>
+
+**Castability.** None: the rails and the recess already field clean on a side face, which is the only place `channel_set` will build (it returns `None` on a thin or domed band). Flat bearing stations at the channel floor are shallower than the recess itself.
+
+**Verified.** Confirmed exactly. `channel_set` (pave.rs:285-330) returns a Group of three `BorderLayer`s — "Low rail", "High rail", "Channel" — and nothing else; `ChannelSpec` is `{ gem, recess_mm }` (pave.rs:545-548), so the stone is used only to size the recess and rails and is then discarded. `setstone::walk` (setstone.rs:82-127) matches `Layer::SeatPad`, `Layer::SeatRun` and `Layer::Group` and falls through `_ => {}` on everything else, so a channel group yields zero `SetStone`s — and since CLAUDE.md establishes that the report, the gem preview and the section view all read that one list, choosing a channel loses the stones from all three at once.
+
+#### F59 A stone has no species: carats, weight, price and every hardness warning are diamond-only — `critical` / `M` / stone-setting *(also found as F193)*
+
+**Problem.** `Gem` is `{cut, w_mm, l_mm, form}`. There is no material anywhere in the codebase — no grep hit for ruby, sapphire, Mohs, hardness or density. `GemCut::carats` uses diamond-anchored packing factors and `GemForm::Cabochon` weighs itself at a literal 0.0176 ct/mm³ (3.52 g/cm³). A 6 mm sapphire cabochon therefore reports 14% light, a CZ 62% light, an emerald 23% heavy. Worse for the bench: with no hardness or toughness the report cannot say the one thing that destroys stones, and the default seat style is GypsyMound — flush setting, which hammers metal against the girdle. Flush-setting an emerald, opal, tanzanite or a coated/fracture-filled stone is how a setter loses a client's stone, and nothing in stones.rs says a word.
+
+**Evidence.** crates/ringdesign-core/src/gem.rs:222-231 (`struct Gem`), :121-143 (`carats`, diamond factors), :255-265 (cabochon at 0.0176 ct/mm³); no matches for `mohs|hardness|species|ruby|sapphire` under crates/ (grep run over all *.rs); crates/ringdesign-core/src/field.rs:1755-1763 — `SeatRunLayer::default` fits a GypsyMound; crates/ringdesign-core/src/stones.rs:591-626 — the warning set is footing, edge clearance and culet only.
+
+**Do this.** Add `gem::GemSpecies` with `sg`, `mohs`, `toughness` and `heat_sensitive`, and a `species: GemSpecies` field on `Gem` with `#[serde(default)] = Diamond` so every design file loads unchanged. Multiply by `sg / 3.52` in *both* carat paths — `GemCut::carats` and the cabochon's 0.0176 literal, which is a separate hardcode. Add the bench warning in `stones::check_seat` alongside the existing four, keyed on `seat.style` being GypsyMound or Bezel and toughness below Good: flush setting drives metal onto the girdle. Also gate it by process: a heat-sensitive stone is a note for the setter regardless, but an opal or emerald in a gypsy mound is the one that loses a client's stone. `spec.rs`'s stone table and `gems::GEM_TINT` both become species-aware for free (see finding 14).
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `gem::GemSpecies` (Diamond, Moissanite, Sapphire/Ruby, Emerald, Aquamarine/Beryl, Topaz, Tourmaline, Garnet, Amethyst/Quartz, Opal, Turquoise, Pearl, CZ, Lab-created variants) carrying `sg`, `mohs`, `toughness: Poor|Fair|Good|Excellent`, `heat_sensitive: bool` and a preview `tint`. Multiply the carat estimator by `sg / 3.52`; give `Gem` a `species` field with a serde default of Diamond so every existing file loads unchanged. Then add the bench warning in `stones::check_seat`: a GypsyMound or a Bezel carrying a stone with toughness below Good or Mohs below 7.5 warns "flush/burnished setting drives metal onto the girdle — <species> chips; use a boss with claws or a bezel with a soft-jaw pusher".
+
+</details>
+
+**Castability.** None. Species is metadata plus report logic; it changes no height field and no verdict. The tint feeds the preview only, which is never in the Mesh.
+
+**Verified.** Grepped `mohs|hardness|species|ruby|sapphire|toughness|refractive` case-insensitive over all of crates/ — zero hits. `struct Gem { cut, w_mm, l_mm, form }` at gem.rs:222-231, no material field. `GemCut::carats` (gem.rs:121-143) is a fixed table of diamond packing factors; the cabochon branch (gem.rs:255-262) hardcodes `v * 0.0176` with the comment naming 3.52 g/cm³ explicitly. `SeatRunLayer::default` fits a `SeatStyle::GypsyMound` (field.rs:1749-1763) with a comment justifying it on castability grounds only — no stone-safety caveat. `check_seat`'s whole warning set (stones.rs:594-626) is: bezel-on-crown, flat-topped-pad draft, band-edge clearance, culet depth. Nothing about the stone's own durability. `SeatStyle::ALL` has three variants and none carries a material caveat.
+
+#### F60 A client's own stone cannot be entered: depth is derived, never measured — `high` / `S` / stone-setting
+
+**Problem.** `Gem::depth_mm()` is always `w_mm * cut.depth_frac()`, a standard-make table. `pavilion_mm()` is 0.65 of that, and that number is what the report's culet check and the census's `gap_deep_mm` are built on. The commonest custom job — reset the client's inherited stone — cannot be expressed. A native-cut Sri Lankan sapphire runs 75-85% depth against the table's 60%; a recut old European brilliant runs 65% with a big culet. The report then under-states the pavilion by a third and passes a stone that will punch through the bore, and the crowding census's culet column is wrong by the same factor. There is also no girdle thickness anywhere, so the girdle is a knife line and a bezel's bearing has nothing to sit on.
+
+**Evidence.** crates/ringdesign-core/src/gem.rs:268-297 — `depth_mm`, `crown_mm`, `pavilion_mm` all derived from `w_mm`; crates/ringdesign-core/src/stones.rs:618-626 — the culet warning reads `gem.pavilion_mm()`; stones.rs:464 — `StoneFrame::pavilion` likewise; crates/ringdesign-gui/src/panels/layers.rs:2052-2095 — `gem_picker` offers cut, one calibrated width and form, nothing else.
+
+**Do this.** Add `depth_mm: Option<f64>` and `girdle_mm: Option<f64>` to `Gem` with serde default None, and have `depth_mm()`/`crown_mm()`/`pavilion_mm()` honour the override in both the Faceted and Cabochon arms. Add `label: Option<String>` for the parcel/cert reference — it is also the key finding 17 needs for stone pricing, so land the two together. Expose an "actual stone" expander in `gem_picker` (layers.rs:2052) with L, W, depth, girdle and name; add a `depth_mm` pin to the `gem` node in crates/ringdesign-graph/src/nodes/gem.rs:44. Print the label in spec.rs's stone table so the flask goes out matched to the parcel.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `depth_mm: Option<f64>` and `girdle_mm: Option<f64>` to `Gem` (serde default None, so `depth_mm()` falls back to the table exactly as now), plus an optional `label: Option<String>` for a parcel or certificate reference. Have `crown_mm`/`pavilion_mm` honour the override. Expose an "actual stone" expander in `gem_picker` with L, W, depth and a name; the graph's `gem.stone` node already has an `l_mm` pin, so add `depth_mm` there too. Have the casting sheet print the label so the flask goes out matched to the parcel.
+
+</details>
+
+**Castability.** None to the sweep. It makes the existing culet/wall check stricter for deep stones, which is the safe direction; `MIN_WALL_MM` still guards the bore.
+
+**Verified.** Verified. `Gem::depth_mm()` (gem.rs:268-274) is `w_mm * cut.depth_frac()` for Faceted and `w_mm * CABOCHON_DOME_FRAC` for Cabochon — no override path. `crown_mm` (:278) and `pavilion_mm` (:290) both derive from it, and `pavilion_mm` is exactly what `check_seat`'s culet warning reads (stones.rs:613-620: `let need = gem.pavilion_mm();`) and what `StoneFrame::pavilion` feeds the census's `gap_deep_mm` (stones.rs:367 `let deep = fa.pavilion.min(fb.pavilion);`). No girdle-thickness field anywhere on `Gem`. The GUI's `gem_picker` (layers.rs:2052-2098) is exactly three combo boxes — cut, a width from `calibrated_mm()`, and form — and every one calls `Gem::calibrated`/`Gem::cabochon`, which force `l_mm = w * aspect`, so length is not settable there either. The graph's node is named `gem` (not `gem.stone`) and does carry both `w_mm` and `l_mm` pins (nodes/gem.rs:44-45), so the graph is the only surface where an off-aspect stone can be expressed at all — and even it has no depth pin.
+
+#### F61 Prongs on a seat pad are unchecked, and a run's posts are offset onto the flanks instead of along the crest line — `high` / `M` / stone-setting
+
+**Problem.** Two separate problems in the same stock. First, `SeatPadLayer::prongs`/`prong_mm` raise cone bumps with no castability or DFM check at all — no footing warning, no post-diameter check against `min_detail_mm` — while the identical stock on a run (`shared_prong_mm`) gets a full lost-wax warning and a detail-floor check. A 4-prong pad on a crown is the same physics as the shared prongs measured at -62°. Second, and more interesting: `SeatRunLayer::prong_off_mm` offsets the post pair in **v**, across the band, which puts both posts on the dome flanks where they lean. The doctrine's own bead lesson (a bead row rides the crest line only; the same row 1.9 mm off-crest locks at -37°) says the castable placement is an offset in **u**, along the ring, keeping both posts on the parting plane. A fore-and-aft two-post pair is a real setting (east-west / peg setting) and it would field clean where the current one does not. The pad's own prong ring already proves it: with `plan_pow <= 2.5` and phase 0, prongs k=0 and k=n/2 land on the crest line and the ones at ±90° land on the flanks — so a 4-prong pad has two safe claws and two that lean, and nothing says so.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1032-1038 (`prongs`, `prong_mm`), :1391-1412 (the bump ring, `phase` at :1401); field.rs:1917-1921 `prong_off_mm` returns `stone_half_v_mm(...) + r*0.35` and field.rs:1959-1960 applies it as `uv.v - (seat.v_mm ± off)`; crates/ringdesign-core/src/stones.rs:247-269 — the warning and the detail-floor check exist for `shared_prong_mm` and only for it; the -62% measurement is recorded at field.rs:1731-1734 and in the test at stones.rs:947-1024.
+
+**Do this.** (a) Lift the run's two checks into `check_seat` gated on `seat.prongs > 0`: the sand/crown lost-wax warning and the post diameter `(0.28*rb).clamp(0.35,0.8)*2` against `min_detail_mm` — the radius expression is already in field.rs:1397, so factor it into a `SeatPadLayer::prong_r_mm()` the way the run has one, and read it from both. (b) Add `SeatRunLayer::prong_axis: ProngAxis { AcrossBand, AlongRing }`, serde default AcrossBand so no file changes, and in `height` (field.rs:1955-1965) place the pair at `u ± off` on the seat's own v when AlongRing. This is the more interesting half of the finding — it turns a lost-wax-only feature into a sand-castable one — so measure it with examples/prong_probe.rs and pin the clean case. (c) In `check_seat`, warn when `prongs` is odd, or 4 on a Crown footing, naming the claws that sit off the parting plane.
+
+<details><summary>The auditor's original recommendation</summary>
+
+(a) In `check_seat`, apply the same two checks to `seat.prongs > 0` that the run gets: the sand/crown lost-wax warning, and the prong radius `(0.28*rb).clamp(0.35,0.8)*2` against `min_detail_mm`. (b) Add `SeatRunLayer::prong_axis: ProngAxis { AcrossBand, AlongRing }` (serde default AcrossBand so files are unchanged) and place the pair at `u ± off` on the seat's own v when AlongRing; measure it with `examples/prong_probe.rs` and pin the clean case. (c) In the pad, warn when `prongs` is not 2 or 4-with-phase-0 on a crown footing, naming the claws that will lean.
+
+</details>
+
+**Castability.** Direct. The along-the-ring pair must be proved by `analyze_field` before it ships; the claim is that two monotone bumps straddling the parting plane on the crest line release exactly as milgrain beads on the crest do. The pad checks are report-only and change no geometry.
+
+**Verified.** Both halves verified, and the asymmetry is stark. The run gets a full check block (stones.rs:247-268): `check.shared_prongs`, the sand/crown lost-wax warning quoting the -62° measurement, and `if run.prong_r_mm() * 2.0 < floor` against `design.draft.min_detail_mm`. `check_seat` — the function that judges a pad — never reads `seat.prongs` or `seat.prong_mm` at all; I read it end to end (stones.rs:540-644) and the field does not appear. The pad's bumps exist and raise real metal (field.rs:1390-1414, amplitude `height_mm + prong_mm`), and `feature_footprints` for SeatPad (field.rs:592-606) does not report the prong radius either, so `dfm.rs` cannot see it. On the v-offset: `prong_off_mm` (field.rs:1917-1921) is `stone_half_v_mm(...) + prong_r*0.35` and it is applied as `uv.v - (self.seat.v_mm + side * off)` at field.rs:1959 — both posts are offset across the band, both off the crest line, which is exactly the placement the bead lesson condemns. The pad's own claw geometry confirms the third claim: at field.rs:1399-1401 the phase is `0.0` when `plan_pow <= 2.5`, and the loop evaluates in `pad_frame` coordinates, so a 4-prong round seat puts two claws on the crest line and two on the flanks.
+
+#### F64 The calibrated size tables are not the trade's, and a fancy cut cannot be given its stocked dimensions — `high` / `S` / stone-setting *(also found as F243)*
+
+**Problem.** `GemCut::calibrated_mm` gives Round 1.0 to 8.0 in 0.25 steps and every other cut except Baguette and Half Moon the same fallback `[3,4,5,6,7,8]`. Real melee is stocked in 0.1 mm steps from 0.8 to 2.0 mm, which is the entire pavé and halo range — a 1.1 mm accent is offerable only because `HaloSpec::default` hardcodes it, and a 0.9 mm melee cannot be picked in the GUI at all. Fancy cuts are worse: a stone is always `w × w·aspect`, so the sizes a supplier actually sells (5×3, 6×4, 7×5 oval; 5×3, 6×4 emerald; 4×2, 5×2.5 baguette; 6×3, 8×4 marquise) cannot be selected. The GUI's `gem_picker` and MCP expose no length at all; only the graph's `gem.stone` node has an `l_mm` pin.
+
+**Evidence.** crates/ringdesign-core/src/gem.rs:167-178 `calibrated_mm`; :241-243 `Gem::calibrated` forces `l_mm = w * aspect`; crates/ringdesign-gui/src/panels/layers.rs:2073-2085 — the size combo iterates `gem.cut.calibrated_mm()` and sets width only; crates/ringdesign-core/src/pave.rs:414 — the halo's 1.1 mm accent is a literal, not a table entry.
+
+**Do this.** Replace `calibrated_mm() -> &[f64]` with `calibrated_pairs() -> &[(f64, f64)]` of stocked (l, w): round melee 0.8-2.0 by 0.1, then 2.0-3.0 by 0.25, then the current larger steps; real L×W pairs for oval (4×3, 5×3, 6×4, 7×5, 8×6), pear, marquise (4×2, 5×2.5, 6×3, 8×4), emerald (4×3, 5×3, 6×4, 7×5) and baguette. Keep `Gem::calibrated(cut, w)` as the nearest-pair shorthand so `HaloSpec::default`, `templates.rs` and the examples are unchanged in shape. Have `gem_picker` show "6.0 × 4.0 mm" and set both axes — this is also what makes the elongated-seat machinery (`elong`, `rot_deg`, `plan_pow`) reachable from the GUI at all, which today it effectively is not for stock stones.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Replace the width list with a per-cut table of stocked `(l_mm, w_mm)` pairs: round melee 0.8-2.0 by 0.1 then 2.0-3.0 by 0.25 then the current larger steps; ovals, pears, marquises, emeralds and baguettes as real L×W pairs. Have `gem_picker` show "6.0 × 4.0 mm" and set both axes, with a free-entry row for a measured stone (see the depth-override finding). `Gem::calibrated(cut, w)` stays as the nearest-pair shorthand so nothing that calls it changes shape.
+
+</details>
+
+**Castability.** None. Finer melee sizes will trip the crowding and detail-floor checks more often, which is the correct direction.
+
+**Verified.** Verified, with one correction to the finding's own wording: `calibrated_mm` (gem.rs:167-178) gives Round 1.0-3.0 in 0.25 steps then 3.0-6.5 in 0.5 then 7.0 and 8.0 — not "1.0 to 8.0 in 0.25". The substance is right and if anything understated: there is nothing below 1.0 mm, so the whole 0.8-1.0 melee range is unreachable, and Baguette and HalfMoon are the only two cuts with their own list; the other twelve share `&[3.0, 4.0, 5.0, 6.0, 7.0, 8.0]`. Every consumer forces the aspect: `Gem::calibrated` (:241) and `Gem::cabochon` (:245) both compute `l_mm` from `cut.aspect()`, and the GUI picker (layers.rs:2071-2085) iterates `calibrated_mm()` and calls those builders, so length is never independently settable. The halo's 1.1 mm accent is indeed a literal — `HaloSpec::default` at pave.rs:414 — a size the picker cannot reach. The graph's `gem` node (nodes/gem.rs:44-45) is the sole surface with a free `l_mm`.
+
+#### F65 MCP cannot put a stone in a seat, and has no run, pavé, halo or channel tool at all — `high` / `M` / stone-setting
+
+**Problem.** `AddSeatPadParams` carries no gem, no `style`, no `prongs`, no bezel fields and no `dimple_mm`; `add_seat_pad_layer` builds a `SeatPadLayer::default()` (gem `None`) and `SEAT_PAD_FIELDS` lists the same seven geometry fields for updates. So every seat an agent creates is stoneless stock: `set_stones` skips it, the report counts zero, the map refuses, the preview draws nothing. The tool's own description compensates by telling the model to compute "diameter_mm - 1.2" by hand — reimplementing `fit_stone` in prose — and there is no `add_seat_run`, `pave`, `halo` or `channel_set` tool anywhere, so an agent cannot author an eternity, a pavé or a halo through the tool surface at all.
+
+**Evidence.** crates/ringdesign-mcp/src/tools.rs:581-611 `AddSeatPadParams`; :1780-1815 `add_seat_pad_layer` (no gem assignment); :1281-1282 `SEAT_PAD_FIELDS`; :1778 the description's "seats a stone roughly diameter_mm - 1.2 across"; the only `async fn add_*` tools are tiling, border, seat pad, signet, milgrain (grep over tools.rs).
+
+**Do this.** Say it as a parity gap, not an absence: the graph node surface is complete (`gen.pave`, `gen.halo`, `gen.channel`, `layer.seat` with a gem pin, `layer.seatrun` + `.solve`) and the flat layer-tool surface is not. Add `gem_cut`, `gem_mm`, `gem_l_mm`, `gem_form` and `style` to `AddSeatPadParams` and call `SeatPadLayer::fit_stone` when a stone is named, then delete the "diameter_mm - 1.2" arithmetic from the description at tools.rs:1778. Add `set_depth_mm`, `style`, `prongs`, `prong_mm` and `dimple_mm` to `SEAT_PAD_FIELDS` (tools.rs:1281) so an update can reach what the add path already sets. Add `add_seat_run_layer` and thin wrappers over `pave::fill`/`halo`/`channel_set` that surface the generator's refusal text — the wrappers are a dozen lines each and remove a two-step detour from the commonest request an agent gets.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `gem_cut`, `gem_mm`, `gem_l_mm`, `gem_form` and `style` to `AddSeatPadParams` and to the update path, and call `SeatPadLayer::fit_stone` when a stone is named — then delete the hand-arithmetic sentence from the description. Add `add_seat_run_layer` (gem, count-or-solve, bridge_mm, taper, taper_theta, tilt_deg, shared_prong_mm, v_mm) and thin wrappers over `pave::fill`, `pave::halo` and `pave::channel_set` that return the generator's own refusal text when it returns `None`. The graph tools reach these through `gen.pave` today, which is a two-step detour for the commonest request an agent gets.
+
+</details>
+
+**Castability.** None — it exposes existing constructors. `fit_stone` on a GypsyMound already sets `crown = 1.0`, which is the measured-safe row.
+
+**Verified.** The direct-tool half is confirmed exactly. `AddSeatPadParams` (tools.rs:581-611) carries name, blend, opacity, theta_deg, v_mm, diameter_mm, elong, rot_deg, set_depth_mm, height_mm, crown, blend_mm — no gem, no style, no prongs, no bezel fields, no dimple_mm. `add_seat_pad_layer` (tools.rs:1780-1815) starts from `SeatPadLayer::default()` and never touches `s.gem` or `s.style`, so every MCP-created seat is stoneless and `set_stones` skips it. `SEAT_PAD_FIELDS` (tools.rs:1281) is the same seven geometry fields and omits even `set_depth_mm`, which the *add* path supports — an inconsistency the finding did not catch. The description at tools.rs:1778 does say "seats a stone roughly diameter_mm - 1.2 across". Grepping `async fn add_` gives tiling, border, seat_pad, signet, milgrain and nothing else, and `pave|halo|channel_set` over crates/ringdesign-mcp/src/ returns zero hits. BUT: the capability is not absent from the MCP surface. `crates/ringdesign-graph/src/nodes/generator.rs:97,118,132` register `gen.pave`, `gen.halo` and `gen.channel`, `nodes/layer.rs:157-241` register `layer.seat` (with a `gem` pin at :179), `layer.seat.fit`, `layer.seatrun` and `layer.seatrun.solve`, and the MCP's `graph_add_node`/`graph_set_input`/`graph_evaluate` reach all of them. So an agent *can* author an eternity, a pavé or a halo — via a graph, not via a layer tool.
+
+#### F67 The setter is handed no setting numbers: no bearing angle, bur size, seat depth or proud height — `high` / `M` / stone-setting
+
+**Problem.** The casting sheet's stone table is Seat / Stone / Sits on / Clearance / Depth, and the stone map prints a name and one width. Nothing in the app tells the person who will cut the seat: the pavilion's bearing angle (a brilliant's ~40.7° main against a step cut's straight bearing — different burs entirely), the setting-bur diameter (the stone's own girdle diameter, and the hart bur for the underbezel), how deep the bearing must be cut below the pad top (`girdle_drop_mm` exists and is never printed), how far the stone will stand proud of the metal when finished (`stand_off_mm` + `crown_mm`, both computable, neither printed), or the metal removed cutting the seat. The `dimple_mm` bur guide exists but nothing recommends a size for it.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:133-160 — the table's five columns; crates/ringdesign-core/src/stonemap.rs:94 — the label is `"{name} {:.1}"` on `st.gem.w_mm` only, so a 6×4 oval prints "4.0"; `SeatPadLayer::girdle_drop_mm` (field.rs:1288) and `stand_off_mm` (field.rs:1304) are read by the census and the preview and never surfaced; `Gem::crown_mm` (gem.rs:278) likewise.
+
+**Do this.** Add a `SetterSpec` computed per `SetStone` in setstone.rs, where the stone record already is: bearing angle from a table beside `GemCut::depth_frac` (a brilliant's ~40.7° pavilion main vs a step cut's straight bearing — different burs), setting-bur Ø as the girdle L and W (which needs finding 7's L×W to be right), bearing depth `girdle_drop_mm` + girdle thickness (finding 3), proud height `stand_off_mm + crown_mm`, and a recommended dimple Ø. Print it as extra columns on spec.rs's stone table and as a per-stone caption on the map. Fix stonemap.rs:94's label to L×W in the same change — it is a one-line bug that misleads the setter today. Also draw the seat's own rim outline behind the stone on the map so the setter sees stock as well as gem.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a `SetterSpec` block computed per `SetStone` in setstone.rs: bearing angle from the cut (a table beside `depth_frac`), setting-bur Ø = girdle L and W, bearing depth = `girdle_drop_mm` + girdle thickness, proud height = `stand_off_mm + crown_mm`, and the recommended dimple Ø. Print it as extra columns on the casting sheet's stone table and as a per-stone caption on the stone map; draw the seat's own rim outline on the map behind the stone so the setter sees the stock as well as the gem, and label with L×W rather than width alone.
+
+</details>
+
+**Castability.** None — reporting only.
+
+**Verified.** Verified. spec.rs:136 emits exactly `<th>Seat</th><th>Stone</th><th>Sits on</th><th>Clearance</th><th>Depth</th>`, where Clearance is `edge_clearance_mm` and Depth is `depth_available_mm` — both castability figures, neither a setting instruction. stonemap.rs:94 labels with `format!("{name} {:.1}", st.gem.w_mm)`, so a 6×4 oval prints "4.0" and the setter reads the wrong axis. Grepped `bur|bearing_angle|setting_bur|proud height` across crates: the only hits are the GUI's "Bur dimple" slider label (layers.rs:2486) and its `dimple_mm` graph pin — a cast guide with no recommended size anywhere. `girdle_drop_mm`/`stand_off_mm` (field.rs:1288, :1304) are read by `stones::frame_at` (:435-437), `check_seat` (:583) and the section view (section.rs:310) and printed by none of them; `Gem::crown_mm` (gem.rs:278) likewise. So every input to a full setter block is already computed and thrown away — which makes this unusually cheap for its value.
+
+#### F68 Every girdle plan is a symmetric superellipse, so pear, heart, trillion and half-moon seats are the wrong shape at their sharp end — `medium` / `L` / stone-setting *(also found as F231)*
+
+**Problem.** `GemCut::plan_pow` maps all fourteen cuts onto one two-parameter symmetric family, and `superellipse_radius_mm` is the only plan anything reads — the seat rim, the prong ring, the band-edge clearance, the crowding census's `plan_r`, the stone map's outline and the viewport preview. A pear gets `plan_pow = 2.0` (a plain ellipse), a heart the same, a trillion 3.2 (a rounded square standing in for a triangle), a half-moon 3.2 (for a shape with one straight side). The seat stock is then fat where the stone is narrow and thin where it is broad, the census measures the gap at a boundary the girdle does not have, and the prong ring puts claws where a pear's or marquise's point is not. The machinery to fix it already exists one module away.
+
+**Evidence.** crates/ringdesign-core/src/gem.rs:154-165 `plan_pow`; crates/ringdesign-core/src/field.rs:1149-1161 `superellipse_radius_mm` and :1254-1257 `rim_mm`; crates/ringdesign-core/src/stones.rs:413-422 `StoneFrame::plan_r`; crates/ringdesign-core/src/stonemap.rs:147-151; crates/ringdesign-core/src/gems.rs:349-360 — the preview reads the same exponent. Contrast `CustomOutline` (a 720-entry polar table with a raycast fit, per CLAUDE.md's imported-plans section), which solves exactly this problem for signet heads.
+
+**Do this.** Add `GemCut::plan_r(bearing) -> f64` as the single accessor and route all four consumers through it — `field::superellipse_radius_mm`'s caller in `rim_mm`, `StoneFrame::plan_r`, stonemap.rs's `superellipse` and gems.rs's `facets`. Back it with a 360-entry normalized polar table per cut, generated from the existing superellipse for the cuts it already fits (so round, oval, cushion and the step cuts are bit-identical and no design moves) and hand-authored for Pear, Heart, Trillion, HalfMoon and Marquise. Assert star-shapedness about the centre on load — that is the property `plan_pow >= 1` was buying, and it is what keeps the mound monotone; refuse a re-entrant plan the way the cut-dome head refuses concave-in-section outlines. This subsumes the Shelf's "flat-edged seat plans".
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `GemCut` a normalized polar plan table in the same shape as `CustomOutline` — 360 or 720 entries in the stone's own frame, unit half-extents — with the existing superellipse as the generator for the cuts it fits and hand tables for Pear, Heart, Trillion, Half Moon and Marquise. Add `GemCut::plan_r(bearing) -> f64` as the single accessor and route `rim_mm`, `plan_r`, `half_extents_mm`, the stone map and the preview through it. Assert convexity (star-shaped about the centre) on load, which is what preserves the monotone-mound guarantee; refuse a heart's cleft the way the cut-dome head already refuses concave-in-section outlines.
+
+</details>
+
+**Castability.** Real and manageable. The monotone-drop guarantee rests on the plan being star-shaped about the seat centre; a table-driven plan must assert that on construction rather than inherit it from `n >= 1`. A concave plan would put two skirts face to face — the 8.2%/-22° two-flange valley the showcase measured.
+
+**Verified.** Verified. `GemCut::plan_pow` (gem.rs:154-165) maps all fourteen cuts to four values: 2.0 for Round/Oval/Pear/Heart, 3.2 for Cushion/Trillion/Hexagon/HalfMoon, 6.0 for the step-cut family, 1.5 for Marquise. Every consumer reads it and nothing else: `SeatPadLayer::rim_mm` via `field::superellipse_radius_mm` (field.rs:1149-1161, :1254), `StoneFrame::plan_r` (stones.rs:413-422), the map's `superellipse` (stonemap.rs:147-151) and the viewport's `facets` (gems.rs:344-360, `let exp = gem.cut.plan_pow();`). So a pear's seat stock, the census's gap, the map's drawing and the preview's stone are all the same plain ellipse, and the pear's point is unrepresented in all four. The `CustomOutline` precedent is real and does exactly this job for heads. One thing the finding gets right that matters most for the guarantee: convexity is what preserves the monotone-mound release, and gem.rs:158's own comment says so — a heart's cleft must stay refused. Related: docs/ROADMAP.md:192's Shelf carries "flat-edged seat plans", which is the step-cut half of this item.
+
+#### F70 Stones can only be laid on a lattice: no run along a curve, no scatter, no explicit count over an arc — `high` / `M` / stone-setting
+
+**Problem.** Three placement laws exist and no more: `SeatRunLayer` (an integer lattice around the whole ring at one constant v), `pave::fill` (hex rows in a v-band or a side face, count always solved from pitch), and `pave::halo` (one ring round one outline). A run cannot follow a path — `seat.v_mm` is a single number for every station, so a wave of stones tracing a curve wire, a vine, or a shank's own edge is not expressible even though `curve.rs` already carries guide point-lists and the tiling layer already warps rows along one. There is no scatter, no cluster of more than one ring, no mirrored pair, and no way to say "eleven stones across this arc" — `fill` and `solve_spacing` both take a pitch and hand back a count.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1923-1948 — `SeatRunLayer::height` places every station at `self.seat.v_mm`; :1786-1801 `solve_spacing` derives `count` from the pitch; crates/ringdesign-core/src/pave.rs:205-231 — both branches floor an arc over a pitch; pave.rs:487-534 — the halo builds exactly one `HaloRing`; docs/ROADMAP.md:190-192 shelf: "march instances along a guide path; blue-noise scatter generator".
+
+**Do this.** Drop the ByCount claim for seat runs and halos — both already have it, with the bridge read back. Keep three things. (a) `SeatRunLayer::v_guide: Vec<(f64, f64)>`, sampled per station in `height` at field.rs:1936, reusing the `(theta, v)` point-list shape `TilingLayer::warp` already carries — this is the highest-value item here and is on the Shelf; the castability story is unchanged because each station stays an independent mound. (b) `count_mode: ByPitch | ByCount` on `PaveSpec` only, which is the one spec that cannot be pinned. (c) `HaloSpec::rows: u32` plus an `under_halo` flag placing a second ring on the bore-facing side face — cheap, and a double halo is a thing customers name.
+
+<details><summary>The auditor's original recommendation</summary>
+
+(a) Give `SeatRunLayer` an optional `v_guide: Vec<(f64, f64)>` — the same `(theta, v)` point-list `TilingLayer::warp` already carries — sampled per station, so a row can follow a curve; the castability story is unchanged because each station is still an independent mound and the guide only moves where it stands. (b) Add `count_mode: ByPitch | ByCount` to `PaveSpec` and `SeatRunLayer` so a user can pin the count and read the bridge back from `bridge_at`, which already inverts the law. (c) Promote the shelf's blue-noise scatter as a third `GenRecipe` with a minimum-separation parameter fed by the same crowding floor. (d) `HaloSpec::rows: u32` for a double halo, and an `under_halo` flag placing a second ring on the bore-facing side face.
+
+</details>
+
+**Castability.** Low. A guided run is the same mound at a different v, and the existing footing check already measures each station against the band it actually sits on. The one caveat is that a guide crossing from a side face onto the crown changes the footing mid-row — `check_seat` already takes the worst over stations, so it will report it.
+
+**Verified.** Mixed, and one sub-claim is simply wrong. WRONG: "there is no way to say 'eleven stones across this arc'". `SeatRunLayer::count` is a plain public field, `solve_spacing` is opt-in, and the GUI exposes it directly — layers.rs:2279-2291 is a `Slider::new(&mut r.count, 3..=120)` with a separate "Solve" button, and layers.rs:2394 reads `r.bridge_at(fctx)` back and colours it red under 0.2 mm. So ByCount already exists for a run, exactly as the finding asks for it. `HaloSpec::count` likewise (pave.rs:359-360: "Accents in the ring; 0 solves the count"). Only `PaveSpec` genuinely has no count field (pave.rs:35-63) — its rows always floor an arc over a pitch (pave.rs:205-231). CONFIRMED: the guide path — `SeatRunLayer::height` places every station at `self.seat.v_mm` (field.rs:1936-1938), one number for the whole row, and there is no `v_guide`; on the Shelf as "march instances along a guide path". CONFIRMED: no scatter of any kind; on the Shelf as "blue-noise scatter generator". CONFIRMED: `halo` builds exactly one `HaloRing` (pave.rs:485-534), no `rows`, no under-halo.
+
+#### F71 The gem preview would not pass as a customer render: one tint for every stone, and no shipped facets — `medium` / `M` / stone-setting
+
+**Problem.** `GEM_TINT` is a single constant applied to every stone of every cut, so a ruby, an emerald and a diamond render as the same grey-blue. True facet meshes are loaded from `library::gem_mesh_dir()` — a user directory the app ships nothing into, confirmed by the absence of any bundled gem OBJ — so the shipped path is always the procedural fallback: sixteen segments, a girdle-bezel-table crown in two bands and a single pavilion fan straight to the culet, with no pavilion mains, no lower girdle facets and no stars. The configurator writes a hero PNG and a turntable GIF into every customer order folder from exactly this.
+
+**Evidence.** crates/ringdesign-core/src/gems.rs:19 `pub const GEM_TINT: [f32; 3] = [0.72, 0.82, 0.92];` and :136-141 — the same tint written into every vertex; :157-188 `true_facets` reads `library::gem_mesh_dir()`; `find . -name "*.obj" -path "*gem*"` finds only harvest captures, nothing bundled; :344-380 the procedural fallback; crates/ringdesign-configurator/src/compose.rs order-file path writes the render into the order folder.
+
+**Do this.** (a) Land finding 2 first, then take the tint from `GemSpecies` — `render::Part` already has a per-part `tint` field (render.rs:43), so the change is in `gems::preview_vertices`, which today writes the constant into every vertex (gems.rs:136-141), not in the render plumbing. (b) Replace the fallback in `facets` (gems.rs:344-380) with an analytic 57-facet round brilliant at standard proportions (table 56%, crown 34.5°, 8 mains + 8 stars + 16 upper girdle; 8 pavilion mains at 40.75° + 16 lower girdle), and parameterise the tier count to derive the step-cut and mixed families from the same generator. It is trigonometry, needs no asset, and the existing flat-facet shading is exactly what makes it read. This is also the cut geometry finding 10's bearing-angle table wants, so the two share a source. (c) Keep the `gem_mesh_dir` OBJ override untouched.
+
+<details><summary>The auditor's original recommendation</summary>
+
+(a) Once `GemSpecies` exists, take the preview tint from it and let `Part::gem` carry per-stone colour instead of one constant. (b) Replace the fallback with a real analytic round brilliant: 57 facets from the standard proportions (table 56%, crown 34.5°, 8 crown mains + 8 stars + 16 upper girdle, 8 pavilion mains at 40.75° + 16 lower girdle), and derive the step-cut and mixed families from the same generator by parameterising the tier count. It is a page of trigonometry, needs no assets, and the flat-facet shading the renderer already uses is exactly what makes it read. (c) Keep the OBJ override for anyone who has better meshes.
+
+</details>
+
+**Castability.** None whatsoever — the preview is never in the `Mesh` and never exported, which gems.rs states at :36-37.
+
+**Verified.** Verified. `pub const GEM_TINT: [f32; 3] = [0.72, 0.82, 0.92];` at gems.rs:19, written into every vertex of every stone at gems.rs:136-141, and used as the default tint for the render `Part` at render.rs:43 and by the GUI viewport at viewport.rs:371-373. `true_facets` (gems.rs:157-188) reads `library::gem_mesh_dir()` for `<cut>.obj` and its own doc comment says outright "the app ships no gem geometry of its own"; `find . -iname '*.obj'` outside target/ returns only the batch6-8 Rhino harvest captures, nothing installed or bundled. So the shipped path is always the fallback at gems.rs:334-380: SEG = 16, a girdle/bezel/table crown in two bands plus a table fan, and one `girdle -> culet` triangle per segment for the whole pavilion — no mains, no lower girdles, no stars, as described. The configurator writes a hero PNG and turntable GIF into every order folder from exactly this.
+
+#### F73 No setting-suitability gate: the app cannot say why a channel, a tension or a basket setting is refused — `medium` / `M` / stone-setting
+
+**Problem.** The app has a `CastProcess` and generators that branch on it (`pave::halo` builds a plate in sand and a proud cluster in lost wax), but no registry of setting types and no way to answer the question a jeweller actually asks: "can I do this setting?" A crest channel, a tension set, an invisible set and a basket head are all refusals with different reasons — a crest channel is a two-flange valley no parting plane clears, tension needs wrought spring temper that no casting has, invisible needs grooved stones on rails, a basket needs open galleries — and today each one is simply absent, which reads to a user as "not built yet" rather than "here is why, and here is the castable equivalent".
+
+**Evidence.** crates/ringdesign-core/src/field.rs:977-999 `SeatStyle` carries three variants and no process metadata; crates/ringdesign-core/src/pave.rs:431-441 shows the pattern that should generalise (`halo` branching on `CastProcess::LostWax`); crates/ringdesign-core/src/pave.rs:283-290 — `channel_set` returns a bare `None` when there is no side face, and the caller has to write the explanation itself (CLAUDE.md: "the menu item says what to change").
+
+**Do this.** Add `setting::SettingKind` with `castable_in(process, footing) -> Verdict` returning a one-line reason and the castable alternative it redirects to. Make the refusal text the return type, not a comment: change `pave::channel_set` and `pave::halo` (and `bar_set` from finding 5) from `Option<T>` to `Result<T, SettingRefusal>` so the GUI menu, the MCP wrapper and the CLI all say the same sentence instead of each inventing one — that single change is most of the user-visible value, and it is what makes finding 8's MCP wrappers worth writing. Star setting and illusion plate fall out nearly free (a Decal of engraved rays round a gypsy seat; a `SeatPad` plate with a cut pattern) and both are castable by construction, so ship them as the redirect targets rather than as bare refusals.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `setting::SettingKind` enumerating the trade's settings — Gypsy/Flush, Bezel, Boss+Claw, Bar, Channel, Pavé/Bead, Halo, Star, Illusion, Tube/Collet, Basket/PegHead, Tension, Invisible, PearlPeg — each with `castable_in(process, footing) -> Verdict` and a one-line reason plus the castable alternative it redirects to. Surface it as the add-menu's own copy, as an MCP `setting_options` tool, and as the refusal text every generator returns instead of `None`. Star setting and illusion plate fall out almost free: a star is engraved rays round a gypsy seat (a Decal at the crest), an illusion is a `SeatPad` plate with a cut pattern, and both are castable by construction.
+
+</details>
+
+**Castability.** None directly — it is a knowledge table and refusal text. Its value is that every future setting has to declare its process before it can be offered, which is exactly the discipline the field verdict enforces for geometry.
+
+**Verified.** Grepped `SettingKind|setting_options` over crates — nothing. `SeatStyle` (field.rs:977-999) is three variants with no process metadata and no reason strings. The two halves of the pattern the finding wants generalised are both real: `pave::halo` branches on `design.draft.process == CastProcess::LostWax` (pave.rs:431-441) and builds a plate or a proud cluster accordingly, with the reasoning in its doc comment; `channel_set` returns a bare `None` at pave.rs:288 and :291 with the explanation living only in the doc comment and (per CLAUDE.md) in the menu item's own copy, so every caller re-writes it — the MCP has no channel tool at all (finding 8) and would have nothing to return. Note two of the settings the finding lists have Shelf entries adjacent to them: docs/ROADMAP.md:191-192 carries "pearl stock" and "flat-edged seat plans".
+
+#### F74 Stones have no cost, so an order folder cannot quote the piece — `medium` / `M` / stone-setting
+
+**Problem.** `prices.json` prices metal per gram and nothing else, so the configurator's review step and the casting sheet quote the metal of a solitaire and say nothing about the stone — which on any set piece is most of the price. There is also no parcel or inventory: a stone cannot be named, sourced, given a cost, or matched to something on the shelf, so the order folder a customer receives is a design with an incomplete price and no bill of materials.
+
+**Evidence.** crates/ringdesign-configurator/src/compose.rs:118-124 `load_prices` reads a `HashMap<String, f64>` of metal names; crates/ringdesign-configurator/src/main.rs:603-618 — the metal step's price line and its "prices show here when a prices.json sits beside the designs folder" empty state; `Gem` (gem.rs:222) carries no cost, source or identity field.
+
+**Do this.** Extend the sidecar to `{"metals": {...}, "stones": {...}}` and keep `load_prices` backward-compatible with the flat metal map already on people's disks — deserialize into an enum over the two shapes, or the change silently zeroes existing metal prices in both the GUI (app.rs:114) and the configurator (compose.rs:122). Key stone entries by species+cut+size, which means this depends on findings 2 and 3 landing first (species for the key, `Gem::label` for the parcel reference — carry the same `label` field, do not add a second one). Print the bill of materials in spec.rs's stone table beside the metal weights already there. A `parcel.json` in the same directory listing shelf stock turns `gem_picker` into a stock picker, which is the version a working bench actually wants.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Extend the sidecar to `{"metals": {...}, "stones": {"Diamond G VS 2.0mm": 18.0}}` keyed by species+cut+size, priced per stone for melee and per carat above a threshold. Add an optional `Gem::label` (shared with the measured-stone finding) that keys into it and prints on the casting sheet as a bill of materials — stone, count, size, carats, unit and line total — alongside the metal weights already there. A `parcel.json` in the same directory listing what is actually on the shelf turns the picker into a stock picker.
+
+</details>
+
+**Castability.** None — data and reporting.
+
+**Verified.** Verified. `compose::load_prices` (compose.rs:118-127) reads `prices.json` beside the designs folder into a bare `HashMap<String, f64>` keyed by metal name; the GUI reads the same file the same way (app.rs:111-114, :171). The configurator's empty state at main.rs:618 spells the schema out as `{"Silver 925": 1.2, "Gold 14k": 55.0}` per gram — metals only. `Gem` (gem.rs:222-231) carries no cost, source, vendor or identity field, and there is no parcel or inventory file anywhere. So the review step and the casting sheet quote metal alone on a piece whose stones are usually most of its price, and the order folder the customer receives has no bill of materials.
+
+#### F211 No stone requisition: the report counts stones but never lists what to buy — `high` / `S` / product-business
+
+**Problem.** `StonesReport` gives per-seat counts and a total carat figure, and the sheet prints one row per seat. There is no rollup across the design by (cut, form, mm size) with a count and a line carat — which is what a stone order to a dealer actually is — and no stone price anywhere, so the biggest cost line in a set ring is absent from every quote.
+
+**Evidence.** crates/ringdesign-core/src/stones.rs:33-57 (`SeatCheck` has `count`, `gem: Option<Gem>`, `carats_override`) and 100-112 (`StonesReport`). crates/ringdesign-core/src/spec.rs:134-166 prints seats, not a stone list. `setstone::set_stones` already walks the design once and yields one `SetStone` per stone with its `Gem` — the exact enumeration a rollup needs.
+
+**Do this.** Unchanged. Build `stones::requisition` on `setstone::set_stones` (not on `StonesReport.seats`), because the seat list is per-layer and would miss the pavé/halo stones the record was introduced to unify — and add it to `every_consumer_counts_the_same_stones` (stones.rs) so the requisition's totals are pinned to the same record as the report's count and carats. Group on `(GemCut, GemForm, mm to 0.1)`: `GemForm::Cabochon` must not merge with `Faceted` at the same footprint, since they are different goods at different prices.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `stones::requisition(&[SetStone]) -> Vec<StoneLine>` grouping by `(GemCut, GemForm, mm rounded to 0.1)` with count, per-stone carat and line carat, sorted largest first. Print it as its own "Stones to buy" table on the sheet and expose it on the CLI's `check`. Extend `prices.json` with a stone table (`{"Round 2.5": 4.50}` per stone or per carat by cut) so `cost::quote` can price the line.
+
+</details>
+
+**Verified.** Confirmed. `StonesReport` (stones.rs:100-112) is seats + stone_count + total_carats + crowding + tight_pairs + closest — no per-(cut, size) rollup. spec.rs:134-166 prints one row per *seat layer*, not per stone type, so two 2.5 mm round rows from different layers are two rows and never sum. The one grouping that exists, `seats_by_shape` (stones.rs:497), is internal to rolling up a pavé group's children into one seat line — it does not cross layers and is not a purchasing view. `setstone::set_stones` does yield one `SetStone` per stone with its `Gem`, and CLAUDE.md names it as the single stone record every consumer reads, so the enumeration for a rollup is already there and free. No stone prices anywhere (the prices.json schema is per-gram metal only).
+
+#### F229 The setter gets no bur schedule, only a dimple — `high` / `M` / competitor-parity
+
+**Problem.** CrossGems generates five families of cutters (Gem, Bright, Channel, Cross, Micro) because the setting is cut, not cast. We correctly refuse to cast cutters — but we also never tell the setter what to cut with. Every number needed is already computed analytically; the bench sheet just does not print it. Today the only setting guidance in the model is `dimple_mm`, a bur-start guide.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1042-1045 — `dimple_mm` is described as "a cast guide for the setting bur", and it is the only setting instruction in the layer. crates/ringdesign-core/src/stones.rs:33-57 — `SeatCheck` carries `seat_diameter_mm`, `gem`, `depth_available_mm`, `edge_clearance_mm`, `bridge_mm` and warnings, but no tool spec. crates/ringdesign-core/src/spec.rs:136 — the sheet's Stones table is Seat / Stone / Sits on / Clearance / Depth. assets/decoded/presets/Gem Cutter/ and Bright Cutter/ hold the reference cutter geometry we decoded and never used.
+
+**Do this.** Unchanged, and note in the pitch that it is nearly free: every quantity `bur_schedule` needs is already an analytic field on `SeatCheck`/`Gem`/`SeatPadLayer`, so this is a formatting-and-tables job, not a geometry one. Emit `Vec<BurSpec>` keyed by distinct seat (the same `seats_by_shape` grouping the stones rollup already uses, so a 240-seat pavé stays one line), print it as a Setting column on `spec::html` beside the existing Stones table, and as a legend on `stonemap.rs`, which is already the setter's sheet. Snap the bur diameters to real supplier ladders while you are at it — a schedule that names a 2.37 mm bur nobody sells is worse than none.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `stones::bur_schedule(&StonesReport) -> Vec<BurSpec>`: per distinct seat, the setting-bur diameter (girdle width plus a bearing allowance), the hart/round bur angle implied by `Gem::pavilion_mm` and the cut's pavilion angle, the seat depth measured from the pad top using `girdle_drop_mm`/`stand_off_mm`, the pilot drill for the pavilion, and for a `SeatStyle::Bezel` the pocket cutter diameter from the plan inset by `bezel_wall_mm`. Print it as a Setting column on `spec::html` and as a legend on the stone map, which is already the setter's sheet.
+
+</details>
+
+**Castability.** n/a — post-cast bench information, no geometry.
+
+**Verified.** Verified. `SeatCheck` (stones.rs:32-56) carries `seat_diameter_mm`, `gem`, `footing`, `edge_clearance_mm`, `depth_available_mm`, `bridge_mm`, `carats_override`, `shared_prongs`, `warnings` — no tool spec of any kind. `spec.rs:136`'s Stones table is Seat / Stone / Sits on / Clearance / Depth. Grepped `bur|cutter|hart|drill` across all crates: the only setting-tool hits are `dimple_mm` (field.rs:1042, gui/panels/layers.rs:2486-2494, nodes/layer.rs:180) and prose. `assets/decoded/presets/` does hold `Gem Cutter/`, `Bright Cutter/`, `Channel Cutter/`, `Cross Cutters/` and `Micro Cutters/` families, decoded and unused. Every input the recommendation needs is already computed: `Gem::pavilion_mm`, `Gem::crown_mm`, `girdle_drop_mm`/`stand_off_mm` (the one-number depth from `set_depth_mm`), `bezel_wall_mm`/`bezel_bearing_mm`, and `field::plan_half_extents_mm` for the plan inset. Not on the Shelf or Niceties.
+
+**Merged into a canonical finding above:** F63 (A channel-set ring reports no stones at all) -> F52, F193 (A stone has no material, so no document can be a bill of materials) -> F59, F230 (Cuts the trade sells that `GemCut` cannot name, and no pearl) -> F44, F231 (A pear, trillion or half-moon gets an elliptical seat it overhangs) -> F68, F243 (Calibrated stock is a width list, so a 6×4 oval cannot be specified) -> F64.
+
+### M21 — A size is a fit, not a number (M, 11 findings)
+
+**Done when:** US, UK, EU or a measured millimetre; a wide comfort-fit band compensated by the trade's convention; every generator re-solved on a size change; a bangle at 60-70 mm.
+
+#### F132 Add wide-band and fit-style size compensation between the stated size and the cut bore — `critical` / `M` / sizing-fit
+
+**Problem.** The bore is the stated size, full stop. `RingDesign::inner_radius_mm()` is `self.size.inner_diameter_mm() * 0.5` with no term for band width, comfort dome, or fit convention. A bench-universal rule — a 6–10 mm band needs roughly a quarter to a half size over a 2 mm band, because the wider wall bears on more of the finger and cannot rock over the knuckle — is nowhere in the codebase. The configurator makes this concrete and customer-facing: `compose()` gives Base::Court (4.0 mm wide) and Base::WideBand (7.0 mm wide) the *identical* bore for the same `cfg.size`, and Base::SignetOval a 14 mm one. Every wide band and every signet this app ships at a customer's stated size is undersized, and that is a return, a resize, or a refund.
+
+**Evidence.** crates/ringdesign-core/src/lib.rs:252-255 (`inner_radius_mm` = size only); crates/ringdesign-core/src/sizing.rs:14-20; crates/ringdesign-configurator/src/compose.rs:198 (`d.size = RingSize::new(cfg.size.clamp(3.0,13.0))`) and 205-256, where width_mm goes 4.0 / 7.0 / 5.5 / 14.0 across bases with no size term; crates/ringdesign-gui/src/panels/design.rs:57-84 (US slider, mm readout, no width coupling). Grep for any width→size mapping across the workspace returns nothing.
+
+**Do this.** Unchanged in structure, but get the SIGN of the two terms right — the auditor's phrasing risks stacking them the same way. Width compensation and comfort fit pull in OPPOSITE directions: a wide standard-fit band runs tight so the cut bore goes UP (+0.25 size at 3-5 mm, +0.5 at 5-8 mm, +0.75 over 8 mm), while a comfort-fit dome makes the same stated size ride EASIER so the cut bore goes DOWN by roughly a quarter to a half size. Implement as `FitSpec::cut_circumference_mm(width_mm, comfort_fit_mm)` returning a signed delta from the two terms summed, on `RingDesign` in `sizing.rs`, with `inner_radius_mm()` (lib.rs:252) becoming the cut bore. Note the signet case is the worst offender: `compose.rs` gives a 14 mm-wide signet the same bore as a 4 mm court band, which is a full size tight in practice. Serde-default the flag off so no saved `.ring.json` changes shape; default it on for `compose::Config` and new GUI designs.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Put a `FitSpec` on `RingDesign` (`sizing.rs`): `{ stated: RingSize, standard: SizeStandard, fit_style: FitStyle, width_compensation: bool }`. `inner_radius_mm()` becomes the *cut* bore derived from the stated size through `FitSpec::cut_circumference_mm(width_mm, comfort_fit_mm)` — a small calibrated table, e.g. +0.00 size under 3 mm, +0.25 from 3–5 mm, +0.50 from 5–8 mm, +0.75 over 8 mm, with the comfort-fit term applied on top. The casting sheet (`spec.rs`) then prints two lines: "Stated US 7 (standard fit)" and "Cut at 17.71 mm — US 7.5, comfort fit, 7 mm wide". Default the flag on for new designs and off in the serde default so no saved file changes shape.
+
+</details>
+
+**Castability.** None. Changing the bore radius scales the sweep's inner_r; the superellipse drop and every side-face guarantee are stated relative to the section, not to an absolute radius. Field verdicts are unchanged in kind, and `analyze_field`'s thinnest-wall sweep already re-measures per size.
+
+**Verified.** Verified. `crates/ringdesign-core/src/lib.rs:252` is exactly `self.size.inner_diameter_mm() * 0.5`, with no width, comfort or fit term. `crates/ringdesign-core/src/sizing.rs` is 54 lines and has no such concept. Grepped `--include="*.rs"` across all crates for `fit_style|FitStyle|SizeStandard|compensat` — the only hits are `comfort_fit_mm` (a profile geometry field), nothing about stated-vs-cut size. Configurator confirmed: `compose.rs:198` `d.size = RingSize::new(cfg.size.clamp(3.0,13.0))` then Court 4.0 mm, WideBand 7.0 mm, Split 5.5 mm and both signets 14.0 mm width — identical bore for all of them. GUI `panels/design.rs:57-84` is a bare US slider with a bore/circumference readout and no width coupling.
+
+#### F133 Sizing knows one standard — US — and no conversion table — `high` / `M` / sizing-fit *(also found as F142, F228)*
+
+**Problem.** `sizing.rs` is 54 lines: a single linear US fit (`circumference = 36.5 + 2.55·size`), a quarter-size rounder, and a `display()` that can only say "US n". There is no UK/Australian letter scale, no EU/ISO 8653 circumference designation, no Japanese or Chinese numeric, no inside-diameter designation. UK letters and Japanese sizes are *tables*, not linear functions, so they cannot be derived from the US formula. A shop that takes a size off a UK sizer set, or a customer who knows their EU number, has no way in, and the casting sheet a client receives names a standard they may not use.
+
+**Evidence.** crates/ringdesign-core/src/sizing.rs (whole file — `inner_circumference_mm`, `from_circumference_mm`, `display`, `common`); crates/ringdesign-core/src/spec.rs:60-64 prints `design.size.display()` as the sheet's only size line; crates/ringdesign-gui/src/panels/design.rs:71-84; crates/ringdesign-configurator/src/main.rs:587-594. Nothing else in the workspace mentions any other scale.
+
+**Do this.** Sharpened: the EU/ISO half is nearly free and should ship first. ISO 8653 designation IS the inside circumference in mm, which `RingSize::inner_circumference_mm()` already computes — so `SizeStandard::EuIso` and `InsideCircMm`/`InsideDiaMm` are formatting, not new data. Only UK/Australian letters and the Japanese/Chinese numeric scales need static lookup tables (nearest-entry both ways, with half-letters). Keep the US linear formula as the internal truth so no geometry moves. Then print `label_all()` on the `spec.rs` sheet header (line 61), in the configurator's `choices.json`, and add a `standard` input to the graph's `band.size` node in `crates/ringdesign-graph/src/nodes/band.rs:129` alongside its existing mm outputs.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Extend `sizing.rs` with `enum SizeStandard { UsCanada, UkAu, EuIso, Japan, China, InsideDiaMm, InsideCircMm }`, a static conversion table for the letter and Japanese scales (nearest-entry lookup both ways, with half-letters), and `RingSize::{from_standard, to_standard, label_in, label_all}`. Keep the US formula as the internal truth so no geometry moves. Print `label_all()` on the casting sheet and in the configurator's order `choices.json`, and expose `SizeStandard` on the graph's `band.size` node alongside the existing mm outputs.
+
+</details>
+
+**Castability.** None — pure presentation and input conversion over the existing bore formula.
+
+**Verified.** Verified. `crates/ringdesign-core/src/sizing.rs` is 54 lines total: `inner_circumference_mm` = `36.5 + size*2.55`, `inner_diameter_mm`, `from_circumference_mm`, `from_diameter_mm`, `display()` which can only emit `US n`, and `common()`. Grepped `--include="*.rs" --include="*.md"` across crates/ and docs/ for `uk size|iso 8653|japan|to_standard|size_standard` — zero hits anywhere in the workspace. `spec.rs:61` prints `Size {size} • sand-cast pattern` from `design.size.display()` as the sheet's only size line.
+
+#### F134 Comfort fit is a constant rise, so its feel changes with band width — `high` / `S` / sizing-fit
+
+**Problem.** The comfort dome is `bore_r(z) = inner_r + lift + comfort·((z − b_c)/hw)²` — a parabola whose *rise* is exactly `comfort_fit_mm` at both bore edges no matter how wide the band. But what the finger feels is the interior *radius*, and that radius is `hw²/(2·comfort)`. At the 0.25 mm default: a 3.6 mm band gets a 6.5 mm interior radius (aggressively domed), a 6 mm band 18 mm, a 10 mm band 50 mm — essentially flat. So the one setting is over-domed exactly where comfort fit does not matter and near-flat exactly where it matters most, which is the wide band. The GUI slider offers 0–1.5 mm with no width coupling and no guidance; at 1.5 mm on a 2 mm band the crown cap collapses to 0.3 mm and the band edge is pinned at `MIN_EDGE_MM`, silently.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:832 (`bore_r`); profile.rs:661-662 (`comfort = self.comfort_fit_mm.clamp(0.0, hw*0.8)`); profile.rs:679 (`crown_cap = thickness − comfort − MIN_EDGE_MM`) and 685 (`edge_t = (thickness − crown).max(MIN_EDGE_MM + comfort)`); profile.rs:516 (default 0.25); crates/ringdesign-gui/src/panels/design.rs:218-230 (slider 0..=1.5, hover text "Dome inside the bore; size is measured at the contact band."). Corroborating datum already in the repo's own notes: the decoded CrossGems head bore "dips 0.245 mm inward at its middle (their comfort fit)" (CLAUDE.md:823) — a rise measured on one width, not a law.
+
+**Do this.** Unchanged in design — `enum ComfortFit { Rise(f64), Radius(f64) }` on `BandProfile`, serde-defaulting to `Rise` so every saved file is bit-identical, with `Radius` computing `comfort = hw²/(2·R)` inserted at `profile.rs:662` BEFORE the existing `hw*0.8` clamp so the clamp still guards. `Radius(20.0)` gives 0.225 mm on a 6 mm band (close to both the 0.25 default and the CrossGems 0.245 datum) and 0.625 mm on a 10 mm band. Restate the GUI warning against the real clamp chain: show the derived rise, the derived radius, AND the resulting `crown_cap = thickness - comfort - MIN_EDGE_MM` (profile.rs:679) so a user watching the crown get eaten sees why. This finding pairs with finding 1 — the comfort dome's depth is also the term that decides how much the stated size should be reduced.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Make it `enum ComfortFit { Rise(f64), Radius(f64) }` on `BandProfile` (serde-defaulting to `Rise` so every saved file is bit-identical), with `Radius` computing `comfort = hw²/(2·R)` inside `sample_spaced` before the existing clamp. Default new bands to `Radius(20.0)` — which reproduces 0.225 mm on a 6 mm band, close to both the current default and the CrossGems datum, and scales honestly to 0.625 mm on a 10 mm band. Label the GUI row with the derived rise *and* radius, and refuse silently-collapsing values by showing the crown cap it leaves.
+
+</details>
+
+**Castability.** None. The bore is reported as a vertical wall regardless of radius (castability.rs:300-303, 425-428, 555), and a comfort dome only gains draft toward both edges. The existing `crown_cap`/`edge_t` clamps already keep `MIN_EDGE_MM` alive; a radius-derived rise goes through the same clamp.
+
+**Verified.** Verified and the maths checks out. `profile.rs:832`: `bore_r = |z| inner_r + lift + comfort * ((z - b_c) / hw).powi(2)` — a parabola whose rise is exactly `comfort` at z = b_c ± hw regardless of hw. Interior radius = hw²/(2·comfort), so at the 0.25 mm default (profile.rs:516): 3.6 mm band → 6.5 mm radius, 6 mm → 18 mm, 10 mm → 50 mm. Confirmed. Grepped `comfort` across profile.rs — no width coupling anywhere; `apply_style` (profile.rs:530) touches only shape_a/b/crown/edge_round. GUI slider is `0.0..=1.5` at `panels/design.rs:222-229`. ONE CORRECTION to the auditor's evidence: `profile.rs:662` clamps `comfort` to `hw*0.8` BEFORE `crown_cap` is computed, so the stated "1.5 mm on a 2 mm band collapses the crown cap to 0.3 mm" is not reachable — on a 2 mm band hw = 1.0 so comfort clamps to 0.8 and crown_cap = thickness − 1.0. The silent-collapse concern is still real, just at different numbers.
+
+#### F137 Nothing reasons about whether a finished design can be resized — `high` / `M` / sizing-fit
+
+**Problem.** A shop's second question after "what size?" is "can I size it later?", and the app has no concept of it — grep for `resiz` across every crate finds only egui window handling and the CLI's per-size rebuild. A full-ring `SeatRunLayer` (whose count is deliberately an integer so "the row closes on itself") cannot be cut and sized. A tiling that wraps the circumference cannot be sized without breaking the pattern at the joint. A signet with a keyframed palm cannot be sized in the palm at all. None of that is derivable by the shop from anything the app prints; the casting sheet says only the size it was built at.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:1706-1712 (`SeatRunLayer`, "The count is an integer so the row closes on itself"); crates/ringdesign-core/src/tiling.rs (`repeats_around: u32`, seamless by wrapping `u`); crates/ringdesign-core/src/spec.rs:60-64 and 97-115 (sheet's size and dimensions blocks carry no such note); workspace-wide grep for resize semantics returns nothing.
+
+**Do this.** Unchanged, and it is cheap because everything it needs already exists analytically. `RingDesign::resizability() -> Resizability { Freely{arc_deg}, ByRemake(reason), No(reason) }` in core: walk the stack the way `setstone::set_stones` already does (that function already knows every stone, its window and whether the entry is enabled), plus `Window::enabled`/`span_deg` per entry and `feature_footprints` for relief height. Full-ring `SeatRun`/pavé group → `No`. Relief above a token height covering more than ~200 deg of palm arc → `ByRemake`. Otherwise `Freely` with the plain arc named. Print it on the `spec.rs` sheet as one line under the size, in the configurator's `choices.json` and review step, and on the MCP `castability` block. It also gates finding 7's `resize_to` sensibly: a `No` design should refuse a silent size change rather than re-solve.
+
+<details><summary>The auditor's original recommendation</summary>
+
+`RingDesign::resizability() -> Resizability { Freely, ByRemake(reason), No(reason) }` in core, derived analytically the way `stones::report` is: full-ring stone runs and pavé groups → `No`; relief covering the palm arc (roughly 200–300°) at more than a token height → `ByRemake`; a plain or shoulder-only design → `Freely`, with the sizeable arc named in degrees. Print it on the casting sheet, in the configurator's `choices.json` and order review, and expose it on the MCP `castability` block. Two lines on a sheet — "Sizeable: no (full eternity)" or "Sizeable ±2 sizes at the palm, 200°–340° is plain" — is the whole feature.
+
+</details>
+
+**Castability.** None — read-only analysis of the existing layer stack and shank modulation.
+
+**Verified.** Verified. Grepped `resiz` case-insensitively across all crates and docs, filtering egui window chrome: the only substantive hits are `Alpha::resized` (image scaling, alpha.rs:2825) and the CLI module doc at `crates/ringdesign-cli/src/main.rs:4` ("each size is resized" — meaning rebuilt at a size, not shop-resizable). No `Resizability`, no sizeable-arc reasoning anywhere. `field.rs` `SeatRunLayer` count is a `u32` for exactly the closes-on-itself reason; `TilingLayer::repeats_around` likewise. `spec.rs:61` prints only `Size {size}`; the Dimensions block (spec.rs:97-115) carries nothing about it. Not on the roadmap Shelf (docs/ROADMAP.md:190-192) or Niceties (195-197) either.
+
+#### F138 A size change never re-solves stone spacing or live generators — `high` / `M` / sizing-fit
+
+**Problem.** Changing the size changes the circumference by 20% across a 5→9 run (49.25 mm to 59.45 mm), but the layers that were solved *to* a circumference are not re-solved. `SeatRunLayer::solve_spacing` is called only when a seat run is created or edited in the GUI panel and once in the configurator; `pave::regenerate_live` is called only from the GUI's `mark_dirty`. The CLI's size run does neither — it sets `d.size = RingSize(size)` and rebuilds. So a full eternity solved to a 0.4 mm bridge at size 7 comes out of a `--sizes 5:9:0.5` run with bridges anywhere from about 0.15 mm (will not fill, two stones sharing a hole) to about 0.7 mm (visibly gappy), and nothing says so. Even in the GUI, dragging the size slider re-runs `regenerate_live` for pavé groups but never touches a standalone seat run.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:172-181 (`d.size = RingSize(size)`, then `analyze_field` and `build` — no re-solve); crates/ringdesign-gui/src/app.rs:393 (`regenerate_live` from `mark_dirty`, groups only); crates/ringdesign-gui/src/panels/layers.rs:155-158 and 2236-2342 (`solve_spacing` on add/edit only); crates/ringdesign-configurator/src/compose.rs:288; crates/ringdesign-core/src/field.rs:1706-1712 (fixed `count: u32`, fixed `gem`); crates/ringdesign-core/src/sizing.rs:14-16 for the circumference figures.
+
+**Do this.** Narrow the ask to the two paths that are actually broken. Add `RingDesign::resize_to(&mut self, size: RingSize) -> Vec<String>` in core that sets the size, rebuilds the `FieldContext`, calls `SeatRunLayer::solve_spacing` on every enabled standalone run and `pave::regenerate_live` for live groups, and returns notes. Then call it from exactly three places: the CLI's per-size loop (main.rs:174), the GUI size slider (`panels/design.rs:66-69`, which currently only sets the size and marks dirty), and `ringdesign-py`'s `set_size` (lib.rs:243). The configurator already gets this for free through `compose()` and needs no change. Gate it on finding 6's `resizability()` and add `--keep-counts` to the CLI for the deliberate same-count run. Also fix the MCP `set_ring` description at tools.rs:1460 to say what re-solves and what does not.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Put `RingDesign::resize_to(&mut self, size: RingSize) -> Vec<String>` in core: set the size, rebuild the `FieldContext`, then walk the stack re-solving everything whose count or pitch was solved to the circumference — `SeatRunLayer::solve_spacing`, live `GroupLayer::recipe` groups via `pave::regenerate_live` — and return the notes ("eternity row re-solved 22 → 24 stones at size 9"). Make the CLI's per-size loop and the GUI's size slider both call it, and make the graph's `design.new`/`band.*` path go through it as well. Add a `--keep-counts` flag for the deliberate case where a design must stay the same stone count across a run.
+
+</details>
+
+**Castability.** Re-solving is what *protects* the guarantee: `pave::fill` and `solve_spacing` keep the integer-lattice, wrap-exact invariant that makes a full-ring row seamless. Not re-solving leaves bridges under `MIN_EDGE_MM`, which is the fill failure `stones::report` exists to catch — and which the size run currently never runs.
+
+**Verified.** Partly wired already. The configurator DOES re-solve: `compose()` calls `run.solve_spacing(&ctx)` at compose.rs:288 and `main.rs` step_size_metal calls `self.rebuild()` on any slider change, so a customer-facing size change re-packs the eternity. The GUI re-runs `pave::regenerate_live` from `mark_dirty` (app.rs:393) for live GROUPS only, guarded by `has_live && graph.is_none()`. What the auditor claims is genuinely missing is confirmed: `crates/ringdesign-cli/src/main.rs:174` does `d.size = RingSize(size)` then `analyze_field` and `build` with nothing in between; and grepping `solve_spacing` across all crates shows the only non-test call sites are compose.rs:288, `panels/layers.rs:158/2236/2255/2275/2288/2342` (add and edit handlers only) and `nodes/layer.rs:240` — none of them size-change paths. So a standalone `SeatRunLayer` is never re-solved on a size change in either the GUI or the CLI. The MCP `set_ring` doc (tools.rs:1460) even enumerates what stays seamless — tiling repeats, milgrain beads, rope twists — and is silent about seat runs, which is the one thing that does not.
+
+#### F145 No printable ring sizer or mandrel scale, and the printables that exist have no scale calibration — `medium` / `M` / sizing-fit *(also found as F215)*
+
+**Problem.** Two true-scale SVG printables already exist — the stone map at 2:1 and the parting line at 1:1, both dimensioned in mm — and neither carries a calibration bar or a "print at 100%, no page scaling" instruction. Browsers and print dialogs default to fit-to-page, so a setter can measure a 0.26 mm gap off a sheet that silently printed at 94%. And there is no ring sizer at all: no wrap strip, no mandrel scale, nothing a shop or a remote customer can print to establish the size in the first place. The roadmap's "Niceties: DPI true-scale" is the adjacent shelved item and deserves promotion, because the same true-scale plumbing serves all three.
+
+**Evidence.** crates/ringdesign-core/src/stonemap.rs:9-10 (`K = 2.0`), 32-35 (`width="{w}mm"` with a matching viewBox, title says 2:1) — no calibration mark anywhere in the file; crates/ringdesign-core/src/castability.rs:700-752 (`write_parting_svg`, mm units, no calibration mark); docs/ROADMAP.md:195-197 ("Niceties: gate & sprue advisor; DPI true-scale; …").
+
+**Do this.** Unchanged, and note explicitly that "DPI true-scale" already sits on the roadmap Niceties list at docs/ROADMAP.md:195 — this promotes and widens it rather than adding something new. Build one shared `printable` helper in core emitting a 50 mm calibration bar plus "Print at 100% — if this bar is not 50 mm, your printer scaled the page", and call it from `stonemap::stone_map_svg` (stonemap.rs:32), `castability::write_parting_svg` (castability.rs:722) and the `spec.rs` HTML sheet, which already has an `@media print` block at spec.rs:58 to hang it off. Then `sizing::sizer_strip_svg(standard)` and `sizing::mandrel_scale_svg(range)` reading the finding-2 standards table, wired into the GUI File menu, the CLI `--formats`, and — highest value of the three — the configurator's size step, where a remote customer currently has no way at all to establish their size. The calibration bar is the load-bearing half: without it the stone map's 0.26 mm gaps are already being measured off silently-scaled paper today.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a shared `printable` helper emitting a 50 mm calibration bar plus "Print at 100% — if this bar is not 50 mm, your printer scaled the page", and call it from `stone_map_svg`, `write_parting_svg` and the `spec.rs` HTML sheet. Then two new emitters in `sizing.rs`: `sizer_strip_svg(standard)` — a wrap strip with the circumference marks labelled in the shop's chosen standard — and `mandrel_scale_svg(range)` — a printed mandrel rule. Wire both into the GUI File menu, the CLI's `--formats`, and the configurator (where a printable sizer on the size step is worth more than any other single addition to that flow).
+
+</details>
+
+**Castability.** None — output documents only.
+
+**Verified.** Verified. `stonemap.rs:10` `const K: f64 = 2.0;` and `:33` emits `width="{w:.1}mm" height="{h:.1}mm"` with a matching viewBox and a `<title>… stone map, drawn 2:1 (mm)</title>` — I read the whole emitter and there is no calibration bar, no ruler, no print instruction. `castability::write_parting_svg` (castability.rs:704-753) is the same: mm units, mm viewBox, no calibration mark. Grepped `sizer|mandrel scale|calibration|print at 100|scale bar` across all crates and docs — the only two hits in the repo are `docs/ROADMAP.md:159` (an unrelated carat calibration) and `docs/ROADMAP.md:195`, which lists "DPI true-scale" on the Niceties parking lot. So the adjacent item IS already shelved, as the auditor suspected; it is unstarted and deserves promotion.
+
+#### F146 The order record carries a size with no provenance or fit convention — `medium` / `S` / sizing-fit
+
+**Problem.** `compose::Config` is explicitly the whole order — "a web frontend or an order queue can carry the same struct verbatim" — and its size is one `f64` doc'd "US finger size". Nothing records how it was measured (plastic sizer at home, mandrel in the shop, guessed from another ring), which standard it came from, or which fit convention the customer expected. The size step is a slider and an inside-diameter readout with no guidance: no note that the customer just picked a 7 mm band and that wide bands run tight, no note that comfort fit slides on easier, no "how to measure" and no printable sizer. When the ring comes back for a resize, `choices.json` cannot tell the shop whose error it was.
+
+**Evidence.** crates/ringdesign-configurator/src/compose.rs:140-156 (`Config`, `size: f64`, doc "US finger size"), 1-8 (module doc on Config being the order); crates/ringdesign-configurator/src/main.rs:582-594 (the whole size step) and 289-310 (`order_files`, `choices.json` is just `Config`).
+
+**Do this.** Unchanged, and it is the cheapest of the sizing findings — a serde struct field and two derived labels, no geometry. Add `Config.fit: FitRecord { standard, measured_as, raw_value, sizer_used: Option<String>, fit_style }` (serde-default so existing order folders still load) and put it in `choices.json` and the review step, so a returned ring's `choices.json` says whose measurement it was. In the size step at main.rs:585, derive two notes from the base ALREADY chosen on the previous step: the wide-band compensation being applied (finding 1 — the signet bases are 14 mm wide and currently get no compensation at all) and, for a comfort-fit base, one line saying the stated size is measured at the narrowest contact band. Land the printable sizer from finding 14 on this same step.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `Config.fit: FitRecord { standard: SizeStandard, measured_as: MeasuredAs, raw_value: f64, sizer_used: Option<String>, fit_style: FitStyle }` and put it in `choices.json` and on the review step. In the size step, derive and show two notes from the already-chosen base: the wide-band compensation being applied (from finding 1) and, for a comfort-fit base, one line saying the size is measured at the narrowest contact band. Add the printable sizer from the previous finding here.
+
+</details>
+
+**Castability.** None — order metadata and UI copy.
+
+**Verified.** Verified. `compose::Config` (compose.rs:140-156) is `{ base, size: f64 /* US finger size */, metal: usize, stone, pattern, milgrain, engraving, script_font, customer }` — the size is one bare f64 with a one-line doc and nothing about how it was arrived at. The module doc and CLAUDE.md both state the struct IS the whole order and that a web frontend can carry it verbatim. `order_files`/`choices.json` serializes `Config` as-is. The size step (`main.rs:582-594`) is a `3.0..=13.0` slider stepped 0.25 plus an `inside diameter {:.2} mm` label — no how-to-measure text, no wide-band note, no comfort-fit note, no printable sizer, and (per finding 1) the base's own width is not consulted at all even though the user has already chosen a 7 mm or 14 mm band on the previous step.
+
+#### F227 Bangles and cuffs: the whole engine works, only the size type refuses — `high` / `M` / competitor-parity
+
+**Problem.** `RingSize` is a US ring size and nothing else. `design.new` rejects anything outside 1–20, which is 39–87 mm of circumference — a bangle needs 60–70 mm of *diameter*. Every other piece of the machinery is diameter-agnostic: the sweep is a circle, `u` wraps at circumference, the verdict reads the section. CrossGems ships Bangle, Bangle Rail and Hoops families; a sand-cast bangle is one of the most natural Delft-clay pieces there is, and we cannot express one.
+
+**Evidence.** crates/ringdesign-core/src/sizing.rs:1-47 — the whole module is `size = (circumference - 36.5)/2.55`, with `common()` running 3..15. crates/ringdesign-graph/src/nodes/band.rs:18-22 — `if !(1.0..=20.0).contains(&size) { return Err(..."is not a US ring size between 1 and 20") }`. crates/ringdesign-configurator/src/compose.rs:198 clamps to 3..13. assets/decoded/presets/Bangle/ holds 16 factory bangle presets with cached meshes we can measure against.
+
+**Do this.** Store inner diameter in mm as the truth and keep `RingSize` as a conversion view (`from_diameter_mm`/`inner_diameter_mm` already exist). Note the quarter-size rounding in `RingSize::new` must not sit on the stored path or a bangle quantizes. There are five guards to widen, not one: `nodes/band.rs:18`, `ringdesign-py/src/lib.rs:240`, `mcp/tools.rs:1467`, `configurator/compose.rs:198`, and the GUI slider at `gui/panels/design.rs:59`. Add a size-family switch (Ring / Bangle / Cuff) driving `sizing::common()`'s ladder and the slider range. A cuff is the interesting second half: it is a bangle with an arc gap, which the existing angular `Window` machinery already expresses, so it is mostly a `ShankKind` question rather than a sweep one — measure against the 16 cached Bangle presets the way the signet loft was measured.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Introduce `BandSize { inner_diameter_mm: f64 }` as the stored quantity and keep `RingSize` as a display/conversion view over it (`RingSize::from_diameter_mm` already exists). Widen the `design.new` guard to a diameter range, give the GUI a size-family switch (Ring / Bangle / Cuff), and let `sizing::common()` return the family's own ladder. Nothing in `profile.rs`, `field.rs`, `mesh.rs` or `castability.rs` needs to change.
+
+</details>
+
+**Castability.** None. The sweep, the superellipse drop and the field verdict never read the size; a larger radius only makes `FieldContext::arc_scale` closer to 1, which is the safe direction for every reported bridge.
+
+**Verified.** Verified. `sizing.rs` is 55 lines and is entirely `size = (circ - 36.5)/2.55`; `common()` runs 3.0..=15.0 in half steps. Guards found: `nodes/band.rs:18` and `ringdesign-py/src/lib.rs:240` both reject outside `1.0..=20.0` with the literal message "is not a US ring size between 1 and 20"; `mcp/tools.rs:1467` rejects outside `0.5..=20.0`; `configurator/compose.rs:198` clamps to `3.0..=13.0`; the GUI slider (gui/panels/design.rs:59) is `3.0..=15.0`. A further wrinkle the finding did not name: `RingSize::new` rounds to the nearest quarter size, so even the stored quantity is quantized to ~0.64 mm of circumference — wrong granularity for a bangle. `assets/decoded/presets/Bangle/` does hold 16 factory presets with cached meshes (gitignored under `.gitignore:3 assets/`), plus `Hoops/`, `Bail/` and `Calotte/` families in the same tree. Nothing in `profile.rs`/`field.rs`/`mesh.rs`/`castability.rs` reads `RingSize` — they read `design.inner_radius_mm()` — so the finding's claim that the geometry is diameter-agnostic checks out.
+
+**Merged into a canonical finding above:** F142 (Neither UI can take a measured millimetre or a UK letter — only a US number) -> F133, F215 (Nothing helps the customer get the size right) -> F145, F228 (Size wizard: one standard, no comfort-fit compensation, no mandrel readout) -> F133.
+
+### M22 — More than one body (XL, 19 findings)
+
+**Done when:** The shipped build reaches Free mode with no C++ toolchain; a Free-mode body gets a verdict before any sink writes; the kernel sweeps a section along a path; a mask pierces a band with the web measured.
+
+#### F32 The height field cannot pierce metal, in either process — `high` / `XL` / lost-wax *(also found as F92, F225)*
+
+**Problem.** `OpenworkLayer` is the closest thing to piercing and can never go through: the carve depth is capped so `keep_mm` (floored at 0.2) of metal always stands over the bore. Correct for sand — a through-hole leaves an island of sand with nothing holding it — but piercing is the defining feature of lost-wax ring work: pierced galleries, filigree, open-back settings, cut-out shanks, negative-space monograms. Because the design is a displacement over a closed swept loop the mesh has torus topology by construction and has no way to express a hole. Lost wax exists in this app precisely to unlock that, and the height field cannot deliver it.
+
+**Evidence.** crates/ringdesign-core/src/field.rs:640-648 (`OpenworkLayer { depth_mm, keep_mm }`) and :663-672 — the carve is capped at `(r − bore_radius − keep_mm.max(0.2)) / nr`. CLAUDE.md's own "Why the mesh is always watertight": "The result has torus topology: no caps, no seams, no special cases."
+
+**Do this.** Two honest options and one dishonest one to avoid. Either (a) accept piercing as a Free-mode job and make Free mode reachable (findings 14/15), or (b) add an export-time `Layer::Pierce` that cuts the openwork mask through the mesh via the solid kernel and returns a still-watertight result, keeping the interactive preview on the height field — that keeps the section view, DFM and stones report working, which crossing to Free mode does not. What must not happen is leaving Openwork labelled as though it could pierce: say in the layer UI that it is relief, not a hole.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Accept that piercing is a Free-mode job and make Free mode reachable (next finding) — or add a narrower escape: a `Layer::Pierce` that, at export only, cuts the openwork mask through the mesh via the solid kernel and returns a still-watertight result, keeping the interactive preview on the height field. Either way, say in the UI that Openwork is relief, not piercing, so nobody expects a hole.
+
+</details>
+
+**Castability.** None to the sand path if piercing stays behind the process check — piercing a sand ring is exactly the island a two-part mould cannot hold, and the field verdict has no way to see it, so it must be refused under SandTwoPart.
+
+**Verified.** Verified. `OpenworkLayer { tiling, depth_mm, keep_mm }` at field.rs:640-651; the carve at field.rs:674 is `let radial = (r - ctx.bore_radius_mm - self.keep_mm.max(0.2)).max(0.0);` — the 0.2 mm floor makes a through-hole unreachable by construction, not by policy. No `Layer::Pierce` or equivalent exists (`Layer` enum, field.rs:495-509, is the eleven kinds listed in the orientation). CLAUDE.md's own "Why the mesh is always watertight" section states the torus topology that forbids it. This is the sharpest lost-wax finding in the list: piercing is the one thing investment buys that sand cannot, and it is precisely what the model cannot express.
+
+#### F33 Free mode is unreachable from the shipped application — `critical` / `S` / lost-wax
+
+**Problem.** `ringdesign-gui` declares `default = []`; the Manifold kernel is behind an opt-in `kernel` feature that pulls a C++ toolchain and a Manifold source clone. The binary a user runs has no solid nodes registered at all. On top of that nothing in any UI ever sets `Mode::Free`: the graph editor reads `self.graph.mode` to filter its palette but offers no control to change it, `Graph::from_design` (Convert to graph) always produces SandRing, `SIMPLE` and all nine bundled graph templates are SandRing, and the one Free artefact — the vine semi-mount — is a *cluster*, listed only under the same feature. A user with the feature compiled in still has no way to create a Free graph.
+
+**Evidence.** crates/ringdesign-gui/Cargo.toml:12-14 (`default = []`). `grep -rn "Mode::Free" crates/` outside tests hits only crates/ringdesign-mcp/src/graph_tools.rs:58 (a string parse), crates/ringdesign-py/src/lib.rs:654 (listing specs) and crates/ringdesign-graph/src/templates.rs:86 (the vine cluster builder). crates/ringdesign-graph-ui/src/editor.rs:888 `let specs = self.reg.list(self.mode)` with `mode` only ever read from the graph. templates.rs:50-56 gates the vine entry on the feature; nodes/mod.rs:22,44 gates the whole solid node module.
+
+**Do this.** (1) Add a mode control to gui/panels/graph.rs's empty state and the editor's background menu, writing `graph.mode`, with a refusal naming the missing feature when `ringdesign_solid::kernel_available()` is false. (2) Decide the shipping question out loud: flip `default = ["kernel"]` and eat the cmake build, vendor a prebuilt Manifold, or state in the empty state that Free mode needs `--features kernel`. The current state — a whole mode that exists, is documented in CLAUDE.md, and cannot be entered from the app — is the worst of the three.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Two small changes. (1) Add a mode control to the graph editor's empty state and node menu — "Free mode (solid kernel)" — writing `graph.mode`, with a refusal naming the missing feature when `ringdesign_solid::kernel_available()` is false. (2) Decide whether the kernel ships: flip `default = ["kernel"]` and eat the build cost, vendor a prebuilt Manifold, or state plainly in the empty state that Free mode needs `--features kernel`. Silence is the worst of the three.
+
+</details>
+
+**Castability.** None — Free-mode nodes are already refused at validation in a SandRing graph (nodes/solid.rs:1-3, tested at :466-470).
+
+**Verified.** Every claim verified. ringdesign-gui/Cargo.toml:12-14 `default = []`, `kernel = ["ringdesign-graph/kernel-manifold", "ringdesign-script/kernel"]`. `Mode::Free` outside tests appears only at mcp/graph_tools.rs:58 (a string parse in `parse_mode`), py/lib.rs:654 (listing specs) and graph/templates.rs:86 (the vine cluster builder). graph-ui/editor.rs:888 `let specs = self.reg.list(self.mode)` with `mode` set only from `self.graph.mode` (editor.rs:418). The GUI's graph empty state (gui/panels/graph.rs:68-80) offers exactly three things — Convert this design to a graph, Start from the simple graph, Open a template graph — all SandRing; no mode control anywhere in the GUI. templates.rs:50-56 gates the vine cluster on the feature. So even a `--features kernel` build gives a user no way to create a Free graph; only MCP `graph_new {mode: "free"}` can.
+
+#### F34 Even with the kernel, a solid never reaches the viewport, the sheet, the stone map or the size run — `high` / `L` / lost-wax
+
+**Problem.** A Free-mode graph produces a `Value::Solid` and, through `solid.mesh`, a `Value::Mesh`. The GUI's build worker evaluates the graph and then builds the *evaluated design* — it never looks at a mesh output — so the vine semi-mount cannot be seen in the 3D viewport at all; you export an STL and open it elsewhere. Nor can a solid reach `spec::write_casting_sheet` (takes a `RingDesign`), `stonemap`, `stones::report`, the modulus scan, the parting-line SVG, or the CLI's size run. `solid.vine_semimount` returns thirteen stones as loose JSON that no report consumes. Free mode is an export pipe with a render node bolted on.
+
+**Evidence.** crates/ringdesign-gui/src/app.rs:475-489 — the worker's `graph` result splices `gd.design` into `self.design` and builds that; there is no `Value::Mesh` path. `grep -rni "solid" crates/ringdesign-gui/src` returns only `PaneKind::Solid`, an unrelated name for the 3D pane. crates/ringdesign-graph/src/nodes/solid.rs:244-253 (`vine` outputs `stones` as `Value::Json`, consumed by nothing). crates/ringdesign-core/src/spec.rs:34 and stonemap take `&RingDesign`.
+
+**Do this.** Add a viewport source that draws the active Free graph's `mesh` output, reusing `render::Part`'s list so the vine's stones can draw alongside the metal. Then lift `spec::write_casting_sheet`/`metal_table` to take a volume plus an *optional* design, so a solid gets weights, quality (`Mesh::quality` already exists) and a stones table without a chart — `solid.mesh` already outputs `volume_mm3`, and the vine node already computes carats and a stone list, so the inputs are all present and simply unconsumed.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a viewport source that draws the graph's `mesh` output when the active graph is Free, reusing `render::Part`'s list so stones draw too. Then lift `spec::write_casting_sheet` and `metal_table` to take a volume plus an optional design, so a solid gets a sheet with weights and a stones table even without a chart — `solid.mesh` already outputs volume and `Mesh::quality` already exists.
+
+</details>
+
+**Castability.** None.
+
+**Verified.** Verified. app.rs:475-489: the worker's graph result splices `gd.design` into `self.design` (keeping the live graph) and builds that; there is no `Value::Mesh` branch anywhere in the GUI. `grep -i solid` across ringdesign-gui/src returns only `PaneKind::Solid` (pane.rs:18) — the name of the 3D *ring* pane, unrelated. `solid.mesh` (nodes/solid.rs:390) outputs mesh, triangles, watertight, volume_mm3, surface_area_mm2, consumed only by sink.export, sink.render and sink.mesh_verdict. `solid.vine_semimount` (nodes/solid.rs:244-253) emits its thirteen stones as `Value::Json` items that no report reads. spec::html and stonemap both take `&RingDesign`.
+
+#### F35 A Free-mode ring gets no manufacturing verdict at all — `critical` / `L` / lost-wax
+
+**Problem.** `judge()` returns `Ok(None)` immediately when `ctx.mode != Mode::SandRing`, so `sink.export`, `sink.save_design` and every file-writing sink in Free mode write whatever they are handed with zero checks. The only verdict node available, `sink.mesh_verdict`, is `free_only` and runs `castability::analyze` — a two-part sand pull test, the wrong question for an investment piece, reporting "vertical walls" as a virtue. Nothing measures minimum wall thickness on a mesh anywhere in the workspace (`Mesh::quality` gives triangle statistics only), so a solid with 0.15 mm tendrils exports silently. Asked directly: a lost-wax design gets silence.
+
+**Evidence.** crates/ringdesign-graph/src/nodes/sink.rs:54-57 (`if ctx.mode != Mode::SandRing { return Ok(None) }`) and :263-264 (`export` calls `judge` first). :484-497 registers `sink.mesh_verdict` with `.free_only()` and outputs `undercut_pct`, `worst_draft_deg`, `parting_z_mm` — pull statistics. `grep -rn "thin|thickness|wall" crates/ringdesign-core/src/mesh.rs` yields only `min_wall_mm`, the build clamp.
+
+**Do this.** Write `sink.investment_verdict` (Free mode): minimum wall by marching inward along vertex normals against the Manifold solid, thinnest section against the process's `min_section_mm`, the longest thin run as a flow-length check (a 0.6 mm wire 20 mm long freezes before it fills), smallest feature by the granulometry idea `Alpha::min_feature_px` already implements, and volume/weight. Then make `judge()` in Free mode require *that* report instead of returning `Ok(None)` — the current behaviour means the mandrel vine, the one finished Free-mode piece, exports with zero checks.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Write `sink.investment_verdict` (Free mode): minimum wall thickness by marching inward along vertex normals against the solid, thinnest section against the process's `min_section_mm`, the longest thin run (a flow-length check — a 0.6 mm wire 20 mm long freezes off before it fills), the smallest feature by the same granulometry idea `Alpha::min_feature_px` uses, and total volume/weight. Then make `judge()` in Free mode require that report rather than nothing. Manifold can give the inward distances cheaply.
+
+</details>
+
+**Castability.** None to sand — SandRing's `judge` is unchanged and still refuses `NotCastable`.
+
+**Verified.** Verified verbatim. sink.rs:54-57: `fn judge(...) { if ctx.mode != Mode::SandRing { return Ok(None); } ... }`, and `export` calls `judge(ctx, i, "export")?` at :263 — so in Free mode every file sink writes unchecked. `sink.mesh_verdict` (registered at :484-497 with `.free_only()`, body at :339-351) runs `castability::analyze` and outputs verdict/undercut_pct/worst_draft_deg/parting_z_mm/vertical_faces — two-part pull statistics, the wrong question, and its refusal string when reached through SandRing sinks even reads "will not release from a two-part sand mould" (:255). No minimum-wall measurement on a mesh exists anywhere: mesh.rs's only `min_wall` is the build clamp, `Mesh::quality` (mesh.rs:163-175) reports min angle, worst aspect and degenerate count only, and ringdesign-solid has no thickness code.
+
+#### F36 The Free-mode construction library is twelve primitives and one hand-ported vine — `high` / `XL` / lost-wax
+
+**Problem.** `ringdesign-solid/src/kernel.rs` is 464 lines: cylinder, cone, sphere, cube, a marquise lens, two rails, a tube, `Frame`, `Parts`, a four-prong round setting, a four-prong marquise setting, a leaf, Catmull-Rom, and `vine_ring` — mandrel's one ring, ported verbatim. There is no basket, no under-gallery, no bezel, no cathedral or tension shank, no sweep-along-path with a section (the only sweep is a round tube), no fillet or 3D offset, no chain link, no hinge, no text-as-solid, no bail. Asked what a second, third and tenth Free-mode part would be: there is no answer in the code, because there is no library — there is one finished ring and a box of shapes.
+
+**Evidence.** crates/ringdesign-solid/src/kernel.rs in full: the only jewellery-domain functions are `marquise_setting` (:180-205), `round_setting` (:207-220), `leaf` (:223-238) and `vine_ring`. crates/ringdesign-graph/src/nodes/solid.rs:266-400 registers 20 nodes, of which exactly three are jewellery (`solid.setting`, `solid.leaf`, `solid.vine_semimount`).
+
+**Do this.** Build in bench order, and note that two of these are cheap because the field side already knows the geometry: (1) `basket(dia, seat_h, rails, prongs)` — the four/six-prong head with a gallery rail, the most-used mount in the trade, and `round_setting` is already 80% of it; (2) `bezel(gem, wall, bearing)` as a solid with a cut seat, reusing the numbers `SeatPadLayer::fit_stone` already derives (collar height from crown, `bezel_bearing_mm` ledge); (3) `sweep(section, guide)` — a profile along a Catmull-Rom, which promotes every existing 2D `BandProfile` into a wire, vine, split shank or bypass arm and is by far the highest leverage single function; (4) `under_gallery(outline, depth)` to pierce a lofted signet's belly; (5) `tension_shank`; (6) chain link / hinge. Hold each to the same measured-and-pinned discipline as the field side.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Build the library in the order a bench uses it: (1) `basket(dia, seat_h, rails, prongs)` — the four/six-prong head with a gallery rail, the most-used mount in the trade; (2) `bezel(gem, wall, bearing)` as a real solid with a cut seat, since the field's bezel already knows the geometry; (3) `sweep(section_path, guide_path)` — a profile swept along a Catmull-Rom, which turns every existing 2D profile into a wire, vine, split shank or bypass arm; (4) `under_gallery(outline, depth)` — pierce a lofted signet's belly; (5) `tension_shank(gap, gem)`; (6) `chain_link`/`hinge`. Each should carry the same measured-and-pinned discipline the field side has.
+
+</details>
+
+**Castability.** All of it is lost-wax territory by construction and would be `free_only`, so the sand guarantees are untouched. Any part that could also cast in sand should be proved with `analyze` the way `a_tube_ring_reads_as_vertical_walls_not_an_undercut` already does.
+
+**Verified.** Verified by enumerating both files. kernel.rs is 464 lines with 26 public functions: v3, cylinder, cone, sphere, cube, marquise_lens, marquise_prism, marquise_rail, round_rail, union_all, Frame{new,on_ring,place,point,rolled,tilted}, segment, tube, Parts{extend,resolve}, marquise_setting, round_setting, leaf, catmull_rom, vine_ring, to_mesh, from_mesh. Exactly three are jewellery-domain: `marquise_setting` (:184), `round_setting` (:208), `leaf` (:224) — plus `vine_ring` (:283), mandrel's one finished ring. The node registry (nodes/solid.rs:269-390) is 21 nodes, of which three are jewellery (solid.setting, solid.leaf, solid.vine_semimount). No basket, gallery, bezel-as-solid, path sweep with a section (the only sweep is `tube`, a round wire), fillet, offset, chain link, hinge, bail or text-as-solid.
+
+#### F37 solid.import takes OBJ and STL only, watertight-only, so a bought head will not come in — `medium` / `M` / lost-wax *(also found as F205)*
+
+**Problem.** `solid.import` reads OBJ and STL through `ringdesign-solid/src/io.rs` and refuses anything Manifold will not accept as a manifold. Commercial mount, head and finding libraries — the ones a jeweller actually buys — ship as STEP or 3DM, and the STLs that do exist are frequently non-manifold (duplicate faces, flipped normals, tiny gaps). There is no welding tolerance, no repair, no hole filling, and no error message distinguishing "this file is not watertight" from "this file is not in a format I read". The project's own CrossGems harvest already parses Rhino `.3dm` in Python, so the format knowledge exists outside the app.
+
+**Evidence.** crates/ringdesign-solid/src/io.rs:1-2 module doc ("OBJ and STL (binary or ASCII)"); crates/ringdesign-graph/src/nodes/solid.rs:377-379 (`solid.import` doc: "it must be watertight") and the `import` body at :240 mapping `kernel::from_mesh`'s error straight through. `kernel::from_mesh` calls `m.status()` and bails.
+
+**Do this.** Add an epsilon-tolerance weld (replacing the bit-exact `to_bits` key in io.rs:120), consistent face orientation and a small hole-fill pass before handing Manifold the mesh, and report what was repaired — that is what turns a real bought STL into an importable one. Apply the weld to the OBJ path too, which currently trusts the file's indices. Then add `.3dm` reading so the CrossGems settings library and any Rhino asset can be placed with `frame.on_ring`. Drop the error-message half of the claim; the messages are already distinct.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a weld tolerance and a repair pass to `io.rs` — merge vertices within epsilon, drop degenerate triangles, orient consistently, report what was fixed — before handing Manifold the mesh, and say in the error which of the two failures occurred. Then add `.3dm` reading (the harvest tools already decode it) so the CrossGems settings library and any Rhino asset can be placed with `frame.on_ring`.
+
+</details>
+
+**Castability.** None; imports are Free-mode only.
+
+**Verified.** Substance confirmed, two details corrected. Confirmed: io.rs:1-2 doc "OBJ and STL (binary or ASCII)"; nodes/solid.rs:377-379 `solid.import` doc "An OBJ or STL file as a solid; it must be watertight"; `kernel::from_mesh` (kernel.rs:390-396) calls `m.status()` and bails; no STEP or 3DM reader in crates/ (the .3dm knowledge lives only in the gitignored tools/harvest Python). Corrected: (a) a weld *does* exist — io.rs:120-141 `weld()` keys on `f32::to_bits`, so it merges bit-identical vertices and drops degenerate triangles; what is missing is a *tolerance* weld, orientation repair and hole filling, and the weld is STL-only (`parse_obj` uses the file's own indices). (b) The errors do already distinguish the two failures: nodes/solid.rs:237 returns "an .obj or .stl file" for an unknown extension, and from_mesh returns "not a manifold: {status}" — so that half of the finding is a misread.
+
+#### F38 mcpd and the Python module cannot enable the kernel, so mandrel's retirement is a capability loss — `medium` / `S` / lost-wax
+
+**Problem.** Only `ringdesign-gui` and `ringdesign-cli` declare a `kernel` feature. `ringdesign-mcp`, `ringdesign-mcpd` and `ringdesign-py` have none, so the standalone MCP server and the Python module build `ringdesign-script`'s registry without solid nodes. `graph_new` happily accepts `mode: "free"` and then `graph_add_node("solid.vine_semimount")` fails as an unknown kind, and `graph_list_clusters` never lists the vine because `BUNDLED_CLUSTERS` is feature-gated. CLAUDE.md states mandrel's own MCP is "retired: the same work is graph_add_node on the cluster, graph_set_input on its exposed pins, graph_evaluate, and a sink.export in Free mode" — that sequence cannot run on the shipped `ringdesign-mcpd`.
+
+**Evidence.** crates/ringdesign-mcpd/Cargo.toml has no `[features]` section at all; crates/ringdesign-mcp/Cargo.toml and crates/ringdesign-py/Cargo.toml have no kernel forward. crates/ringdesign-mcp/src/graph_tools.rs:27-29 uses `ringdesign_script::registry`, and crates/ringdesign-script/Cargo.toml:10 has the feature but nothing upstream enables it. crates/ringdesign-graph/src/templates.rs:50-56 gates the vine cluster.
+
+**Do this.** Add a forwarding `kernel` feature to ringdesign-mcp, ringdesign-mcpd and ringdesign-py (each `kernel = ["ringdesign-script/kernel"]`), and make `graph_new` refuse `mode: "free"` with a message naming the missing feature when `kernel_available()` is false, rather than creating a graph whose only nodes cannot be added. Then either ship the feature or correct the CLAUDE.md paragraph that says mandrel's MCP was retired in favour of a sequence that does not run.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add a forwarding `kernel` feature to `ringdesign-mcp`, `ringdesign-mcpd` and `ringdesign-py`, and make `graph_new` refuse `mode: "free"` with a clear message when `kernel_available()` is false rather than creating a graph whose nodes cannot be added. Then either correct the CLAUDE.md claim or ship the feature.
+
+</details>
+
+**Castability.** None.
+
+**Verified.** Verified by reading all five manifests. `[features] kernel` exists only in ringdesign-gui/Cargo.toml:12-14 and ringdesign-cli/Cargo.toml:12-14; ringdesign-script/Cargo.toml:8-10 has `kernel = ["ringdesign-graph/kernel-manifold"]` but nothing else forwards to it. ringdesign-mcpd/Cargo.toml has no `[features]` section at all; ringdesign-mcp/Cargo.toml and ringdesign-py/Cargo.toml likewise. mcp/graph_tools.rs:27-29 builds from `ringdesign_script::registry()`, and `parse_mode` (:55-61) happily accepts "free" — so `graph_new {mode: "free"}` succeeds and the subsequent `graph_add_node("solid.vine_semimount")` cannot. templates.rs:50-56 excludes the vine cluster from `BUNDLED_CLUSTERS` without the feature. CLAUDE.md's claim that mandrel's MCP is retired in favour of that exact sequence is therefore false for the shipped `ringdesign-mcpd`. (Note: because cargo features are additive, a GUI built with `--features kernel` does get solid nodes in its in-process MCP — the loss is specific to the standalone daemon and the Python module.)
+
+#### F39 There is no way back from a solid, so "sand until it fails, then lost wax" only works while the piece stays a height field — `high` / `XL` / lost-wax
+
+**Problem.** The round trip is one-directional. Flipping `draft.process` keeps everything — layers, stones, sheet, stone map, size run — which is genuinely good and is the honest half of the story. But the moment a design needs geometry the field cannot express (a real basket, a pierced gallery, a stone off the band), the only route is a Free graph with `solid.from_design`, which converts the band to a mesh. Nothing converts back: there is no `design.from_solid`, no way to keep editing layers on the band while a solid setting rides it, and crossing over loses the section view, the DFM chips, the stones report, the casting sheet and the size run. It is a fork, not a promotion.
+
+**Evidence.** crates/ringdesign-graph/src/nodes/solid.rs:305-310 — `solid.from_design` takes a `Design` and returns a `Solid`; the registry has no inverse. `solid.mesh` produces `ValueKind::Mesh`, consumed only by `sink.export`, `sink.render` and `sink.mesh_verdict`. `RingDesign` has no mesh or solid member.
+
+**Do this.** Model the finished piece as band-plus-attachments rather than as one mesh: add `RingDesign::attachments: Vec<SolidPart>` (a placed solid plus provenance — a graph subtree or an imported file), which the viewport draws, the weight table sums, the stones report reads through the existing `setstone::SetStone` record, and the export unions last. `Frame::on_ring` already exists and is exactly the placement primitive this needs. The band then keeps every field-side tool while carrying real settings, and choosing lost wax becomes a setting rather than a fork. This is the structural item the other Free-mode findings all lean on — worth sequencing first.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Model the finished piece as band-plus-attachments rather than as one mesh: add `RingDesign::attachments: Vec<SolidPart>` (each a placed solid plus its provenance — a graph subtree or an imported file) that the viewport draws, the weight table sums, the stones report reads, and the export unions at the end. The band then keeps every field-side tool it has while carrying real settings, and switching process becomes a setting rather than a fork.
+
+</details>
+
+**Castability.** Attachments must be refused (or reduced to zero-height markers) under SandTwoPart, since a solid outside the height field has no chart and `analyze_field` cannot see it — the same reason `sink.mesh_verdict` is Free-only today.
+
+**Verified.** Verified. `solid.from_design` (nodes/solid.rs:305-310) takes a Design and returns a Solid; the registry's 21 solid nodes contain no inverse — no `design.from_solid`, no attachment node. `RingDesign` (lib.rs:70-101) has eleven fields — name, size, profile, shank, layers, build, draft, drawn, embedded, texts, svgs, recipes, graph — and no mesh, solid or attachment member. `solid.mesh` produces `ValueKind::Mesh`, consumed only by sink.export, sink.render and sink.mesh_verdict. So the moment a design needs a real basket or a pierced gallery, everything downstream of the chart — section view, DFM chips, stones report, casting sheet, stone map, size run — is lost at once. The honest half is also true: flipping `draft.process` alone keeps all of it, which is what makes the cliff so abrupt.
+
+#### F46 No assembly: a spinner, a puzzle ring, a ring guard, a stacking set or a matched wedding pair has no home in the file or the exporter — `high` / `L` / ring-typology
+
+**Problem.** Everything downstream assumes one body. There is no way to author two parts that must fit together with a running clearance (spinner core and outer band, ring guard on a shank, interlocking puzzle bands), and no way to hold a matched his/hers pair as one order — which is how bridal is actually sold. 3MF, the one export format designed for multi-object packages, writes a single object.
+
+**Evidence.** crates/ringdesign-core/src/lib.rs:68 `RingDesign` carries one `profile` and one `shank`. crates/ringdesign-core/src/stl.rs:72,79,104 `write_stl/write_obj/write_ply(path, mesh: &Mesh, name)`; crates/ringdesign-core/src/threemf.rs:121 `pub fn to_3mf(mesh: &Mesh, name: &str, size_label: &str)`. crates/ringdesign-graph/src/nodes/sink.rs:265 `let mesh = mesh_of(i, "mesh")?;` — one mesh per export node. crates/ringdesign-configurator/src/compose.rs Config is one ring with one `size`. `render::Part` (render.rs) is the only multi-body idea in the codebase and it is render-only.
+
+**Do this.** Three steps, each independently useful. (1) `threemf::to_3mf(parts: &[(&Mesh, &str)])` — the store-only zip writer already handles a package, and 3MF's whole point is per-object names and metadata; this alone lets a wedding set, a spinner, or a Free-mode semi-mount ship as one file. (2) An `Assembly { parts: Vec<RingDesign|Mesh>, clearance_mm }` type in core with a minimum-gap check between parts (the pairwise girdle census in `stones.rs` is the same shape of measurement). (3) `compose::Config` grows an optional partner band so the kiosk can sell a set.
+
+**Castability.** Neutral. Each part is judged on its own by the existing field verdict; the new check is a fit clearance, not a draft one. A spinner's outer ring is an ordinary band and casts fine — it is only the pair that has no representation.
+
+#### F53 Open, adjustable and cuff rings are structurally impossible — the sweep is hard-wired to a closed torus — `medium` / `XL` / ring-typology
+
+**Problem.** A band that does not close at 360° — an adjustable/open cuff ring, an open-shank tension-look ring, a wrap or snake ring with a free tail — cannot be built. This is not a sand limitation: an open cuff parts perfectly well on a Z plane. It is an architectural one, and it is worth naming as such so the decision is deliberate.
+
+**Evidence.** crates/ringdesign-core/src/mesh.rs:326 `let theta = frac * 360.0;` and mesh.rs:381 `let i1 = (i + 1) % n_theta;` — the θ direction wraps unconditionally. lib.rs's module doc: "a closed cross-section profile swept 360° about the finger axis". CLAUDE.md: "The cross-section is a closed loop and the sweep closes at 360°, so both grid directions wrap. The result has torus topology: no caps, no seams, no special cases." The refined builder is a quadtree over "the `(u, s)` torus" and depends on the same wrap.
+
+**Do this.** Add `RingDesign::sweep_arc_deg: Option<f64>`. When set, the sweep runs the arc, the θ direction does not wrap, and the two end cross-sections are triangulated as caps — the section is already a closed loop, so a cap is a fan from its centroid and the result is a cylinder-with-caps, watertight by a different but equally cheap construction. The refiner needs the same: no wrap in `u`, and the two boundary columns pinned. Reserve it behind a flag until the refiner follows, and let the swept builder have it first.
+
+**Castability.** An open band still parts on the same plane and the superellipse drop is unchanged, so the base guarantee holds. The two new end caps are planar faces perpendicular to nothing in particular — they need the same draft/fill review any new surface does, and `analyze_field` must be taught to include them or it will silently judge only the swept part.
+
+#### F54 Tension, basket, peg-head and six-prong Tiffany heads have no construction in either mode — `high` / `L` / ring-typology *(also found as F69)*
+
+**Problem.** The four commonest engagement-ring heads all involve a void under the stone — a basket's open sides, a peg head's gallery, six claws standing off a shank, the gap of a tension set. All are structurally impossible in a height field, which is correct and stated. But Free mode does not fill the gap either: it has a marquise and a round setting, and one hosted cluster, and that cluster is a vine.
+
+**Evidence.** crates/ringdesign-solid/src/kernel.rs:184 `marquise_setting`, kernel.rs:208 `round_setting`, kernel.rs:224 `leaf`, kernel.rs:283 `vine_ring` — the whole setting vocabulary. crates/ringdesign-graph/src/nodes/solid.rs exposes `solid.setting` (marquise or round) and `solid.vine_semimount`; the bundled clusters are `signet.cluster.json` (sand) and `vine-semi-mount.cluster.json` (Free). No basket, no peg head, no prong count, no tension gap. crates/ringdesign-core/src/field.rs:1032 `SeatPadLayer::prongs` builds "drafted cone bumps on the seat circle — cast oversize, notched and shaped at the bench", which is stock, not a head.
+
+**Do this.** Add to `kernel.rs` and expose as nodes: `basket(dia, seat_h, prongs, rails)` (a ring of posts joined by one or two bearing rails), `peg_head(dia, prongs, peg_len)` (a head with a peg for a drilled shank), and `tension_gap(band, gem, gap_mm)` (the band cut and the girdle bearing cut into both faces). Then ship a "Solitaire semi-mount" cluster the way the vine one is shipped: band from `solid.from_design`, head placed by `frame.on_ring`, unioned, judged by `sink.mesh_verdict`. Say in each node's doc that these are lost wax and why.
+
+**Castability.** All four are lost wax by definition — a basket's window and a tension gap are voids no two-part sand mould clears, and the field verdict must never be asked to bless them. The mesh verifier is the right judge, which is already how the vine semi-mount reports.
+
+#### F62 Bar setting is missing, and the collar measurement already proves it casts — `high` / `M` / stone-setting
+
+**Problem.** There is no bar setting anywhere — no `Layer` variant, no `SeatStyle`, no generator. It is the one classic setting that is provably castable in a two-part sand pull and is not offered. A bar runs across the band from bore edge to bore edge with stones between the bars; its flanks face round the ring, parallel to the pull, which is exactly the geometry the sketches example already measured at 0.000% for a collar wire from bore edge to bore edge. The app instead offers a channel set, which is only castable on a side face and reads visually as a groove rather than a channel.
+
+**Evidence.** CLAUDE.md, sketches section: "a collar across the whole outer surface (a flat curve wire from bore edge to bore edge, eight round the ring on a beveled band) fields 0.000% — its flanks face round the ring, parallel to the pull"; crates/ringdesign-core/src/pave.rs:285-330 `channel_set` — two `BorderLayer` rails plus a Subtract recess, gated to `VGate::SideFaces`, returning `None` on a dome; `SeatStyle::ALL` at crates/ringdesign-core/src/field.rs:990-991 lists three styles, none of them a bar.
+
+**Do this.** Add `pave::bar_set(design, gem, count, bar_w_mm) -> Option<LayerEntry>` with a fourth `GenRecipe::Bar(BarSpec)` arm (pave.rs:556) and a `kind_label`/`generate` case beside the other three — this is the one classic setting that works on a dome, which is what makes it worth more than the channel it complements. Emit `count` bars as a v-spanning family plus a `SeatRunLayer` of `count` seats at the midpoints, both at the crest, so `u` wrapping guarantees the seam. Unlike channel_set, refuse on the stone-plus-two-bar-halves overrunning the *arc*, not the face, and return the refusal as text (see finding 16). Pin at 0.000% via `analyze_field` the way the collar was pinned, and add the stones to the same test so it cannot repeat finding 6's mistake.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `pave::bar_set(design, gem, count, bar_w_mm) -> Option<LayerEntry>` as a live generator with its own `GenRecipe::Bar(BarSpec)`. It emits a `CurveLayer` (or a v-spanning border family) of `count` bars at integer spacing so it wraps, plus a `SeatRunLayer` of `count` seats at the midpoints between them, both on the crest so the bar's flanks stay parallel to the pull. Cap the bar height at the doctrine's crest-line budget and refuse when the stone plus two bar halves overruns the band. Pin it with `analyze_field` at 0.000% the way the collar was pinned.
+
+</details>
+
+**Castability.** Low and provable rather than tuned: the bar's flanks face along the ring, so each is a vertical wall; the only real work is that the bar must die into the band edges monotonically (the same fairing the collar does) and that bar and stone-mound must not form a valley between them, which is what the field check must confirm.
+
+**Verified.** Searched `bar_set|BarSpec|bar setting|bar-set` over all crates — nothing. `enum GenRecipe` (pave.rs:556-560) has exactly three arms: Pave, Halo, Channel. `SeatStyle::ALL` (field.rs:990-991) has Boss, Bezel, GypsyMound. The castability argument checks out: `channel_set` (pave.rs:285-330) gates itself to `VGate::SideFaces(SideFacePick::Wider)` and returns `None` on a dome (its test at pave.rs:1224 asserts exactly that on a HalfRound), so the app's only channel-family setting is unavailable on the commonest band shape. CLAUDE.md's sketches section records the collar-across-the-outer-surface result at 0.000%, which is the same flank orientation a bar has. Worth noting the bar's own catch, which the finding does not raise: a bar's *ends* run out at the bore edges, so the bar has to be a full v-span feature and its height budget on the crest is the same crest-line budget a bead row gets.
+
+#### F106 Head and shank cannot be different stock — the missing fourth construction — `high` / `L` / signet-heads
+
+**Problem.** Three constructions exist and are well measured (prism, cut dome, `Tent` loft), all of which build the head out of one continuous swept band sharing one `BandProfile`. The construction a jeweller would name fourth is the standard one at the bench: a head *blank soldered to a shank*, where head and shank are separate stock with different sections, different widths, and sometimes different metals, joined at a defined fillet. Today the shank is forced to be the head's section scaled by a fraction, which is why `SIGNET_SHANK_ROUNDING` had to be invented and why the finding above exists.
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:2620-2690 (`ShankStyle::modulation`'s Signet arm — one `band: &BandProfile` threaded through `head_at`, `signet_span`, `tent_for`); 1849-1852 (shank = one fraction of the head); crates/ringdesign-core/src/profile.rs:1339-1341 the head's only section control is `table_flat`. The union machinery already exists and is proven: `smax`/`smin` join two heads' spans tie-exactly (2658-2668), which is structurally the same problem as joining a head to a differently-proportioned shank.
+
+**Do this.** Unchanged, and note it subsumes finding F13: with a real `shank_profile` the `(1.0 - loft_k)` fudge at profile.rs:2652 and the `SIGNET_SHANK_ROUNDING = 9.0` constant both become unnecessary, and templates stop having to choose between a side-face-capable head and a comfortable shank. The blend weight already exists and is already smoothed — `ShankMod::head` is `smootherstep(0.0, 1.0, on_head) * (1.0 - dome_k)` at profile.rs:2688 — so the crossfade has a C2 weight to ride on rather than needing a new one. Sequence: F14 before F13 if both are taken.
+
+<details><summary>The auditor's original recommendation</summary>
+
+`ShankStyle::shank_profile: Option<BandProfile>` plus a `joint_fillet_mm`: build the shank's section from its own profile, the head's from the head's, and cross-fade the two spans through the existing `smax` over the swell's tail where the head's presence (`ShankMod::head`, already a smoothed `on_head`) is already the blend weight. The sweep stays one watertight torus and the terrain argument is untouched — it is still a band that widens and rises toward the top. For a genuinely soldered, two-metal piece, the Free-mode path (`solid.from_design` + `solid.union`) is the right answer and needs a signet-facing cluster.
+
+</details>
+
+**Castability.** Moderate and worth measuring. Two different sections joined by a fillet must not create a re-entrant silhouette where they cross — the same failure the head's outline-against-swell fillet was built to avoid (`HEAD_SHANK_FILLET`, `HEAD_FILLET_ON`). Sweep `analyze_field` over head/shank width ratios from 1:1 to 6:1 and pin the worst, the way `the_swell_matches_a_real_signet` pins the swell.
+
+**Verified.** Verified. `ShankStyle` (profile.rs:1600-1626) is kind/amount/waves/head/extra_heads/keys/custom_outlines — one `BandProfile` is threaded in from the design and shared by head and shank; `modulation`'s Signet arm (profile.rs:2623+) takes a single `band: &BandProfile`. `signet_shank_frac` is one scalar fraction of the head's width. grep for `shank_profile`, `joint_fillet`: nothing. The `smax`/`smin` union machinery the auditor points at is real (profile.rs:2660-2668, unioning multiple heads' `outer_r`/`cap_r` tie-exactly).
+
+#### F107 No pierced gallery or open back under the head — `medium` / `M` / signet-heads
+
+**Problem.** The classic openwork under a heavy head — a pierced gallery, scroll-cut windows through the flank below the table — is not expressible. `SignetHead::hollow_mm` scoops the bore upward into the belly, which lightens the head but leaves it solid; a gallery is a through-hole in the flank, and a height field over a swept band cannot make one because the result is no longer a terrain over (u, v).
+
+**Evidence.** crates/ringdesign-core/src/profile.rs:1349-1355 (`hollow_mm` — "a scoop from the finger hole up into the head's belly"); crates/ringdesign-core/src/field.rs:640-674 (`OpenworkLayer` carves *toward a floor over the bore* — `depth.min(radial / nr)` explicitly keeps `keep_mm` of metal, so it can never pierce); docs/ROADMAP.md:184 files the hollow under "Gallery/hollow underside" as if it discharged the gallery, which it does not. The escape hatch exists: crates/ringdesign-graph/src/nodes/solid.rs has `solid.from_design`, `solid.difference`, `frame.on_ring`, `solid.place`, all Free-mode only, and there is no signet-facing cluster among them.
+
+**Do this.** Unchanged. Add that the roadmap edit is the cheap half and worth doing regardless: retitle F85 to "Hollow underside" and open a separate Shelf line for the gallery, or the next person reads M9 and concludes it is done. For the cluster itself, `vine-semi-mount.cluster.json` is the exact template to copy — including its listing rule (only offered under the kernel feature, so a build without Manifold never shows a cluster it cannot run) and its honest lost-wax verdict via `sink.mesh_verdict`.
+
+<details><summary>The auditor's original recommendation</summary>
+
+A bundled Free-mode cluster — "Signet gallery" — wiring `solid.from_design` on a lofted head, a ring of `solid.cylinder`/`solid.extrude` cutters placed by `frame.on_ring` under the table's rim, `solid.difference`, then `solid.mesh` → `sink.mesh_verdict`. It parallels the existing `vine-semi-mount.cluster.json` exactly, including the honest lost-wax verdict. Separately, retitle the roadmap item so the hollow is not mistaken for the gallery.
+
+</details>
+
+**Castability.** A pierced gallery is lost wax by definition — the windows are through-holes with walls facing every direction. The cluster must report the mesh verdict as what it is and never claim sand, exactly as the vine cluster does.
+
+**Verified.** Verified, including the roadmap point. `OpenworkLayer::height` (field.rs:650-674) computes `radial = (r - ctx.bore_radius_mm - self.keep_mm.max(0.2)).max(0.0)` and `depth = self.depth_mm.clamp(0.0, 6.0).min(radial / nr.clamp(0.05, 1.0))` — the `.max(0.2)` floor on `keep_mm` means it provably cannot pierce, exactly as claimed. `SignetHead::hollow_mm` (profile.rs:1348-1354) is documented as a scoop from the finger hole into the belly. `graphs/clusters/` holds exactly two files: `signet.cluster.json` and `vine-semi-mount.cluster.json` — no gallery cluster. docs/ROADMAP.md M9 does file the ticked item as "Gallery/hollow underside (M–L, F85): SignetHead::hollow_mm", so the mislabelling is real and a reader would think the gallery shipped.
+
+#### F238 Free mode has no loft and no sweep — the one primitive every reference body is built from — `high` / `L` / competitor-parity
+
+**Problem.** The solid kernel offers primitives and booleans and nothing that runs a section along a path. CrossGems' own replication cheat sheet says the sweep is the one algorithm not expressible in stock nodes, and every body in their catalogue — band, shank, bezel, bail, hoop, head, bangle — is a loft or a sweep. Without it Free mode cannot build a shank from a profile, a bezel from a girdle curve, or a setting from sections; it is a boolean toy around one hard-coded vine.
+
+**Evidence.** crates/ringdesign-solid/src/kernel.rs — the public API is cylinder, cone, sphere, cube, marquise lens/prism/rail, round rail, union_all, Frame, segment, tube, Parts, marquise_setting, round_setting, leaf, catmull_rom, vine_ring, to_mesh, from_mesh. The only `extrude` calls are linear extrusions of a 2D cross-section (kernel.rs:53, 60, 66, 225); grep for `loft`/`sweep` in the crate finds nothing else. batch6-8/reports/CrossGems-Clusters.md §4.4 and §5.1 document `SweepOneRail.PerformSweep` with closest-point-sorted section parameters and closed-curve seam reparametrization as their shared sweep engine.
+
+**Do this.** Unchanged, and note what already exists so the estimate is honest: `catmull_rom` (kernel.rs:243) gives the rail, `Frame` (kernel.rs:84-131) gives the per-station orientation with tilt and roll, and `tube` (kernel.rs:144) is the working degenerate sweep — so `kernel::sweep` is mostly parallel-transport framing plus section interpolation on top of pieces that are already there, not a from-scratch surfacer. `kernel::loft` is the genuinely new one. Both Free-mode only, exposed as `solid.loft`/`solid.sweep`. Pair the pitch with finding 12: a sweep with no way to compute a rail or a section is half a feature, so `path.*` and `solid.sweep` land together. Highest craft payoff: a shank swept from a `BandProfile` section, and a bezel swept round a girdle curve — the two bodies a semi-mount builder needs and cannot currently make.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `kernel::loft(sections: &[Vec<V3>], closed: bool)` (matched-point ruled surfacing between consecutive closed sections, capped) and `kernel::sweep(rail: &[V3], sections: &[(f64, Vec<[f64;2]>)])` using parallel-transport frames along the rail, sections sorted by rail parameter and a seam re-parameterization for closed rails — the exact three steps their script does. Expose as `solid.loft` and `solid.sweep`, Free-mode only.
+
+</details>
+
+**Castability.** Free mode is judged by `castability::analyze` on face normals and is lost-wax territory by declaration; the SandRing verdict never reads a solid, so this cannot weaken any sand guarantee.
+
+**Verified.** Verified by dumping every `pub fn` in `crates/ringdesign-solid/src/kernel.rs`: v3, cylinder, cone, sphere, cube, marquise_lens, marquise_prism, marquise_rail, round_rail, union_all, Frame (new/on_ring/place/point/rolled/tilted), segment, tube, Parts, marquise_setting, round_setting, leaf, catmull_rom, vine_ring, to_mesh, from_mesh. No loft, no rail sweep. `tube` (kernel.rs:144) is the degenerate case only — a chain of circular segments along a polyline, fixed radius, no section, no twist, no scale. The graph's `solid.extrude` and `solid.revolve` (nodes/solid.rs:294, 300) are Manifold's own linear extrusion and surface of revolution, which cover prisms and lathe bodies but not a section run along an arbitrary rail. `CrossGems-Clusters.md` §4.4/§5.1 documents `SweepOneRail.PerformSweep` with closest-point-sorted section parameters and closed-curve seam reparametrization as their shared engine.
+
+**Merged into a canonical finding above:** F69 (No sand-native prong head, and no notion of a separately cast part soldered on) -> F54, F92 (Openwork never opens, and there is no path from a mask into the solid kernel) -> F32, F205 (The mesh importer welds on exact float bits, so it rejects most real-world STLs) -> F37, F225 (A pierced band: let the field punch a hole through the band's thickness) -> F32.
+
+### M23 — The shop floor: quote it, order it, catalogue it (XL, 15 findings)
+
+**Done when:** A quote states metal, stones, labour and yield; two orders from one customer never collide; a kiosk order reaches the shop; a catalogue entry is a record, not a Rust literal.
+
+#### F125 No pour weight, no labour, no stone cost — the shop cannot quote from this — `high` / `L` / dfm-verdict *(also found as F210)*
+
+**Problem.** The sheet gives a casting weight per alloy and explicitly disclaims sprue, button and finishing. What a shop weighs out is the *pour* weight — casting plus sprue plus button, typically 1.4–1.8x the casting for a delft-clay ring — and what it quotes is metal plus labour plus stones plus setting. Every input exists in the engine already: surface area for finishing time, `stone_count` and per-size carats for stone cost, `SeatCheck::count` and `style` for setting labour (bead, bezel and prong are different rates), DFM findings for the extra hand-finishing a soft-cast texture needs. The one interchange file the app writes carries none of it.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:118-131 — the weights table plus the disclaimer. crates/ringdesign-gui/src/export.rs:318-348 `export_cost_json` writes exactly `{name, size_us, volume_mm3, surface_mm2, metals[]}` — no stones, no carats, no seat counts, no findings. `prices.json` reaches only the GUI's metal step and review (per CLAUDE.md); it is not in core.
+
+**Do this.** Sharpened: this is not "add pricing", it is "lift the pricing that already exists in two frontends into core and complete it". `compose::load_prices` in the configurator and `app.prices` in the GUI are two independent readers of the same `prices.json`; a core `quote.rs` with a `Rates` struct (per-alloy £/g, sprue factor, £/hr, minutes per cm² of finishing, £ per stone by `SeatStyle` and size, loss %) and a `Quote` built from `Report` + `FieldReport` + `StonesReport` + `[DfmFinding]` unifies them and gives the CLI and MCP the same figure. Put `sprue_factor` on `DraftSettings` so the pour weight prints beside the casting weight on the sheet, replacing spec.rs:131's disclaimer with a number. Build it after finding 11's gate advisor, since the gate is where the sprue weight comes from.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `quote.rs` to core: a `Quote` struct built from `Report`, `FieldReport`, `StonesReport` and a small `Rates` struct (metal £/g per alloy, sprue factor, £/hr, minutes per cm² of finishing, £ per stone by style and size, loss %). Emit it as the cost JSON's payload, as a costed section on the casting sheet, and as a customer-facing approval sheet. Put the sprue factor on `DraftSettings` so the pour weight is a first-class number the sheet prints beside the casting weight.
+
+</details>
+
+**Castability.** None.
+
+**See also.** F18 and F2 are the pour-weight half of this, in M19.
+
+**Verified.** Half of the metal side exists and the auditor understated it. Per-gram prices are read from `prices.json` beside the designs folder by `compose::load_prices` (configurator/src/compose.rs:118-122) and shown on the metal step and review (configurator/src/main.rs:603, :783), and the GUI report panel prices its metal table the same way (`metals_priced(ui, report, &app.prices)`, report.rs:67). The sprue rule of thumb exists as prose in the MCP prompt (mcp/src/prompts.rs:238, "budget roughly 1.5 to 2 x the part weight"). Everything else is confirmed missing: `grep -rln "Rates|labour|labor"` finds no such type in any crate; there is no `quote.rs` in core; `export_cost_json` (gui/src/export.rs:318-348) writes exactly `{name, size_us, volume_mm3, surface_mm2, metals[]}` — no stones, no carats, no seat counts, no findings, no pour weight; and spec.rs:131 disclaims the loss rather than quantifying it. So: metal pricing exists in two frontends and nothing else does, with no core type either frontend could share.
+
+#### F131 The shop gets a casting sheet and a stone map, but no work order and no QC card — `medium` / `M` / dfm-verdict
+
+**Problem.** The two documents that exist both address the front of the job: what to pour, and where the stones go. Nothing addresses the back of it. There is no bench work order (the ordered steps, with the parting-line location so the finisher knows where the flash runs and the modulus hot spot so they know where the sprue was), and no QC card (finished bore against nominal after reaming, finished band width, thinnest wall as-finished, stone count and carats to verify against the setter's return, weight tolerance). The parting line is exported as a standalone SVG that never appears on the casting sheet, so the caster and the finisher hold two unlinked pieces of paper.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:29-215 `html` — sections are Cast check, Dimensions, Casting weight, Stones, Spacing, Build. No parting-line drawing, no ream allowance, no finished-dimension column, no process steps. `write_parting_svg` (castability.rs:697-760) and `stonemap::stone_map_svg` are separate exports with separate menu items; grep for `spec::html` shows five callers and none of them composes the SVGs into the page.
+
+**Do this.** Unchanged, with the refactor named: `write_parting_svg` currently builds its SVG string and immediately `std::fs::write`s it — split it into `parting_svg(...) -> String` plus a thin writer (the same split `threemf::zip_store`/`library::design_json` already use for the web build), then `spec::html` can inline it with no new dependency and no external reference. Do the same for `stonemap::stone_map_svg` if it is not already string-returning. The work order needs finding 11's `gate_theta_deg` to say where to cut the sprue, so sequence it after the gate advisor; the QC card needs only figures the `Report` already has plus a ream allowance constant.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Inline the parting-line SVG and the stone map into the casting sheet (both are already strings and the sheet is already self-contained, so this costs nothing and closes the no-external-references test's own intent). Then add two sections: a work order — cut sprue at {gate_theta}°, file the parting flash at z = {parting_z}, {dfm findings that need hand chasing}, ream bore to {nominal + ream allowance}, set {n} stones by style, polish — and a QC card with an as-designed / as-finished / tolerance column for bore, width, thinnest wall, weight and stone count.
+
+</details>
+
+**Castability.** None.
+
+**Verified.** Read spec.rs:29-215 in full. The sections are exactly: Cast check, Dimensions, Casting weight, Stones, Spacing (conditional), Build/Provenance. No parting-line drawing, no gate mark, no ream allowance, no as-finished column, no process steps. `write_parting_svg` (castability.rs:697-760) writes to a path and returns a byte count, and `stonemap` is a separate export with its own menu item — neither is composed into `spec::html`, which builds its string from scratch and whose own test asserts `!page.contains("http")` and `!page.contains("src=")`, i.e. the page is already committed to being self-contained. Inlining both SVGs as literal markup satisfies that test rather than fighting it, which makes this the cheapest structural improvement on the list.
+
+#### F179 The web configurator shows every ring in gold, with no stones, and the order never reaches the shop — `critical` / `M` / ux-workflow
+
+**Problem.** Three things a customer-facing kiosk cannot have. (1) The preview is always `render::GOLD` regardless of the metal step, so someone choosing Silver 925 or Platinum sees yellow gold. (2) The preview and the order's hero/GIF/GLB render `out.mesh` only, so a 5 mm oval solitaire or an eternity row shows as bare seat stock — the customer never sees the stone they are buying. (3) On the web the finished order is handed to the *customer's* Downloads as a zip; there is no upload, email or webhook, so the shop receives nothing.
+
+**Evidence.** crates/ringdesign-configurator/src/main.rs:135 `render::render_ss(m, job.yaw, job.pitch, edge, edge, ss, render::GOLD)`; :311-313 `to_glb(..., render::GOLD)`, `png_bytes(&out.mesh, ..., render::GOLD)`, `turntable_gif_bytes(&out.mesh, ..., render::GOLD)`; :338 `deliver_order` on wasm calls `web::download` and returns "your downloads"; `gems::preview_mesh` and `render::render_parts_ss` are both in core and unused here.
+
+**Do this.** Unchanged, with the tint move made concrete: add `pub tint: [f32; 3]` to `metal::Metal` (metal.rs:5-14) and fill the ten `METALS` rows from `viewport::FINISHES` (viewport.rs:531+), then delete FINISHES and index the viewport by the design's metal — that collapses two user-facing pickers into one and fixes the configurator at the same time. Add the stone map to `order_files` (main.rs:307-314) via `stonemap`, and render every one of the five GOLD sites through `render_parts_ss` with `gems::preview_mesh`. The upload endpoint is the one genuinely new piece.
+
+<details><summary>The auditor's original recommendation</summary>
+
+(1) Move the finish tint table out of `crates/ringdesign-gui/src/viewport.rs` into `metal.rs` as a field on `Metal`, and pass `METALS[cfg.metal].tint` everywhere GOLD is hardcoded — this also fixes the desktop, where FINISHES (7 display colours) and METALS (10 alloys) are two unrelated lists the user picks from separately. (2) Render through `render_parts_ss` with `gems::preview_mesh`. (3) Add an optional `ORDER_POST_URL` that POSTs the zip (`fetch` on wasm, `ureq` natively), falling back to the download when unset, and put the stone map (`stonemap`) in the order folder — it is a stone-setting order and the setter's sheet is missing.
+
+</details>
+
+**Castability.** n/a — the composed design and its field verdict are unaffected.
+
+**Verified.** All three limbs confirmed. `render::GOLD` is hardcoded at configurator/src/main.rs:136 (the preview job), :215 (the at-rest supersampled frame), :311 (`to_glb`), :312 (`png_bytes`) and :313 (`turntable_gif_bytes`) — the metal step's choice never reaches any of them. All five render `&out.mesh` alone; `gems::preview_mesh` and `render_parts_ss` are unused in that crate. `deliver_order` on wasm (main.rs:338-346) calls `web::download` with a `zip_store` and returns "your downloads" — no upload path exists. The two-table problem is real and worse than stated: `metal::Metal` (metal.rs:5-14) carries only `name`, `density`, `shrink_pct` — no tint — and `viewport::FINISHES` (viewport.rs:531+) is a separate 7-entry display table in the GUI crate, indexed by `app.finish` independently of the design's metal. Also confirmed: `order_files` (main.rs:290-315) writes six files and the stone map is not one of them.
+
+#### F180 The configurator cannot change band width, and does not lay out for a phone — `high` / `M` / ux-workflow
+
+**Problem.** `Config` carries base, size, metal, stone, pattern, milgrain, engraving, font and customer name. It carries no width and no thickness — the two dimensions every ring buyer actually asks about ("do you have it in 4 mm?"). The bases hardcode their own proportions in `compose`. Separately, the layout is a fixed 360 px left panel plus a square preview in the centre, with no narrow-screen branch, so on a phone browser — the most likely way a customer meets it — the panel is the whole screen and the ring is off it.
+
+**Evidence.** crates/ringdesign-configurator/src/compose.rs:140-155 (`Config` fields) and :196+ (`compose` sets width/thickness per base); crates/ringdesign-configurator/src/main.rs:861 `.default_size(360.0)`; grep for `screen_rect|is_mobile|narrow` in that crate returns nothing; index.html sets the viewport meta but the egui layout ignores width.
+
+**Do this.** Unchanged. One craft note that strengthens it: `reconcile()` is what strips a pattern a base cannot carry, and it must re-run after a width change for the reason CLAUDE.md's own side-face doctrine gives — usable face is `thickness - crown`, so narrowing a band past its side face turns an approved pattern into crest relief. Wire `width_mm`/`thickness_mm` into `compose` *before* `reconcile` so the strip happens on the new dimensions, not the base's.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `width_mm` and `thickness_mm` to `Config` with per-base ranges (`Base::width_range`), applied in `compose` after the base's own setup, and re-run `reconcile` — narrowing a Wide band past the point where its side face carries the chosen pattern should drop the pattern the way switching base already does. For layout, branch on `ctx.screen_rect().width() < 700.0`: preview on top, choices below in a single scroll, step chips as a compact row. Also encode `Config` into the URL fragment (it is already serde) so a customer can share or resume a configuration — today closing the tab loses everything.
+
+</details>
+
+**Castability.** Changing width moves the side faces, so `reconcile` must re-check `has_sides` against the actual profile rather than the base enum — otherwise a narrowed band keeps a pattern its crest cannot hold. The field test that runs every base through both dresses should be extended over the width range.
+
+**Verified.** Confirmed. `Config` (configurator/src/compose.rs:140-156) carries `base`, `size`, `metal`, `stone`, `pattern`, `milgrain`, `engraving`, `script_font`, `customer` — no width, no thickness; `Default` at :158-170 matches. Grepping the whole crate for `screen_rect|is_mobile|narrow` returns nothing, and the only layout constant is `.default_size(360.0)` at main.rs:861. No URL-fragment state either: `web.rs` has no `location`/`hash`/`fragment` reference.
+
+#### F198 No product document a webshop or ERP could consume — `high` / `M` / interop
+
+**Problem.** The cost JSON is name, size, volume, surface area, and ten alloy weights. It has no price (even though `prices.json` is read and displayed in two places), no stones, no verdict, no images, no SKU, no variants. There is no other business-facing output. A shop that wants to list a design on a webshop, or push it into an ERP, has to re-derive everything by hand from the HTML sheet.
+
+**Evidence.** crates/ringdesign-gui/src/export.rs:316-346 — the whole cost document: `{name, size_us, volume_mm3, surface_mm2, metals:[{metal,grams,dwt}]}`. `prices.json` is loaded twice, independently, and lives in neither crate's core: crates/ringdesign-gui/src/app.rs:111-114 `load_prices()` and crates/ringdesign-configurator/src/compose.rs:118-121 `load_prices()`. crates/ringdesign-configurator/src/main.rs:291-315 `order_files` — six files, none of which carries a price or a SKU. `Gem` has no cost (gem.rs:223).
+
+**Do this.** Move the price table into core first as `metal::Prices::load()` — one type, one parse, read by the GUI, the configurator and anything new — since two independent loaders of the same file is already the bug waiting to happen. Then add core::product.rs emitting one document per (size x metal) variant: a deterministic SKU slug from design + size + metal, display name, dimensions, weight, metal cost, the stone BOM and stone cost from finding 8, the field verdict with its notes, the DFM findings, and references to hero PNG / GLB / sheet as sibling filenames. Emit it from CLI --formats product (alongside finding 10's sheet/parting), the GUI File menu, and a sink.product node, and add it to the configurator's order_files so an order folder is machine-readable end to end. It depends on findings 7 and 8 landing first — without design.metal and Gem::material the document has to guess the two things a shop most needs it to state.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Move the price table into core (`metal::Prices::load()`), then add `core::product.rs` emitting one document per size x metal variant: SKU (a deterministic slug of design + size + metal), display name, dimensions, weight, metal cost, stone BOM and stone cost (once `Gem::material` lands), the field verdict and its notes, DFM findings, and references to hero PNG / GLB / sheet — either as sibling filenames or data URIs. Emit it from CLI `--formats product`, the GUI File menu, and a `sink.product` node, and have the configurator's `order_files` include it so an order folder is machine-readable, not just human-readable.
+
+</details>
+
+**Castability.** n/a, except that the document must carry the verdict verbatim so an uncastable ring cannot be listed as sellable — the same rule `sink.export` already enforces on files.
+
+**Verified.** Confirmed. crates/ringdesign-gui/src/export.rs:329-345 is the whole cost document: name, size_us, volume_mm3, surface_mm2 and the ten-alloy metals array from report.metals — no price, no stones, no verdict, no SKU. prices.json is loaded twice and independently, in crates/ringdesign-gui/src/app.rs:113 and crates/ringdesign-configurator/src/compose.rs:121, both as `default_design_dir().with_file_name("prices.json")` into a bare HashMap<String, f64> — the same file parsed by two crates with no shared type, which is the divergence CLAUDE.md warns about elsewhere. The configurator's order (main.rs:291-315) is six files: design.ring.json, choices.json, casting_sheet.html, ring.glb, hero.png, turntable.gif — choices.json is machine-readable but it is the customer's picks, not a product record, and nothing in the folder carries a price or a part number.
+
+#### F199 The configurator cannot open a design and a configured ring is not a link — `high` / `M` / interop
+
+**Problem.** `compose::Base` is eight hardcoded arms built in code. There is no way to publish a design from the library into the kiosk, so the shop's own catalogue and the customer-facing picker are two disconnected worlds. And there is no URL state — grep for `location`/`search`/`hash` in the crate finds nothing — so on the web build a customer cannot bookmark or send back the ring they configured; the only output is a zip download. A customer's choice reaches the shop only if they carry the file.
+
+**Evidence.** crates/ringdesign-configurator/src/compose.rs:22-42 — `enum Base { Court, WideBand, Cathedral, Wave, Twist, Split, SignetOval, SignetHeart }` and `Base::ALL`. compose.rs:140-156 — `Config` is a small serde struct, exactly the thing a URL fragment wants. crates/ringdesign-configurator/src/web.rs — the whole web delivery path is one Blob download link. crates/ringdesign-configurator/src/main.rs:327-342 — `deliver_order` writes a folder natively or downloads a zip on wasm; no upload, no endpoint.
+
+**Do this.** Add `Base::Design(String)` resolving through a new library::list_designs() natively and through a bundled catalogue on wasm (an include_str! map, the way ringdesign-graph bundles graphs/templates/*.graph.json), with reconcile() still stripping what the base cannot carry — the curation rule is the crate's whole argument and must apply to a published design exactly as it does to Court. Serialize Config to the URL fragment on every change and parse it at startup, so a configured ring IS a link the customer can bookmark or send back; Config is already Serialize + Deserialize, so this is base64-of-JSON in a fragment plus a startup read. On wasm, POST the order bytes to a configurable endpoint — finding 9's /v1 tier is the natural target — with the existing zip download as the fallback when no endpoint is set.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `Base::Design(String)` resolving through `library::list_designs()` natively and through a bundled catalogue (an `include_str!` map, the way the graph templates are bundled) on wasm, with `reconcile()` still stripping what a base cannot carry — that is the curation rule and it should apply to a published design too. Serialize `Config` to the URL fragment on every change and parse it at startup, so a configured ring *is* a link. On wasm, POST the order bytes to a configurable endpoint (the `/evaluate` service above) with the zip download as the fallback.
+
+</details>
+
+**Castability.** A published design must still pass `reconcile()` and the per-base field check the configurator's test already runs over both dresses — otherwise a customer configures a ring the shop cannot pour.
+
+**Verified.** Both halves confirmed. crates/ringdesign-configurator/src/compose.rs:20-44: `enum Base { Court, WideBand, Cathedral, Wave, Twist, Split, SignetOval, SignetHeart }` with a hardcoded Base::ALL, and no path from library::list_designs (which does not exist — see finding 3) or from a design file. `grep -rn "location|hash|search|history" --include=*.rs crates/ringdesign-configurator/src/` returns nothing, so there is no URL state of any kind. crates/ringdesign-configurator/src/web.rs is 24 lines and does exactly one thing: hand bytes to a Blob download anchor. deliver_order (main.rs:326-343) writes a folder natively or downloads order-<slug>.zip on wasm — no upload, no endpoint. Config (compose.rs:139-156) is a ten-field serde struct, which is indeed exactly the shape a URL fragment wants.
+
+#### F206 An order overwrites the last one from the same customer — `critical` / `M` / product-business
+
+**Problem.** `deliver_order` writes to `orders/<slug>` where the slug is only the customer's name lowercased, with fixed filenames inside. A repeat customer, or two customers sharing a name, destroys the earlier order's design file, sheet and renders with no warning. There is no order number, no timestamp, no index, and nothing that lets the shop answer "what did we sell in March".
+
+**Evidence.** /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/crates/ringdesign-configurator/src/main.rs — `order_slug` (customer name -> [a-z0-9_]), `deliver_order` (`default_design_dir().with_file_name("orders").join(slug)`, `create_dir_all` then `fs::write` of six constant names), `order_files` returns `Vec<(&'static str, Vec<u8>)>` with literal names. The test `an_order_is_six_files_and_a_slug` pins exactly that behaviour. No `order` type, index or listing exists anywhere in the workspace (grep for `order` across crates returns only the configurator and unrelated list-ordering).
+
+**Do this.** Unchanged in substance, with two sharpenings. (1) Put `Order` in core, not the configurator: the GUI already writes into the same `default_design_dir()` tree and MCP/CLI would want to read it, and core is the only crate all frontends share (the configurator deliberately depends on core alone — see its Cargo.toml). (2) `order_files` returns `&'static str` names; widen it to `String` so the writer can carry the order id into the filenames as well as the folder, and make `deliver_order` refuse a non-empty existing directory rather than `create_dir_all` + overwrite. Keep the existing test `an_order_is_six_files_and_a_slug` (main.rs:898) and extend it to assert the refusal.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add an `order` module to the configurator (or better, to core so the GUI and MCP can read it too): an `Order { id, placed_at, config: compose::Config, customer: Customer, state: OrderState }` where `id` is a monotonic, human-quotable number (`KOA-2026-0417`) and `OrderState` is `Quoted | Approved | PatternPrinted | Cast | Cleaned | Set | Finished | Shipped | Cancelled` with a timestamped transition log. Write to `orders/<id>-<slug>/` and maintain `orders/index.json` (append-only) plus an `orders/index.html` contact sheet built the way `examples/gallery.rs:295` already builds one. Refuse to write into an existing order directory.
+
+</details>
+
+**Castability.** n/a — pure record-keeping, no geometry touched.
+
+**Verified.** Verified exactly as described. main.rs:318 `order_slug` maps the customer name to [a-z0-9_] and nothing else; main.rs:327 `deliver_order` does `default_design_dir().with_file_name("orders").join(slug)`, `create_dir_all`, then `fs::write` of six literal names from `order_files` (main.rs:291, `Vec<(&'static str, Vec<u8>)>` — design.ring.json, choices.json, casting_sheet.html, ring.glb, hero.png, turntable.gif). Two saves for "Ada" land in the same directory and clobber. Greps for `struct Order`, `OrderState`, `order_id`, `orders/index`, `enum Order` across crates/ and docs/ return only `struct OrderParams` (main.rs:273, which is build resolution, not an order record). Nothing in docs/ROADMAP.md mentions orders — the only "Order:" hit is a milestone sequence. The kiosk also nulls `saved_to` on every rebuild (main.rs:424), so even the path is not retained.
+
+#### F207 The web configurator never delivers the order to the jeweller — `critical` / `M` / product-business
+
+**Problem.** On wasm the terminal action of the five-step flow hands the customer a zip of their own order and stops. Nothing is submitted, no email or phone is collected (only a free-text `customer` name), no price is shown at all (prices.json is absent on the web by design), and there is no delivery estimate or terms. The customer-facing funnel has no conversion event.
+
+**Evidence.** crates/ringdesign-configurator/src/main.rs — `#[cfg(target_arch = "wasm32")] fn deliver_order` calls `web::download(...)` and returns "your downloads, as order-<slug>.zip"; `src/web.rs` is a Blob + anchor click. `Config` (compose.rs:139) carries only `customer: String` — no email, no address, no consent. `step_review` shows metal price only when `self.prices` is non-empty, and CLAUDE.md records that `prices.json` is simply absent on the web.
+
+**Do this.** Unchanged, with the price fix restated precisely: `compose::load_prices` is a `std::fs` read and is dead code on wasm, so either `include_str!` a bundled prices.json behind `#[cfg(target_arch = "wasm32")]` or fetch it once at startup. For the submit seam, note the crate already has `wasm-bindgen-futures` and `web-sys` in its wasm deps, so a `fetch`-based `OrderSink` needs no new dependency — add `"Request"`/`"Response"`/`"Headers"` to the existing web-sys feature list. Add `Contact { email, phone, note, consent }` to `Config` behind `#[serde(default)]` so existing choices.json files still parse.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Give `compose::Config` a sibling `Contact { email, phone, note, consent }` and add a `submit` seam: a `trait OrderSink { fn place(&self, order: &Order) -> Result<Receipt> }` with a native filesystem impl (today's behaviour) and a wasm impl that POSTs the order JSON plus the hero PNG to a configured endpoint. Ship the price on the web by baking a `prices.json` into the wasm bundle at build time (or fetching it once), so the review step always shows a number. Keep the zip as the customer's own copy, not as the delivery mechanism.
+
+</details>
+
+**Verified.** Confirmed. main.rs:338 (wasm) `deliver_order` calls `web::download(&format!("order-{slug}.zip"), ...)` over `threemf::zip_store` and returns "your downloads, as …" — no network call anywhere; web.rs is 25 lines of Blob + anchor. `Config` (compose.rs:139-166) carries base/size/metal/stone/pattern/milgrain/engraving/script_font/customer — no email, phone, address or consent. One correction to the finding's wording: price is NOT universally absent — `step_size_metal` (main.rs:596-608) shows "about $N in metal" per alloy and the review step repeats it, but only when `load_prices()` (compose.rs:121, `std::fs::read_to_string`) found a file, which on wasm it never can. So the accurate claim is "no price on the web", not "no price at all".
+
+#### F208 An order file records unstable ordinals, so an old order decodes to a different ring — `high` / `S` / product-business
+
+**Problem.** `Config` serialises `metal: usize` (an index into `metal::METALS`) and `pattern: Option<usize>` (an index into `compose::PATTERNS`). Both are positions in `const` slices. Inserting Gold 9k into METALS, or reordering PATTERNS, silently changes what every previously saved `choices.json` means — the order for a platinum ring becomes a palladium one. There is no version key on `choices.json` and no test pinning the slice order.
+
+**Evidence.** crates/ringdesign-configurator/src/compose.rs:139-172 (`pub metal: usize`, `pub pattern: Option<usize>`), read back at main.rs:597 `metal::METALS.get(self.cfg.metal)` and compose.rs:294 `PATTERNS.get(p)`. `metal::METALS` is a bare `&[Metal]` (crates/ringdesign-core/src/metal.rs:16). Contrast `library.rs`, which does this right for designs: `FORMAT_VERSION`, a `MIGRATIONS` ladder, and a test that every version has a step.
+
+**Do this.** Unchanged. One extra: the pattern entry carries a repeat count as well as a name, so serialise `pattern: Option<String>` keyed on the alpha name and look the count up from `PATTERNS` — that way retuning a repeat count for castability improves old orders instead of silently changing their geometry (or, if reproducibility is wanted over improvement, store the pair). Also give `metal` and `pattern` `#[serde(default)]`-friendly fallbacks so an unresolvable name fails loudly at load rather than silently defaulting to index 0 (Silver 925).
+
+<details><summary>The auditor's original recommendation</summary>
+
+Serialise names, not positions: `metal: String` resolved through the existing `metal::find` (which already handles aliases), and `pattern: Option<String>` keyed on the alpha name in `PATTERNS`. Stamp `choices.json` with its own `format_version` and give it the same migration ladder shape as `library.rs`. Add a test that a stored order round-trips to an identical `RingDesign` after a deliberate insertion into the middle of `METALS`.
+
+</details>
+
+**Verified.** Confirmed and worse than stated in one respect. compose.rs:145 `pub metal: usize` ("Index into metal::METALS") and compose.rs:151 `pub pattern: Option<usize>` ("Index into PATTERNS"), read back at main.rs:597 `metal::METALS.iter().enumerate()` by position and compose.rs via `PATTERNS.get(p)`. `METALS` (metal.rs:16) is a bare `&[Metal]` with no stable ids; `PATTERNS` (compose.rs:131) is `&[(&str, u32)]` where the u32 repeat count is also positional data. `Base`, `Stone` and `GemCut` serialize by name, so metal and pattern are the only two ordinals — the finding is exactly right about scope. There is no `format_version` on Config; the only round-trip test is `the_config_round_trips_as_json` (compose.rs:474), which round-trips within one build and therefore cannot catch a reorder. `metal::find` (metal.rs:31) already resolves "sterling"/"14k"/prefix, so the name-keyed read is a one-line change.
+
+#### F212 There is no catalogue — five hand-written collections and none of them is a product — `critical` / `L` / product-business
+
+**Problem.** The shop's designs live in five unrelated places, all as Rust code: `templates::TEMPLATES` (9, File menu), `compose::Base` (8, kiosk), and the `showcase`/`collection3`/`commissions`/`gallery` examples. Nothing has a SKU, a price, a description, a photo set, or a variant axis (size × metal × stone × pattern). Adding a product requires a developer and a release. Meanwhile the exact data-driven mechanism this needs already exists and is unused for it: `graphs/presets/*.preset.json` and `graphs/clusters/*.cluster.json`, with a file layer that already prefers user-dir files over bundled ones.
+
+**Evidence.** crates/ringdesign-core/src/templates.rs:66 `static TEMPLATES: [Template; 9]` with `build: fn() -> RingDesign`. crates/ringdesign-configurator/src/compose.rs:22-92 (`enum Base`, `const ALL`, `match cfg.base` in `compose`). /home/shadowbroker/Documents/Rust/JewelryProjects/RingDesigner/graphs/presets/{cushion-signet,heart-signet}.preset.json and graphs/clusters/signet.cluster.json exist; crates/ringdesign-graph/Cargo.toml shows the crate is pure-Rust, core-only, default features contain no C++ (kernel-manifold is opt-in) — so it is wasm-safe and the configurator could depend on it without breaking `trunk`.
+
+**Do this.** Unchanged in shape, with one caution the code adds: making the configurator read graph presets means giving it a dependency on `ringdesign-graph` plus `ringdesign-script` (expression pins), and the crate's whole current virtue is that it depends on core only and therefore builds under trunk with no surgery. Either verify both crates pass `cargo check --no-default-features --target wasm32-unknown-unknown` first, or make v1 of the catalogue a plain `Product` JSON that names a *template* by name plus overrides, and only move to graph-backed products once the wasm check is green. Keep `has_sides`/`takes_stones`/`crest_is_stationary` as declared per-product booleans regardless — they are the curation rule `every_offered_combination_is_castable` (compose.rs:379) tests, and a data-driven catalogue must carry them or that test loses its subject.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Define `Product { sku, name, description, hero, base_graph: PathBuf, variants: VariantAxes { sizes, metals, stones, patterns }, price_rule }` as a JSON file per product in a `catalogue/` directory beside `designs/`, with each product's geometry being a graph preset over a bundled cluster. Make the configurator read `catalogue/` instead of `Base::ALL` (keeping the current eight as the shipped seed files), and make `templates::all()` a thin wrapper over the same directory. The reconcile rules (`has_sides`, `takes_stones`, `crest_is_stationary`) become per-product declared capabilities rather than a `match`.
+
+</details>
+
+**Castability.** n/a — each catalogue entry still evaluates through the same field verdict; the product test becomes "every catalogue entry × every variant is not NotCastable", which is `every_offered_combination_is_castable` generalised.
+
+**Verified.** Confirmed. `static TEMPLATES: [Template; 9]` (templates.rs:66) with `build: fn() -> RingDesign`; `Base::ALL` is 8 hard-coded arms (compose.rs:33) with `label`/`blurb`/`has_sides`/`takes_stones`/`crest_is_stationary` all `match self`, and `compose` branches on the enum. Greps for `catalogue`, `catalog`, `sku`, `SKU`, `Product` across crates/, docs/ and graphs/ return only two prose mentions of "catalog three-quarter view" in examples. The data-driven mechanism does exist and is unused for this: graphs/presets/{cushion-signet,heart-signet}.preset.json, graphs/clusters/{signet,vine-semi-mount}.cluster.json, graphs/templates/*.graph.json (9 files mirroring the code templates). The wasm-safety claim also checks out — the configurator's Cargo.toml depends on `ringdesign-core` alone with `default-features = false`, so adding `ringdesign-graph` is a real (but new) dependency edge, not a free one.
+
+#### F216 The customer is never told their pattern will cast soft — `medium` / `S` / product-business
+
+**Problem.** `order_files` computes `dfm::findings_in` and writes it into the sheet, but the kiosk's review step shows only the three-state verdict. CLAUDE.md records that the measured DFM run on the shipped templates names Chevron at 0.07 mm gaps and Braid at 0.04 mm — both offered in the kiosk's `PATTERNS` list — as castable-but-softer-than-drawn. The customer approves an image showing crisp relief and receives something visibly softer, with no expectation set.
+
+**Evidence.** crates/ringdesign-configurator/src/main.rs:812-825 `step_review` renders only `f.verdict`; `order_files:298` computes `dfm::findings_in(&d, &lib)` and passes it only to `spec::html`. `compose::PATTERNS` (compose.rs:131) offers Waves, Braid, Chevron, Rope, Florentine. crates/ringdesign-core/src/dfm.rs is the granulometry check CLAUDE.md documents as naming exactly these.
+
+**Do this.** Unchanged. Implementation detail: `findings_in` is the granulometry path and is the expensive one (it reads each tiling's mask at the layer's mm-per-texel), so compute it in `Worker::run` on the design-changed branch only — the branch that already runs `mesh::build` and `analyze_field` — and not on the camera-only rerender path (`job.design` is `None` there). Carry `Vec<DfmFinding>` on `Frame` beside `field`, which is already cloned per frame.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Compute `dfm::findings_in` in `Worker::run` alongside the field report, carry it on `Frame`, and render it on the Detail and Review steps in customer language — "Chevron on this band casts with 0.07 mm grooves; expect a softer, hand-worn line rather than a crisp edge" — driven off `DfmFinding.message`. Also use it as a nudge: when a pattern measures under the detail floor on the chosen band, suggest the next-coarser repeat count rather than only warning.
+
+</details>
+
+**Castability.** n/a — DFM is the fill/detail axis, not the pull axis; the verdict is unchanged.
+
+**Verified.** Confirmed. `dfm::findings_in(&d, &lib)` is called once in the configurator, at main.rs:298 inside `order_files`, and passed straight into `spec::html` — the sheet the customer never opens. `Worker::run` (main.rs:124-143) computes mesh, grams and `analyze_field` only; `Frame` (main.rs:88-93) carries generation/image/field/grams/volume, no DFM. `step_review` (main.rs:812-825) renders only the three-arm `Verdict` match. `compose::PATTERNS` (compose.rs:131) is Waves/Braid/Chevron/Rope/Florentine, which includes the two CLAUDE.md's measured DFM run names as casting soft (Chevron 0.07 mm gaps, Braid 0.04 mm). So the customer approves a crisp render of a pattern the app has already measured as marginal, and is told nothing.
+
+#### F218 No production planning: nothing knows what pours together — `high` / `L` / product-business
+
+**Problem.** The CLI's size run is the closest thing to a work order — it builds a size ladder and writes a manifest — but it is one design at a time. Nothing groups the day's work by alloy and pour temperature, nothing packs a flask (the mesh bounding box and the parting-line height are both computed and both discarded), nothing produces a bench sheet for the day, and `modulus_scan` — the Chvorinov freeze-order scan that tells you where to gate and feed — is computed for a GUI banner and consumed nowhere else.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:172-236 — one `base` design, `--sizes`, a per-size manifest CSV. `Report.bounds_mm` (mesh.rs:268) and `castability::parting_line` (castability.rs:666) exist and are unused for layout. `castability::modulus_scan` (castability.rs:631) returns `Vec<(theta, modulus)>`; CLAUDE.md says the GUI "names where the ring freezes last" and nothing more. docs/ROADMAP.md:195 shelves the "gate & sprue advisor" as a nicety.
+
+**Do this.** Unchanged; note that the gate advisor is already on the M9 Niceties shelf, so this is a promotion argument, and the argument is that it has a consumer once orders exist. Two grounding details: `modulus_scan(design, lib, bins)` returns `Vec<(theta, modulus)>` and the GUI already picks the hot spot out of a 64-bin scan at app.rs:990, so `foundry::gating` can reuse that read verbatim; and the sprue allowance the gate plan produces is precisely the `sprue_ratio` input finding 5's cost model needs, which is the argument for doing them in that order.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Promote the shelved gate advisor and give it a job: `foundry::gating(design, lib) -> GatePlan` reading `modulus_scan` for the last-freezing slice, `parting_line` for where the sprue can meet the pattern on the parting plane, and `Report.volume_mm3` for the riser/button volume — returning a recommended gate angle, sprue diameter and pour weight, printed on the sheet and fed to the cost model as the sprue allowance. Then add `ringdesign flask <order-ids...>` that groups orders by alloy, packs their bounding boxes into a named flask footprint, prints a one-page work order (pattern list, pour weight per flask, gate plan per piece) and writes the size-run files.
+
+</details>
+
+**Castability.** Directly castability-relevant, but additive: the gate plan reads the same field/section machinery the verdict does and changes no geometry. A gate on the parting plane is required precisely because the mould parts there — the same guarantee, applied to the feed system.
+
+**Verified.** Confirmed. The CLI's size run (cli/main.rs:160-233) takes one `base` design, loops `sizes`, and writes a per-size manifest CSV whose columns are size,file,format,bytes,triangles,watertight,verdict,undercut_pct,thinnest_wall_mm,volume_mm3 — nothing about alloy grouping, flask footprint or gating. `castability::modulus_scan` has exactly two consumers: app.rs:990 (the GUI's settled-pass banner) and the Python binding (py/lib.rs:352) — nothing acts on it. `parting_line` has one consumer, export.rs:243 (the SVG). Greps for gate/sprue/riser/flask/foundry across core and the CLI find only prose: spec.rs:131's "no sprue, button, or finishing loss" disclaimer, castability.rs:628's comment that porosity collects "unless a gate or riser feeds it", and cli/main.rs:256's "past any flask" error message. docs/ROADMAP.md:195 shelves "gate & sprue advisor" under Niceties.
+
+#### F219 No pattern inventory: nothing records which physical pattern exists — `medium` / `M` / product-business
+
+**Problem.** A sand shop's real capital is its stock of rigid patterns. The CLI does the hard part correctly — it scales for shrink and renames the file so an oversize pattern can never be mistaken for nominal — but nothing then records that a pattern for design X, size 7, sterling shrink was actually printed, where it is, how many pulls it has taken, or whether it is still good. Every order re-prints from scratch.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs:180-208 — `mesh.scaled(k)`, the STL solid name becomes `"{name} [pattern +1.9% for Silver 925]"`, and the filename gains `_pattern-silver_925`. The manifest CSV records size/file/format/bytes/triangles/watertight/verdict/undercut/wall/volume — nothing about the physical object. No pattern, inventory or stock concept exists in the workspace.
+
+**Do this.** Unchanged. One dependency worth stating: the `design_digest` this needs is the same hash finding 17 wants for the sheet, and `library::design_json` is the deterministic canonical form to hash (it is already version-stamped and embeds referenced alphas, so the digest covers the assets too). Do the digest once and let the sheet, the order record and the pattern index all quote it — three separate hashes would be worse than none.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Extend the manifest into a persistent `patterns/index.json`: one row per physical pattern with `{ design_id, design_digest, size, shrink_metal, scale, printed_at, material, location, pulls, retired }`. Have `ringdesign export --shrink` append to it, and give the flask work order a lookup so it prints "pattern exists — drawer 3" instead of re-printing. The `design_digest` should be the same content hash proposed for the sheet's provenance, so a pattern is provably of a specific design revision.
+
+</details>
+
+**Castability.** n/a — but shrink scale is a casting parameter, and tying a physical pattern to the alloy it was cut for is what keeps it honest.
+
+**Verified.** Confirmed. cli/main.rs:176-208 does the scaling and naming exactly as described — `built.mesh.scaled(k)`, solid name `"{} [pattern +{:.1}% for {}]"`, filename tag `_pattern-{slug_of(m.name)}` — and the manifest CSV (cli/main.rs:216-227) records only file/mesh/verdict facts. The manifest is written once per run to `{slug}_manifest.csv` and overwritten on the next run, so it is not even a durable log of what was exported, let alone of what was printed. Greps for pattern/inventory/stock as a physical-object concept across the workspace find only `pattern_scale`, `PATTERNS` (the kiosk's texture list) and `patternmaker's allowance` in metal.rs's doc comment. No index.json of any kind exists outside the graph/preset file layer.
+
+#### F222 The casting sheet is not a record: no date, no design identity, no digest — `high` / `S` / product-business
+
+**Problem.** `spec::html` takes provenance as a free-form caller string, and both callers pass only an app version (the GUI adds the sweep resolution). There is no date, no design file name, no design id and no content hash. A sheet found in a drawer cannot be tied to a design file, and a customer's signed approval cannot be tied to the geometry they approved. `RingDesign` itself has no id, author or timestamp either, so there is nothing to hash *to*.
+
+**Evidence.** crates/ringdesign-core/src/spec.rs:29-36 (`provenance: &str`) and 201-214 (printed verbatim). Callers: crates/ringdesign-gui/src/export.rs:295 `format!("RingDesigner {} • {} x {} sweep", ...)`; crates/ringdesign-configurator/src/main.rs:305 `concat!("Build-a-Ring ", env!("CARGO_PKG_VERSION"))`. crates/ringdesign-core/src/lib.rs:70-101 — `RingDesign` has no id, author or timestamp. The test at spec.rs:225 asserts the sheet is self-contained but says nothing about identity.
+
+**Do this.** Unchanged. Note that `library::design_json` is the right thing to hash — it is the deterministic, version-stamped canonical form that also embeds referenced non-regenerable alphas as PNG, so the digest covers the assets a rebuild would need. Make the same digest serve findings 14 and 16 rather than minting three. Keep the `provenance` parameter as a `Provenance` struct with an `operator: Option<String>` so a shop hand can be named on the sheet without a schema change.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Replace the free-form string with a `Provenance { app, version, built_at, design_id, design_digest, size, operator }` struct rendered as a block, where `design_digest` is a hash of the canonical `library::design_json` bytes (which are already deterministic and version-stamped). Add `RingDesign::id: Option<Uuid-ish string>` and `created_at`, serde-defaulted like `graph`. Then a signed quote is just the sheet plus the customer's approval of that digest — and reproducing a ring sold three years ago becomes: look up the order, read the digest, rebuild, verify it matches.
+
+</details>
+
+**Castability.** n/a — but the sheet is the document the caster works from, and a sheet that cannot be tied to the file that produced it is how the wrong revision gets poured.
+
+**Verified.** Confirmed verbatim. spec.rs:28 documents `provenance` as "a freeform line — app, version, date" and spec.rs:201-214 prints it as one `<td>` under a Build table of triangle count, watertightness and worst corner angle. Neither caller supplies a date: gui/export.rs:295 passes `format!("RingDesigner {} • {} x {} sweep", ...)` and configurator main.rs:305 passes `concat!("Build-a-Ring ", env!("CARGO_PKG_VERSION"))`. `RingDesign` (lib.rs:70-101) carries no id, author or timestamp. The sheet test (spec.rs:225, `the_sheet_carries_the_verdict_the_weights_and_escapes_the_name`) asserts escaping and self-containment and says nothing about identity.
+
+**Merged into a canonical finding above:** F210 (There is no quote engine, only a metal multiply) -> F125.
+
+### M24 — File doors (L, 11 findings)
+
+**Done when:** STEP out of the swept grid; a 1:1 plan/section/unrolled band as DXF; MCP over HTTP with no server-side paths; the deviation probe as a core measurement.
+
+#### F186 Export a real solid: STEP from the swept grid, not a mesh — `critical` / `L` / interop
+
+**Problem.** Every 3D writer in the tree is a triangle writer — `stl.rs` (STL/OBJ/PLY), `gltf.rs`, `threemf.rs`. A grep for `step`/`iges` across all of `crates/` returns nothing but loop variables. Casting bureaus, CNC houses, and every CAD shop the ring will be sent to want a solid; a mesh ring arrives as something they cannot fillet, section, or re-size, and most will refuse it or charge to rebuild it. This is the number-one interop complaint in jewellery CAD and the project has no answer.
+
+**Evidence.** crates/ringdesign-core/src/stl.rs (to_stl_binary, write_obj, write_ply), gltf.rs::to_glb, threemf.rs::to_3mf are the complete 3D writer set. crates/ringdesign-core/src/mesh.rs:283-302 — `BuildResult` from a swept build is a regular `n_theta.clamp(24,4096)` x `n_prof.clamp(24,1024)` lattice, closed in both directions (CLAUDE.md "Why the mesh is always watertight": torus topology, no caps, no seams). crates/ringdesign-core/src/profile.rs:1170 `ProfileLoop` is the closed 2D section; profile.rs:632 `sample_spaced` produces it per angle.
+
+**Do this.** Add crates/ringdesign-core/src/step.rs, hand-rolled ISO 10303-21 the way threemf.rs hand-rolls its zip. Tier 1 (do first, it is the one that actually answers the bureau): the swept build forced on (`params.refine = None`), vertices reshaped [theta][s], run a periodic cubic interpolation solve in both directions so the control net reproduces the sampled surface rather than shrinking from it, and emit one B_SPLINE_SURFACE_WITH_KNOTS closed in u and v inside ADVANCED_BREP_SHAPE_REPRESENTATION with `( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) )`. Closed both ways means no trimming curves, no seam edges, no caps. Scope it honestly: plain bands and bare drop profiles first; a design carrying a signet rim or milgrain should either refuse or be told it will come out fillet-smoothed. Tier 2 (AP242 TRIANGULATED_FACE_SET) is 40 lines over the existing face loop but lands in CAD as a mesh, so it is a convenience, not the answer to "send me a solid". Route both through the same finite-face filter finding 12 asks for. Add `step` to ringdesign-cli's format allowlist (main.rs, the `matches!(f.as_str(), ...)` arm), an MCP `export_step`, and the match in ringdesign-graph/src/nodes/sink.rs:284-292.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `crates/ringdesign-core/src/step.rs`, hand-rolled ISO 10303-21 exactly the way `threemf.rs` hand-rolls its zip (no dependency for a text format this regular). The swept build already hands you a periodic bicubic control net: reshape `mesh.vertices` as [theta][s] and emit one `B_SPLINE_SURFACE_WITH_KNOTS` closed in u and v, wrapped in `ADVANCED_BREP_SHAPE_REPRESENTATION` with `( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) )`. Because the surface is closed both ways there are no trimming curves, no seam edges and no caps to author — the hardest part of STEP export does not arise here. Ship a second, honest tier first if wanted: AP242 `TRIANGULATED_FACE_SET`, which is 40 lines over the existing face loop and which Rhino/SolidWorks/Fusion all read. Add `step` to `ringdesign-cli --formats`, MCP `export_step`, and `sink.export`'s format list in ringdesign-graph/src/nodes/sink.rs:452.
+
+</details>
+
+**Castability.** None — a representation change only. The exported surface is the same h(u,v) the field verdict judged; the verdict must still come from `analyze_field`, never from the exported entity.
+
+**Verified.** Verified: `grep -rniE "iges|AP242|B_SPLINE_SURFACE|ISO 10303|opennurbs" --include=*.rs crates/` returns nothing. The complete 3D writer set is crates/ringdesign-core/src/stl.rs (to_stl_binary/to_stl_ascii/write_obj/write_ply), gltf.rs::to_glb and threemf.rs::to_3mf — all triangle writers. Two corrections to the recommendation's craft, both load-bearing: (a) the swept grid's vertices are points the surface passes THROUGH, not B-spline control points — emitting them as a control net produces a surface that shrinks away from every crest and rim, so a real B-rep tier needs a periodic global interpolation solve (a cyclic tridiagonal system per grid direction, cheap but not optional); (b) mesh.rs:294 returns build_refined() before the lattice code whenever design.build.refine is Some, and a refined build is a quadtree with hanging nodes, not a lattice — a STEP writer must force a swept build or refuse. Also worth saying plainly: a signet's table rim, a flange corner and a milgrain bead are genuine creases, and one C² sheet cannot carry them, so the honest first target is the plain band and the bare drop profile.
+
+#### F188 MCP over HTTP cannot receive a design or return a file — `high` / `S` / interop
+
+**Problem.** Every file-shaped MCP tool speaks in server-side filesystem paths. `load_design` and `save_design` take a path on the machine the server runs on; `export_stl/obj/3mf/glb/stone_map` return `ExportResult { path, bytes }` — a path the caller may have no access to and no bytes at all. `get_design` returns the design JSON, but there is no inverse: nothing accepts a design as text. The sync module's own doc comment says this out loud. So an agent attached over `ringdesign-mcpd --http` from anywhere but the same box can read a ring and cannot hand one over or take one away.
+
+**Evidence.** crates/ringdesign-mcp/src/tools.rs:2281-2400 (export_stl/obj/3mf/glb/stone_map, save_design, load_design), tools.rs:344-347 `pub struct ExportResult { path: String, bytes: usize }`. crates/ringdesign-mcp/src/sync.rs:1-9 — "the MCP tools cannot do the job anyway — `save_design`/`load_design` take paths on the *server's* filesystem, so `load_design` called from a phone would load a file on the desktop". crates/ringdesign-mcpd/src/main.rs:27-40 documents the HTTP transport as the way to attach to a running GUI.
+
+**Do this.** Add `set_design { json: String }` to tools.rs as the mirror of get_design, going through Engine::set_design (engine.rs:78) so the generation bump still wakes a GUI sharing the engine — and have it delegate to the same deserialize-and-validate path sync.rs already uses rather than a second one. Give load_design an optional `{ json }` alternative to `{ path }`. Give every export_* an `inline: bool` returning base64 alongside the path — to_stl_binary/to_glb/to_3mf/stone_map_svg all produce the bytes before writing, so this is plumbing. Add `library::list_designs()` over default_design_dir() plus an MCP `list_designs` so an agent stops guessing paths. Separately, wire sync::serve into ringdesign-mcpd behind a flag so the daemon can serve the receive route it already owns the code for.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `set_design { json: String }` in tools.rs (the mirror of `get_design`, going through `Engine::set_design` so the generation bump still wakes a GUI sharing the engine), and give every `export_*` an optional `inline: bool` returning base64 bytes alongside the path — the mesh is already produced as a `Vec<u8>` by `to_stl_binary`/`to_glb`/`to_3mf` before it is written. Add `list_designs` over `library::default_design_dir()` so an agent stops guessing paths, and `load_design` should accept `{ json }` as an alternative to `{ path }`.
+
+</details>
+
+**Verified.** The MCP half is confirmed: tools.rs has get_design (:1329) and no inverse; save_design (:2367) and load_design (:2383) take server-side paths; ExportResult is `{ path: String, bytes: usize }` (tools.rs:344-347) on all five export tools; `library::list_designs` does not exist (the full public API of library.rs is set_data_root, data_root, design_json, save_design, save_design_embedded, load_design, load_design_str, the dir getters, list/save outlines and list/save profiles). But the premise "nothing can receive a design over HTTP" is too strong: crates/ringdesign-mcp/src/sync.rs:138-166 already serves `POST /design`, parsing a RingDesign from the body straight into `Engine::set_design`, with a token required off loopback. What is true is that (a) the MCP tool surface itself has no set_design, so an MCP client must know about a second, differently-shaped service, and (b) `ringdesign-mcpd --http` (main.rs:96-101) starts only the MCP transport — sync::serve is not wired into the daemon at all, so on a headless box the receive path is not running.
+
+#### F189 MCP is missing most layer kinds and every generator — `high` / `M` / interop
+
+**Problem.** The tool surface stopped at the five layer kinds that existed when it was written. There is no way over MCP to add a `SeatRun` (an eternity or graduated row), a `Curve` wire, `Flutes`, `Openwork`, `Decals`, or a `Group` — and none of the three generators (`pave::fill`, `pave::halo`, `pave::channel_set`) is exposed at all. Those are exactly the features CLAUDE.md spends the most measured doctrine on. An agent asked for "an eternity band" or "a pavé shoulder" has to fall back to `graph_*` node wiring, which the tool descriptions never mention as the workaround.
+
+**Evidence.** crates/ringdesign-mcp/src/tools.rs — the add-layer tools are `add_tiling_layer`, `add_border_layer`, `add_seat_pad_layer`, `add_signet_layer`, `add_milgrain_layer` only (tools.rs:1701-1888). grep counts in tools.rs: `pave|Pave` = 0; `Curve|Openwork|Flutes|Decal` = 9, all inside `update_layer`'s kind-mismatch error text. Compare crates/ringdesign-core/src/field.rs `Layer` = Tiling Signet Border SeatPad Milgrain Group Curve Flutes Openwork Decals SeatRun, and crates/ringdesign-core/src/pave.rs (fill/halo/channel_set with `GenRecipe` provenance).
+
+**Do this.** Add add_seat_run_layer, add_curve_layer, add_flutes_layer, add_openwork_layer, add_decal_layer, add_group_layer, plus gen_pave / gen_halo / gen_channel wrapping pave::fill / halo / channel_set (each returns an ordinary live Group carrying its GenRecipe, so update_layer/remove_layer indices are unaffected). Carry each one's measured doctrine into the tool description the way add_tiling_layer already does: add_seat_run_layer must state the shared-prong "cast flush and bead-set, or judge for lost wax" rule and that stations move under a taper; add_curve_layer must state the headline placement is a side face (0.000% vs 1.1% at -31° on a crest rail); gen_halo must state that the accent ring casts as zero-height markers on a gypsy plate in sand and only frees up under CastProcess::LostWax; gen_channel must state it returns None on a thin or domed band and why. Cheap interim while those land: say in the server instructions that anything not listed goes through graph_add_node on ringdesign-graph/src/nodes/layer.rs's nodes, which already cover every Layer variant.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `add_seat_run_layer`, `add_curve_layer`, `add_flutes_layer`, `add_openwork_layer`, `add_decal_layer`, `add_group_layer`, and `gen_pave` / `gen_halo` / `gen_channel` wrapping `pave::fill`/`halo`/`channel_set` (each returns an ordinary live Group, so the existing `update_layer`/`remove_layer` indices keep working). Carry each one's measured doctrine into its description the way `add_tiling_layer` already does — a `SeatRun`'s tool text should say the shared-prong lost-wax caveat and the graded-station warp, and `add_curve_layer`'s should say the headline placement is a side face. Cheaper interim: say in the server instructions that anything not listed goes through `graph_add_node` on the layer nodes, which already cover every variant (ringdesign-graph/src/nodes/layer.rs).
+
+</details>
+
+**Castability.** None new — each tool wraps a constructor whose field verdict is already pinned (e.g. `lost_wax_frees_the_halo_and_the_verdict_says_which_is_which`, the turned-run side-face measurements). Every one should return the fresh `analyze_field` verdict in its response the way `castability` does, so an agent sees the cost of what it just added.
+
+**Verified.** Verified by listing every `#[tool]`/`async fn` in crates/ringdesign-mcp/src/tools.rs: the add-layer surface is exactly add_tiling_layer (:1701), add_border_layer (:1749), add_seat_pad_layer (:1780), add_signet_layer (:1820), add_milgrain_layer (:1888). No SeatRun, Curve, Flutes, Openwork, Decals or Group; no pave/halo/channel_set anywhere in the file. The graph router (graph_tools.rs:405-608) is the only workaround and the tool descriptions never say so. Worth adding to the finding: these are the layers CLAUDE.md spends its hardest-won measurements on — the graded-run eccentric warp, the shared-prong lost-wax caveat, the curve wire's side-face placement, Openwork's depth-vs-radial-metal rule — so the omission costs an agent exactly the doctrine the project is proudest of.
+
+#### F190 Reference-mesh import and deviation are gitignored Python, though the reader is already in-tree — `high` / `M` / interop *(also found as F241)*
+
+**Problem.** Every calibration claim in CLAUDE.md — the 0.04-0.05 mm head deviation against the CrossGems cached meshes, the 12-degree shoulder dihedral census, the bought-signet measurements — rests on `tools/harvest/deviation.py` and `dihedral.py`, which are gitignored, and on `examples/scan_signet.rs`, which hardcodes `/home/shadowbroker/jewelry-scan/RING/Signets`. None of it exists in the app. A jeweller who owns a ring they want to match, or who has had a wax scanned, has no way to put it next to their design and read the difference. The roadmap parks this under "Niceties". Meanwhile the mesh readers are already written and, notably, are NOT behind the C++ feature gate.
+
+**Evidence.** crates/ringdesign-solid/src/lib.rs:9-11 — `#[cfg(feature = "manifold")] pub mod kernel; pub mod io;` — `io` is unconditional. crates/ringdesign-solid/src/io.rs:13-67 `read_obj`, `parse_obj`, `read_stl` (binary and ASCII), `parse_stl`. crates/ringdesign-core/examples/scan_signet.rs:18 `const DIR: &str = "/home/shadowbroker/jewelry-scan/RING/Signets";` with its own duplicate welding reader in examples/common/scan.rs:9. docs/ROADMAP.md, M9 "Niceties: ... reference-mesh import + deviation report as a core feature (the exact point-to-triangle measure and the crease census, today script-only)". tools/harvest/README.md rows for deviation.py and dihedral.py.
+
+**Do this.** Promote the M9 Niceties item rather than re-proposing it. Move io.rs's readers into ringdesign-core (they depend only on mesh::Mesh/Vec3, nothing kernel-side) — that single move also fixes finding 20's duplicate-reader problem — and add `core::compare::deviation(ours: &Mesh, reference: &Mesh) -> DeviationReport`: exact point-to-triangle, mean/p90/max, bucketed by theta so head / shoulder / shank read separately, which is exactly the breakdown deviation.py already prints and the one CLAUDE.md's loft calibration table is written in. Add `crease_census` (the dihedral histogram, the measure that found 740 mm of hard edges on the pre-rebuild signet). Bring the bore-fit alignment out of examples/common/scan.rs with it — without alignment the numbers are meaningless. Surface it as a GUI "Compare to reference…" reusing the existing ghost VBO and u_alpha path, `ringdesign compare ours.ring.json reference.stl` in the CLI, and an MCP compare_reference.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Promote it. Move `io.rs`'s readers into `ringdesign-core` (they have no kernel dependency) and add `core::compare::deviation(ours: &Mesh, reference: &Mesh) -> DeviationReport` — exact point-to-triangle, mean/p90/max, bucketed by theta so head/shoulder/shank read separately, which is precisely what deviation.py already computes — plus `crease_census` (the dihedral histogram). Wire it to a GUI "Compare to reference…" that reuses the existing ghost VBO and `u_alpha` path in viewport.rs, a `ringdesign compare ours.ring.json reference.stl` CLI verb, and an MCP `compare_reference`. Bore-fit alignment already exists in examples/common/scan.rs and should move with it.
+
+</details>
+
+**Castability.** n/a — measurement only. An imported reference must never enter the height field or the verdict.
+
+**Verified.** Confirmed on every point. crates/ringdesign-solid/src/lib.rs:9-11 really does gate only `kernel` behind the manifold feature while `pub mod io;` is unconditional, so read_obj/parse_obj/read_stl/parse_stl (io.rs:13-108) are available with no C++ toolchain. examples/scan_signet.rs:18 hardcodes /home/shadowbroker/jewelry-scan/RING/Signets and examples/common/scan.rs:9-41 carries a second, better STL reader. castability::modulus_scan (castability.rs:631) and the whole deviation machinery it would compare against exist. Already on the roadmap: docs/ROADMAP.md:195 lists "reference-mesh import + deviation report as a core feature (the exact point-to-triangle measure and the crease census, today script-only)" under M9 Niceties — so this is a promotion, not a new idea, and the note should say so.
+
+#### F191 No 1:1 drawings of the ring: no plan, no section, no unrolled band, no DXF — `high` / `M` / interop
+
+**Problem.** Two SVGs exist and both are about stones and the mould split. There is no drawing of the ring itself: no plan outline at 1:1 for laser or waterjet, no cross-section at 1:1 to file a former or check on a shadowgraph, and no unrolled band layout — even though the unrolled editor draws exactly that on screen every frame and exports nothing. There is no DXF writer of any kind, so nothing here reaches a laser cutter, an engraving machine, or a CAM package that speaks 2D.
+
+**Evidence.** The complete SVG writer set: crates/ringdesign-core/src/stonemap.rs::stone_map_svg and crates/ringdesign-core/src/castability.rs:704 `write_parting_svg`. Both are honest true-scale (`width="{w}mm"`; stonemap at K=2.0 and says so). crates/ringdesign-gui/src/panels/unrolled.rs draws the chart interactively with no export. grep for `dxf` across crates: nothing. `castability::section_at` already returns the exact section the mesh is built from, and `ProfileLoop` (profile.rs:1170) is a closed 2D loop in (r,z).
+
+**Do this.** Do not rebuild the plan — extend it. Add crates/ringdesign-core/src/draw.rs in the stonemap.rs idiom (mm-dimensioned SVG, viewBox in mm) with the two drawings that genuinely do not exist: `section_svg(design, lib, theta)` — one castability::section_at slice at 1:1 with the parting height, the crest, the bore and min_section_mm called out, which is what a bench files a former against or checks on a shadowgraph; and `unrolled_svg(design, lib)` — the (u,v) chart at the true circumference_mm x band_v_len_mm with layer footprints and stone stations, the thing panels/unrolled.rs already renders. Add dimension callouts to write_parting_svg's existing plan rather than writing a second plan. Then a ~100-line DXF R12 writer (ASCII, ENTITIES section, LWPOLYLINE only — R12 needs no HEADER or TABLES) taking the same point lists, so the plan and the section reach a laser or an engraver. Add `draw`/`dxf` to CLI --formats alongside finding 10's sheet/parting, a File-menu entry, and sink.* nodes alongside finding 19's.
+
+<details><summary>The auditor's original recommendation</summary>
+
+A `crates/ringdesign-core/src/draw.rs` with three functions in the `stonemap.rs` idiom (mm-dimensioned SVG, `viewBox` in mm): `plan_svg(design, lib)` — the silhouette from `parting_line`-style per-slice max radius plus the bore, dimensioned; `section_svg(design, lib, theta)` — one `section_at` slice at 1:1 with the parting height, the crest and `min_wall_mm` called out; `unrolled_svg(design, lib)` — the (u,v) chart with layer footprints and stone stations, at the true `circumference_mm x band_v_len_mm`. Then a ~100-line DXF R12 writer (ASCII, ENTITIES section, LWPOLYLINE only — no headers, no tables needed for R12) taking the same point lists, so the plan and the section reach a laser. Add `draw`/`dxf` to CLI `--formats`, a File-menu entry, and `sink.*` nodes.
+
+</details>
+
+**Verified.** The DXF half is confirmed — `grep -rn dxf` across crates/ finds nothing. But the plan claim is wrong: castability::write_parting_svg (castability.rs:704-753) already emits a true-millimetre drawing (`width="{w}mm"`, viewBox in mm) containing the ring's plan silhouette — parting_line is per-slice maximum outer radius, i.e. the plan outline — closed with Z, plus the bore drawn as a dashed circle at bore_radius_mm, plus the parting line's height unrolled around the ring beneath it with the plane as a dashed rule. That is a plan at 1:1 with the bore and an unrolled strip, both already there. What is genuinely missing: a cross-section drawing (castability::section_at returns the exact section the mesh is built from and nothing draws it to paper), an unrolled BAND layout (the parting strip is one line's height, not the (u,v) chart with layer footprints and stone stations that panels/unrolled.rs draws on screen every frame and exports nothing), any dimensioning on any of it, and any DXF. Also note write_parting_svg has exactly one call site in the whole tree, crates/ringdesign-gui/src/export.rs:244 — see finding 19.
+
+#### F194 The HTTP surface is two routes over one global design — a website cannot use it — `high` / `M` / interop
+
+**Problem.** `sync.rs` serves `/health` and `GET`/`POST /design`, and a POST *replaces the running engine's design*. That is right for its stated purpose (phone sync against a live desktop) and useless as a shop or webshop service: there is no `/build`, `/verdict`, `/render.png`, `/export/{fmt}`, `/sheet`, `/stones`, `/cost`; there is no design-by-id; and because the one design is global mutable state, two concurrent requests fight. The MCP HTTP transport is the only other network surface and it has the path problem above.
+
+**Evidence.** crates/ringdesign-mcp/src/sync.rs:114-176 — the entire router: `(GET, "/health")`, `(GET, "/design")`, `(POST, "/design")` calling `e.set_design(design)`, everything else 404. sync.rs:1-15 states the purpose is phone pull/push against the live engine. crates/ringdesign-mcpd/src/main.rs:96-101 — `--http` binds only the MCP transport on 127.0.0.1.
+
+**Do this.** Keep the two engine routes exactly as they are for the phone — they are correct for their stated job — and add a stateless tier beside them, on a distinct path prefix so the mutable-engine routes and the pure ones can never be confused: `POST /v1/evaluate` taking a RingDesign (or a configurator compose::Config) in the body and returning verdict + notes + Report weights + StonesReport + DFM findings, computed on a fresh engine per request; `POST /v1/render.png`; `POST /v1/export/{stl|3mf|glb|step}` returning bytes; `POST /v1/sheet` returning spec::html. Every one of those is already a pure function of (design, lib) — analyze_field, mesh::build, stones::report, dfm::findings_in, render::png_bytes, spec::html — so this is routing plus a body-size cap, not geometry. Serve it from ringdesign-mcpd behind the token rule Config::remote already enforces, and wire sync::serve into the daemon while you are there (today it is only started by the GUI).
+
+<details><summary>The auditor's original recommendation</summary>
+
+Keep the engine routes for the phone and add a stateless tier beside them: `POST /evaluate` taking a `RingDesign` (or a `compose::Config`) in the body and returning verdict + notes + `Report` weights + `StonesReport` + DFM findings, computed on a fresh engine per request; `POST /render.png` and `POST /export/{stl|3mf|glb|step}` returning bytes; `POST /sheet` returning the `spec::html`. All of it is already pure functions of (design, lib) — `analyze_field`, `mesh::build`, `stones::report`, `dfm::findings_in`, `render::png_bytes`, `spec::html` — so this is routing, not new geometry. Serve it from `ringdesign-mcpd` behind the same token rule `Config::remote` already enforces.
+
+</details>
+
+**Castability.** n/a — as long as `/evaluate` returns `analyze_field`'s verdict and never a mesh-facet one, which is the rule the GUI banner and MCP already follow.
+
+**Verified.** Verified against the router itself, crates/ringdesign-mcp/src/sync.rs:119-171: the match arms are exactly (GET, "/health"), (GET, "/design"), (POST, "/design") calling `e.set_design(design)` and bumping the generation, with everything else falling to a 404. MAX_BODY is 8 MB, token required off loopback (Config::remote refuses a token under 8 chars). No /build, /verdict, /render, /export, /sheet, /stones, /cost, and no design-by-id. mcpd's --http (main.rs:96-101) binds only the MCP transport on 127.0.0.1 and never calls sync::serve at all, so on a headless box even these two routes are absent. The module doc (sync.rs:1-15) is explicit that phone sync is the whole remit, so this is scope, not oversight — but it does mean there is no service tier a webshop or a shop queue could call.
+
+#### F195 The CLI cannot produce the documents a shop prints, and cannot batch a library — `high` / `S` / interop
+
+**Problem.** `ringdesign export --formats` accepts stl, obj, 3mf, glb, ply, stonemap. It cannot write the casting sheet, the parting-line SVG, a hero render, a turntable, or the cost document — all of which exist in core and are reachable only from the desktop GUI. And the command takes exactly one design file: there is no way to re-verdict a whole design library after a code change, bulk-render a catalogue, or run a nightly regression across the shop's rings.
+
+**Evidence.** crates/ringdesign-cli/src/main.rs — the format allowlist `matches!(f.as_str(), "stl"|"obj"|"3mf"|"glb"|"ply"|"stonemap")`; `run()` destructures `[c, p, ..]`, one path. `spec::html` is called only from crates/ringdesign-gui/src/export.rs:302 and crates/ringdesign-configurator/src/main.rs:296; `castability::write_parting_svg` only from gui/export.rs:244; `render::write_png`/`write_turntable_gif` only from the GUI and the graph's `sink.render`. The manifest CSV (main.rs) is described in its own module doc as "the export-regression diff" but has no directory mode to diff across.
+
+**Do this.** Extend --formats with sheet,parting,png,gif,cost — each is one call to an existing core function, and --shrink already resolves the metal the sheet's headline weight wants. Accept a directory or glob as the design argument and emit one combined manifest so `ringdesign check designs/` re-verdicts the whole library after a code change; that is the use the manifest's own module doc promises and cannot deliver today. Add --fail-on marginal|notcastable returning a non-zero exit so it works as a CI gate, and --jobs N since sizes and designs are independent builds. Order the work by what a shop misses first: sheet and parting before png/gif, directory mode before --jobs.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Extend `--formats` with `sheet,parting,png,gif,cost` (each is a one-line call to an existing core function; `--shrink` already carries the metal for the sheet's headline). Accept a directory or a glob as the design argument and emit one combined manifest, so `ringdesign check designs/` re-verdicts the whole library. Add `--fail-on marginal|notcastable` returning a non-zero exit so it is usable as a CI gate, and `--jobs N` since builds are independent.
+
+</details>
+
+**Castability.** n/a — the batch verdict must stay `analyze_field` at a fixed sampling so the manifest diff means something between runs.
+
+**Verified.** Verified in crates/ringdesign-cli/src/main.rs: the allowlist is `matches!(f.as_str(), "stl"|"obj"|"3mf"|"glb"|"ply"|"stonemap")` and run() destructures `[c, p, ..]` — one design path, no directory or glob, no --fail-on, no --jobs. spec::html is called from crates/ringdesign-gui/src/export.rs:301, crates/ringdesign-configurator/src/main.rs:299 and ringdesign-graph/src/nodes/sink.rs:245 only; castability::write_parting_svg from gui/export.rs:244 only; render::write_png/write_turntable_gif from the GUI, sink.render, the Python module (py/src/lib.rs:360) and examples. The manifest CSV already carries verdict, undercut %, thinnest wall and volume per size — it is one directory loop away from being the shop-wide regression the module doc claims it is.
+
+#### F200 Rhino .3dm is read only by a gitignored Python script and written by nothing — `high` / `L` / interop
+
+**Problem.** The industry's lingua franca is in this repo as data and as a Python dependency, and not at all as a capability. `rhino3dm==8.32.0` decodes the factory clusters, the profile curves, the gem archives and the factory `.3dm` sections — all inside `tools/harvest/`, which the README says is "never tracked". `batch6-8/from-rhino/**/*.3dm` are files the Rhino VM produced for calibration. Nothing in any Rust crate reads or writes a `.3dm`. So the profile library that CLAUDE.md describes as imported from the factory presets can only be reproduced on the one machine that has the harvest venv and the proprietary archive, and no customer or bench can send a Rhino file in or take one out.
+
+**Evidence.** tools/harvest/requirements.txt:1 `rhino3dm==8.32.0`; cluster_curves.py:24 `import rhino3dm`; tools/harvest/README.md rows for `factory_extract.py` ("Factory `.3dm` profiles -> `BandProfile` JSON (user profile dir)") and `cluster_curves.py`. tools/harvest/README.md line 3: "never tracked". batch6-8/from-rhino/{nocturnal,sketches2,brief01-loft}/*.3dm. grep for `3dm` across `crates/`: nothing.
+
+**Do this.** Two tiers, and the cheap one is genuinely cheap. Cheap: promote the non-proprietary half of the harvest as a tracked tools/threedm.py converting a .3dm of closed planar curves into .profile.json and .outline.json in the user dirs (documented in the repo README, rhino3dm from pip) — a client's Rhino curve becomes a band section or a signet plan today with no new Rust, and it pairs directly with finding 2's import constructors. Real: a ringdesign-3dm crate wrapping openNURBS behind a cmake feature on exactly the ringdesign-solid/manifold precedent (default off, kernel_available()-style probe, no C++ in the default workspace build), reading closed planar curves for profiles and outlines and writing the same periodic B-spline surface finding 1 builds as a .3dm Brep — one surface construction, two containers. Both directions matter: read to receive a client's shape, write to hand a ring to a bench that lives in Rhino.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Two tiers. Cheap: promote the *non-proprietary* half of the harvest — a tracked `tools/threedm.py` that converts a `.3dm` of closed curves into `.profile.json` and `.outline.json` in the user dirs, documented in the README, so a customer's Rhino curve becomes a section or a signet plan today with no new Rust. Real: a `ringdesign-3dm` crate wrapping openNURBS behind a cmake feature exactly as `ringdesign-solid/manifold` does (same precedent, same off-by-default rule), reading closed planar curves for profiles/outlines and writing the STEP-side B-spline surface as a `.3dm` Brep. Both directions matter — read to receive a client's shape, write to hand a ring to a bench that lives in Rhino.
+
+</details>
+
+**Castability.** An imported curve must go through `CustomOutline::from_points`/`BandProfile::apply_shape` so the containment and monotone-drop guarantees are inherited, never through a bespoke path.
+
+**Verified.** Confirmed: `grep -rn 3dm --include=*.rs crates/` returns nothing but threemf.rs's "3dmanufacturing" XML namespace strings and its "3D/3dmodel.model" zip entry name — no .3dm handling anywhere in Rust. tools/harvest is gitignored per its own README. Craft check on the premise: .3dm as the trade lingua franca is right for jewellery specifically — most bench-side CAD in this trade is Rhino plus Matrix/RhinoGold, so "send me your file" usually means .3dm, and STEP (finding 1) is the bureau/CNC answer rather than the bench answer. The two findings are complementary, not duplicates, and if only one ships, STEP is the one that unblocks casting bureaus while .3dm is the one that unblocks other jewellers.
+
+#### F202 3MF writes one object per file, so a size run is nine files laid out by hand — `medium` / `S` / interop
+
+**Problem.** `to_3mf` emits a single `<object id="1">` and a single `<build><item objectid="1"/></build>`, with no `<basematerials>` and no transforms. The size-run CLI therefore writes nine separate packages. But a flask or a print plate holds the whole run at once, and 3MF's entire advantage over STL is that it is a *package* — multiple objects, placed, with materials and metadata.
+
+**Evidence.** crates/ringdesign-core/src/threemf.rs:156 — `"...</mesh>\n  </object>\n </resources>\n <build>\n  <item objectid=\"1\"/>\n </build>\n</model>"`. threemf.rs:36 `zip_store` already takes `&[Entry]` and is public with `Entry` exposed (the configurator reuses it for order zips). crates/ringdesign-cli/src/main.rs — the per-size loop writes one file per format per size.
+
+**Do this.** Add `to_3mf_multi(items: &[(&Mesh, &str, [f64; 12])], title: &str)` emitting one <object id=N> per item and one <item objectid="N" transform="..."/> per placement, plus a <basematerials> entry carrying the alloy's name and tint so the package states what metal it is — which is finding 7's design.metal reaching a file for the first time. Keep to_3mf as the single-object path so nothing existing changes. Give the CLI a --plate flag laying the size run out on a grid in one package with each ring's size in its object name, and keep the per-size files as the default so the current workflow is untouched. The deterministic store-only zip already supports all of it.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `to_3mf_multi(items: &[(&Mesh, &str, [f64; 12])], title: &str)` emitting one `<object>` per item and one `<item objectid="N" transform="..."/>` per placement, plus a `<basematerials>` entry carrying the alloy's tint and name so the package says what metal it is. Give the CLI `--plate` to lay the size run out on a grid in one package, with each ring's size still in its object name. The store-only deterministic zip already supports it.
+
+</details>
+
+**Castability.** n/a — a packaging change. Each ring must keep its own size in its object name so a plate cannot be mis-picked.
+
+**Verified.** Confirmed literally: crates/ringdesign-core/src/threemf.rs:156 closes the model with `</mesh>\n  </object>\n </resources>\n <build>\n  <item objectid=\"1\"/>\n </build>\n</model>` — one object, one item, no transform attribute, no <basematerials>. zip_store and Entry are public (threemf.rs:39) and already reused by the configurator's order zip (configurator main.rs:339-342), so the packaging half needs nothing new. The CLI's per-size loop (cli main.rs:172-230) writes one file per format per size and names them {slug}_size{n}. Craft check: a Delft-clay flask holding a size run at once is the real workflow this crate's own module doc describes ("one flask, one command"), so a package that can hold the run is the natural unit, and a resin plate is the same argument for the print route.
+
+#### F204 The graph has no node for the two documents a shop prints — `medium` / `S` / interop
+
+**Problem.** The graph is the project's automation surface, and its sinks are export (5 mesh formats), sheet, render, save_design, write_text and mesh_verdict. There is no stone-map sink and no parting-line sink — the setter's map and the mould split, the two SVGs a shop actually prints. Symmetrically, `spec::html` is reachable only from the desktop GUI, the configurator, and `sink.sheet`; there is no CLI format and no MCP tool for it. So an automated pipeline can write a mesh but cannot produce the paperwork that goes with it.
+
+**Evidence.** crates/ringdesign-graph/src/nodes/sink.rs:284-292 (export formats stl/obj/ply/3mf/glb), :226 `sheet`, :305 `render_sink`, :431-452 the NodeSpec list; no stonemap, no parting. crates/ringdesign-core/src/stonemap.rs::write_stone_map_svg call sites: gui/export.rs, cli main.rs (as a `--formats stonemap` entry), MCP `export_stone_map` — but `castability::write_parting_svg` has exactly one call site, crates/ringdesign-gui/src/export.rs:244.
+
+**Do this.** Add sink.stone_map and sink.parting_line nodes — one core call each; parting_line already returns Vec<[f64;3]> and stone_map_svg already returns Option<String>, so both are thinner than sink.sheet already is. Add MCP export_sheet and export_parting, and CLI --formats sheet,parting (the same two entries finding 10 asks for, so do them once). Have sink.stone_map refuse a stone-less design with the message write_stone_map_svg already produces rather than failing opaquely, the way sink.export refuses an unjudged ring by name. Prioritise parting_line: it is the drawing with one call site in the whole project and the one a sand caster cannot pour without.
+
+<details><summary>The auditor's original recommendation</summary>
+
+Add `sink.stone_map` and `sink.parting_line` nodes (both one call each, both already returning `String`/`Vec<[f64;3]>` that `sink.write_text` could almost consume), an MCP `export_sheet` and `export_parting`, and CLI `--formats sheet,parting`. While there, have `sink.stone_map` refuse a stone-less design with the same message `write_stone_map_svg` already gives rather than failing opaquely.
+
+</details>
+
+**Castability.** n/a — both are reports. The parting-line sink should read the same `analyze_field` parting height the verdict used, not recompute one, so the printed line and the judged line cannot disagree.
+
+**Verified.** Confirmed by listing every NodeSpec in crates/ringdesign-graph/src/nodes/sink.rs: OUTPUT_KIND (:357), sink.field_verdict (:362), gate.castable (:376), sink.build (:384), sink.refine (:399), sink.stones (:413), sink.dfm (:424), sink.sheet (:431), sink.write_text (:439), sink.export (:447), sink.render (:462), sink.save_design (:475), sink.mesh_verdict (:484). No stone_map, no parting_line. And write_parting_svg has exactly ONE call site in the entire tree — crates/ringdesign-gui/src/export.rs:244 — so the mould-split drawing is desktop-only, absent from the CLI, MCP, the graph, the Python module and the phone. write_stone_map_svg is better off (gui/export.rs:268, cli main.rs:208, MCP tools.rs:2357) but still has no graph node. spec::html has sink.sheet but no CLI format and no MCP tool, exactly as claimed.
+
+**Merged into a canonical finding above:** F241 (Reference-mesh deviation is script-only, and it is the measure that proved the loft) -> F190.
+
+## Method
+
+Thirteen dimensions, each audited by an agent instructed to judge like a working bench
+jeweller and a foundry hand rather than a software reviewer: sand process, lost wax, ring
+typology, stone setting, ornament, signet heads, DFM and the verdict, sizing and fit, code
+architecture, UX, interop, product and business, and parity with the tools a professional
+would otherwise buy. Each dimension's findings were then handed to a second agent whose
+brief was adversarial - grep widely, including `examples/`, `tools/`, `graphs/`, the MCP
+tools, the CLI and the configurator, since a capability may exist somewhere other than where
+the auditor looked - and which could mark a finding ALREADY_EXISTS, PARTIALLY_EXISTS,
+CONFIRMED_GAP or WRONG. Three findings were then re-checked by hand against the tree and all
+three held exactly as reported.
+
+Raw audit: 4.9M subagent tokens, 1,404 tool calls, 26 agents, 0 errors.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -195,3 +195,423 @@ A core-only crate that evaluates a graph to a `RingDesign` with implicit-list se
 - Niceties: gate & sprue advisor; DPI true-scale; reference-mesh import + deviation report as a
   core feature (the exact point-to-triangle measure and the crease census, today script-only);
   comparison views beyond the ghost.
+
+**The parking lot is closed.** The 2026-08-30 audit gave every Shelf and Nicety item a milestone,
+so nothing sits here unowned any more: march instances along a guide path and the blue-noise
+scatter generator to **M16**, along with mm-true mask morphology, nesting-depth stepped relief and
+the honest rope rail; `stones::probe_seat`, pearl stock and flat-edged seat plans to **M20**; the
+gate & sprue advisor to **M19**; DPI true-scale to **M13**; reference-mesh import and the deviation
+report to **M24**; comparison views beyond the ghost to **M17**.
+
+---
+
+# The second half: M10 — M24
+
+Everything above is shipped. What follows comes from the **2026-08-30 audit**
+(`docs/AUDIT-2026-08-30.md`): thirteen domain auditors reading the tree from a bench jeweller's
+and a foundry hand's chair, each finding checked by an adversarial verifier, then two independent
+sequencing passes. 243 findings, none dropped as already-existing. Findings are cited as `#n`
+against that document, which carries the file and symbol every claim was read from.
+
+## Where this is going, restated
+
+M0–M9 built a model that can prove a ring pulls from a two-part sand mould. The audit's verdict on
+it is that the *pull* is world-class and everything *after* the pull is missing: nothing says where
+to gate, how much to melt, what polish eats, or whether the ring survives a week on a hand. Three
+structural holes account for most of the rest:
+
+- **The model has one stage where the trade has two.** Every layer is cast geometry judged against
+  the sand's 0.30–0.40 mm detail floor, so bright-cut, wriggle, guilloché, intaglio seals and
+  inside lettering — the fine work a signet shop actually sells — are judged NotCastable or
+  measured as mush (F93). One concept, `LayerEntry::stage`, unlocks four families at once.
+- **The verdict is radial and blind to the axial web.** `thinnest_wall` and `bore_span_wall` both
+  subtract bore radius from surface radius at one `z`. Nothing measures metal *across* the band,
+  which is exactly where the doctrine sends every deep carve — and `OpenworkLayer`'s own cap is
+  documented as opening up there. Four dimensions found this independently (F115).
+- **The app states numbers that are not true.** `CastProcess::apply` never restores the sand floors
+  (F21); stone crowding is judged against a hardcoded 0.3 mm while the sand's floor is 0.7–0.8
+  (F58); the report panel prints the retired mesh analyzer's numbers under the field verdict's
+  banner (F123). And there is no CI (F155).
+
+So the order is: **truth, then measure, then variety.** M10 stops the lying and stands up CI. M11
+gives the verdict the section it cannot currently see. M12 is the cheapest visible variety win —
+19 findings, no new subsystem — and only then do the multipliers land.
+
+Fixed decisions, as before: the sand-cast ring stays its own mode with `analyze_field` as the gate;
+lost wax gets honest immediately (M10, M18) and complete later (M22); nothing derived from
+proprietary assets enters the repository.
+
+## Dependency order
+
+```
+M10 ──> everything
+ ├─> M11 ──> M14 ──> M15     (a bench cut, an inside cut and a pierce may not
+ │      ├──> M20              remove metal before the web that stops them is measured)
+ │      ├──> M22
+ │      └──> M19
+ ├─> M12 ──> M14              (a seal needs a plan to sit in)
+ │      ├──> M16
+ │      └──> M17              (a grid over parameters that do not exist is
+ ├─> M13                       one ring shown nine times)
+ └─> M18 ──> M19 ──> M23
+M20 + M19 + M21 ──> M23
+M24 last: it exports what the earlier milestones made true
+```
+
+Two things are deliberately late despite being `critical`. The **gating plan** (F1) sits in M19,
+not M10: every input exists, but they are calibrated against three unsourced sand constants (F7),
+so a gate advisor shipped now manufactures a confident wrong number at the flask — source the sand
+first. The **variant explorer** (F168) sits in M17, after M12 and M16 have given it axes worth
+enumerating.
+
+## M10 — One verdict, spoken once (L, 47 findings, epic #154)
+
+Accept: CI is green; a golden corpus pins verdict, `volume_mm3` and thinnest wall for every
+template; Sand→LostWax→Sand restores `min_section_mm` 0.7 / `min_detail_mm` 0.35 exactly; and no
+sink — GUI export, `--sizes`, the kiosk's `save_order` — writes a file the field verdict refuses.
+
+- [ ] **M10.1 The process switch tells the truth** (M, #169). F21≡F114, F22, F23, F25, F5.
+  `CastProcess::apply` gains its else arm; `DraftSettings` gains `sand: SandProcess` (which today
+  derives no serde at all); the field banner stops telling a lost-wax design it "clears a two-part
+  pull" while its own note says the opposite; `analyze` stops speaking sand out loud in Free mode;
+  `min_detail_mm` either gates or the tooltip stops promising it does; the drag downgrade to
+  Marginal explains itself. Test: a round-trip identity on the floors.
+- [ ] **M10.2 One verdict everywhere** (S, #170). F123≡F166, F127. The report panel, the status chip and
+  the Draft shading stop reading the retired mesh analyzer; the three headline castability
+  guarantees are re-pinned on `analyze_field`, which the doctrine already says is the verdict.
+- [ ] **M10.3 Numbers that are not true** (M, #171). F58, F83, F91, F105, F109, F110, F143, F144, F147,
+  F151. Crowding and run bridges against `min_section_mm` at all five call sites — `spec.rs` and
+  `stonemap.rs` included, or the sheet and the setter's map disagree; the transposed `Flutes`
+  footprint, which lets reeding evade the arc-scale correction entirely; `edge_mm` discarding
+  contrast and bias; the flat square-edged shank every new lofted signet now gets, which makes a
+  shipped M0.4 accept criterion false; tiling DFM ignoring the shank modulation; `RingSize::display`
+  printing "US 7."; a shrink-scaled export labelled with the nominal size; an inside diameter that
+  is measured rather than echoed; the SDF re-baked when `edge_mm` changes.
+- [ ] **M10.4 Stop losing work** (M, #172). F152, F153, F154, F163, F164, F165, F167, F203. Embedded
+  alphas unpacked on session restore and not only on File▸Open; undo re-bakes drawn, text and SVG
+  alphas, so painted metal stops surviving Ctrl+Z; an atomic design write with one backup; alpha
+  name collisions between two designs in one session; the build worker restarts after a panic
+  instead of leaving the app read-only; a cap on what a design file may rasterize at load — the
+  67 GB lesson, applied to the other door; `FORMAT_VERSION` unfrozen; profile and outline library
+  files get a version.
+- [ ] **M10.5 Nothing non-finite leaves the app** (S–M, #173). F149, F150, F156, F196, F197. The
+  `is_finite` guard `mesh::build` lacks and its three sibling consumers already have — one line,
+  and it ships before the refactor, not behind it; then the four displacement copies become one
+  function with refine pinned against the sweep; `whole_faces` requires finite vertices, which
+  fixes STL, OBJ and PLY at once and brings them in line with 3MF and GLB; `--steps` stops being
+  silently ignored; GUI export is gated on the verdict and on `hit_cap`/`saturated_leaves`.
+- [ ] **M10.6 CI and the golden corpus** (M, #174). F155, F128, F139, F223. GitHub Actions running the
+  workspace build, the wasm check and the test suite under the cgroup memory guard — this machine
+  has no swap and the guard is not optional; a golden corpus pinning verdict, volume and thinnest
+  wall for every template and showcase design, so a silent geometry regression fails something;
+  the size run re-checks stones and DFM per size instead of gating on the field verdict alone; the
+  kiosk refuses what the graph sinks refuse.
+- [ ] **M10.7 Hygiene and the hot path** (M, #175). F17≡F30, F19, F81, F157, F158, F159, F160, F161,
+  F162, F172. The two disagreeing hard wall floors; the build's wall clamp divorced from the
+  fill floor; `Alpha::make_seamless` is dead code and CLAUDE.md calls it the import mechanism;
+  stop cloning the whole design per layer inside undercut attribution; resolve each layer's alpha once per build
+  instead of once per sample; cut `outline.rs` out of `field.rs` and `signet.rs` out of
+  `profile.rs`; `sizing.rs` gets tests and a range guard — it is the only core module with none;
+  CLAUDE.md's head-draft numbers contradict the code and themselves; track `tools/harvest/`, which
+  is the evidence for the doctrine and is gitignored; the default band is a HalfRound the doctrine
+  itself says "honestly has no side".
+
+## M11 — The band has a thickness across it, too (L, 20 findings, epic #155)
+
+Accept: an axial web is reported per slice beside `thinnest_wall_mm`; two opposing 0.9 mm
+side-face carves on a 2.0 mm band report a 0.2 mm web and fail; the openwork cap on a side face is
+bounded by that measure instead of by `keep_mm`.
+
+- [ ] **M11.1 The axial web** (L, #176). F115≡F4≡F226≡F47. `min_local_thickness_mm` and its (theta, v) on
+  `FieldReport`, computed in `analyze_field`'s per-slice loop from the closed `Section` polygon it
+  already builds — the minimum over surface-sample pairs whose connecting segment stays inside the
+  loop — gated on `min_section_mm` alongside `thinnest_wall_mm`. `stones::check_seat` already reads
+  across the band on a side face; generalize that idea rather than inventing one. Then give
+  `OpenworkLayer` and `FlutesLayer` a real cap on side faces, where `depth_mm` is currently the only
+  limit and a carve can drive the low face past the high one unnoticed.
+- [ ] **M11.2 Measure what was built, not the bare profile** (M, #177). F66, F72. The seat report samples
+  `profile.sample_mod` with no layers evaluated, so a seat over a carve over-credits its metal; a
+  bezel's collar wall and a pad's prong post are never checked against the sand's detail floor.
+- [ ] **M11.3 Strength is not fill** (M, #178). F118≡F136, F130, F140, F141. Every wall number answers
+  "will the sand fill this?" and none answers "will this survive a week on a hand?" — a 6 × 0.8 mm
+  sterling band fields 0.000% and bends out of round in a month. `modulus_scan` already walks every
+  section polygon; add the second moment in the same loop, reduce to an equivalent radial thickness
+  over the palm arc, and report it against a per-alloy floor. Never gate — a wire ring is
+  legitimate. Plus wearability (a proud prong catches), balance (a heavy head spins on the finger),
+  and the wear floor under a culet, which is currently `MIN_WALL_MM` — a mould constant doing a
+  second job.
+- [ ] **M11.4 Section ratio, and relief that stands on a wall** (M, #179). F3, F11. A thin shank feeding a
+  heavy head shrinks porous at the junction and nothing flags the progression; nothing tells a user
+  their relief walls are vertical, and the fix that exists is wired to one layer type.
+- [ ] **M11.5 Undercut, said usefully** (M, #180). F120≡F178, F121, F122. Attribution names the culprit
+  layer and stops at "muting it clears it" — but muting is not a fix, and the largest relief that
+  still clears is a monotone one-dimensional bisection over ten field passes. The in-flight
+  `dfm::fit_to_floor` is the precedent, and its own test is named *the solver is the checker read
+  backwards*. Also: severity by depth and angle rather than an area fraction, so a sand-tearing
+  gouge and a burnishing drag stop reading alike; cluster in `v` as well as theta; locate drag.
+- [ ] **M11.6 Corners and fins** (M, #181). F126, F10≡F116. A sharp internal corner in the metal is a
+  sharp external edge in the sand: it erodes under the pour and is a stress riser in wear, and the
+  doctrine asks for a radius repeatedly without measuring one. And DFM measures how *wide* a feature
+  is and never how *deep*, so the fin aspect ratio — the thing that decides whether a stroke washes
+  out of the mould, and whether polish will eat it — cannot be computed.
+
+## M12 — Draw the plan, notch the band (M, 19 findings, epic #156)
+
+The cheapest visible variety win: no new subsystem, nearly all S/M, and it widens the shop window
+on three axes at once. Accept: a head plan is drawn or imported without touching the graph and
+saved to the outline library; a `ShankKey` axial offset produces a notched band; "14 × 12 head on a
+3 mm shank" is typed in millimetres and printed on the sheet; a milgrain row holds its inset from
+the band edge to within 0.05 mm across a size 5→9 run.
+
+- [ ] **M12.1 A head plan without the graph** (M, #182). F100≡F175≡F187, N7. `CustomOutline::from_svg` and
+  `from_alpha` beside the existing `from_points`, so the recentre/raycast/rolling-ball containment
+  guarantee and `fair_r_for(hull_defect(..))` are inherited on every path rather than re-proved; the
+  missing `library::save_outline` wrapper over the dead `save_outline_in`; an Import/Draw button
+  beside the Face combo; MCP `import_outline`; a CLI verb; and a reference-image underlay with
+  two-point millimetre calibration, which is how a sketch becomes a plan in the first place. Fix
+  CLAUDE.md in the same change — it already claims these imports exist.
+- [ ] **M12.2 The axial keyframe** (M, #183). F40, F45. `ShankKey::z_offset_frac`, carried as a fourth
+  Catmull-Rom channel through `ShankStyle::modulation` into `ShankMod::z_center_frac` under Wave's
+  measured 0.6-of-half-width cap. `width_scale` plus the offset place the two band edges
+  independently, which is the contoured / notched / chevron wedding band — the largest bridal
+  category after the engagement ring, off one serde field. Ship two presets. And rebuild
+  `ShankKind::Cathedral`, which today is a shoulder swell and nothing else, as a crest rise plus a
+  bore lift plus a shoulder arc — `SignetHead::hollow_mm` already casts exactly that void through
+  `ShankMod::bore_lift_mm` with the field clean.
+- [ ] **M12.3 The groove leaves Split** (S–M, #184). F48, F51. `ShankMod::side_groove_mm` is consumed with
+  its own cap and only `Split` and `Bypass` ever set it. Promote it to the band with a position
+  along the wall, a width and a count: the grooved, stepped and double-rail men's band family,
+  already proved to field 0.000% because a groove's floor faces along the pull and its walls stand
+  radial. Inlay channels come with it as a concept — a material, a fill volume, and the honest note
+  that the retention undercut is a bench cut.
+- [ ] **M12.4 Placed relative, not absolute** (M, #185). F49, F113, F148, N10. `MilgrainLayer::v_mm` and
+  `BorderLayer::v_mm` are absolute millimetres in the reference chart, so a beaded edge cannot
+  follow the band's edge; shoulder windows are hand-typed degrees that go stale the moment the head
+  moves; angular windows drift against millimetre-placed ornament across a size run or a matched
+  pair. And one boolean over the chart's `u` mirrors a design for the left hand.
+- [ ] **M12.5 Say it the way a jeweller says it** (S, #186). F102, F103, F104. A signet is "14 × 12 on a
+  3 mm shank" and the app cannot express it — the head's extent across the band *is*
+  `profile.width_mm`. Add millimetre authoring, the trade head-size table to suggest from (8×6
+  child, 10×8 / 11×9 / 12×10 ladies, 13×11 / 14×12 / 16×14 gents), and state the head on the sheet,
+  which today prints everything about the band and nothing about the ring.
+- [ ] **M12.6 Head dressing** (M, #187). F99, F101, F112. Milgrain, rope and bright-cut borders around the
+  head's rim, following the outline — this is *cast* relief needing only M12.4's edge-relative
+  placement, and must not be bundled with the bench-stage seal work in M14 or it waits three
+  milestones for nothing. Plus head rotation in plan, and the stepped, bevelled and bordered table
+  treatments the family stops short of.
+- [ ] **M12.7 Shapes as assets** (S, #188). F55≡F237, F57. `ShankKind::Keyframes` is the most expressive
+  shank in the model — the cloud ring is one — and an authored band shape can be neither saved,
+  shared, nor built from the graph. And a Claddagh, a class ring and a crest ring have every piece
+  they need and no path and no example.
+
+## M13 — The first ten minutes (M, 10 findings, epic #157)
+
+Accept: a new install opens on a visual gallery, at least three shipped templates carry stones,
+every user library has one browser, Ctrl+S saves the file it opened, and the phone has design-level
+undo. Owns F56, F171, F173, F174, F176, F181, F184, F185, F239, F240, plus **N1** (nothing is ever
+shown at actual size — no life-size lock, no DPI calibration, no scale reference in any render).
+The load-bearing ones: there is no Help and nowhere the sand doctrine is explained once (F171); the
+user owns seven kinds of library and only alphas have a browser (F176); a fresh machine gets 28
+procedural patterns, 9 templates, 2 clusters and 2 presets, and the shippable libraries cannot grow
+(F240).
+
+## M14 — Cast is a stage; bench is the next one (L, 12 findings, epic #158)
+
+The single largest multiplier in the audit, and it must land after M11: a bench cut removes metal,
+and the wall it must leave is the axial one. Accept: `LayerEntry::stage` is `Cast | Bench`,
+serde-defaulted to `Cast` so no file migrates; a Bench entry is skipped by `analyze_field` and
+`dfm::findings` but drawn in the viewport and the unrolled editor; a mirrored intaglio on a 12 mm
+head renders its own wax negative; the engraver's sheet prints artwork mirrored at 1:1 with a depth
+column, built the way `stonemap.rs` builds the setter's.
+
+Owns F93≡F77 (the stage itself, first), F94 (intaglio: mirrored, recessed, wax-releasing — `grep -i
+intaglio` across all crates returns nothing today, and `Alpha::flipped` already exists and is
+tested, so the mirror is a bake-time flip rather than a sampling change), F95 (the wax-impression
+preview), F96 (the engraver's sheet), F97 (monogram layout and engraver's alphabets), F98 (a crest
+library), F86 (curve wires have one constant width — no swell, no graver-angle V), F79 (surface
+finish is not modelled: the only `Finish` in the codebase is a viewport RGB triple, and a bright-cut
+or matte face is applied after the pour, so it is a bench attribute), F89 (paint mode has no guides
+and a subtly elliptical brush), F90 (two bundled fonts, no user font), F108 (the brush refuses the
+table and can only raise).
+
+## M15 — The inside of the ring is a surface (L, 6 findings, epic #159)
+
+The largest duplicate cluster in the audit — five dimensions independently found that nothing can
+exist on the inside of the ring (F41≡F78≡F111≡F220≡F224). Accept: `v` runs through the bore; a
+0.15 mm inside inscription on a 1.6 mm band leaves a web the verdict reports; the bore still reads
+as vertical wall throughout, because a bore surface's normal is radial at any radius; and both bore
+edges carry a ≥0.2 mm break by default (F135, **N9** — the reference signet has them, and a sharp
+arris at the bore is the commonest complaint about a shop-made band).
+
+The honest part: almost nothing on the bore is castable. The sand column in the finger hole is one
+rigid piece pulled along Z, so any pocket or ridge locks it. So the inside surface is built as
+**bench** geometry (M14's stage), not as a new cast region — an inside inscription is cut or lasered
+after casting anyway. Plus **N5**, the punch check: you cannot strike a hallmark into a 1.0 mm shank
+without bellying the ring, you need a flat land about 2.5 mm wide, and the app knows the wall
+thickness at every angle and never says it. No competitor makes that check.
+
+## M16 — Patterns get knobs and a seed (L, 14 findings, epic #160)
+
+Accept: every one of the 28 builtins exposes its defining parameter plus a seed; the same seed
+rebuilds byte-identical geometry; `every_pattern_tiles_seamlessly` sweeps the parameter ranges;
+mask booleans and mm-true morphology exist; and a rope rail measures a real over/under stroke
+≥ `min_detail_mm` at 2.7 mm cells.
+
+Owns F82 (`draft_limited` is a destructive one-shot bake rather than a layer property), F75 (all
+28 generators have their defining parameter hardcoded — Rope is always 3 cords and 6
+twists, Starburst always 24 rays, and the noise patterns call `hash01`/`fbm` with literal seeds, so
+there is exactly one Hammered texture in the world), F76 (wire `dfm::fit_to_floor` — the in-flight
+work — so the app can *fix* the mush finding it already prints), F80 (the graph has six alpha
+sources and zero operators), F82, F84, F85≡F232 (`BorderProfile::Rope` is a fake rope and its own
+comment says so), F87, F88, F177 (the tiling editor never shows the cell size in millimetres, which
+is the one number the sand cares about), F233, F234 (the cluster publish loop is dead code — nothing
+can publish a cluster or a preset), F235 (no node anywhere emits a `Path`, though four pins take
+one), F236 (no seeded randomness anywhere in the product).
+
+## M17 — Many combinations, one grid (L, 7 findings, epic #161)
+
+The literal answer to "many combinations", built after M12 and M16 have given it axes. Accept: a
+variant grid renders with stones in the chosen metal, each cell carrying its own field verdict
+encoded by shape as well as hue, with the size ladder available as an axis.
+
+Owns F168 (the app's whole comparison story is one manually-pinned translucent ghost;
+`examples/gallery.rs` already builds N designs, renders each and judges each — lift that loop into
+a pane rather than writing it twice), F183 (the size run is a variant axis: do not build the batch
+runner twice), F169 (hero renders and turntables leave the stones out, though `render.rs` was
+deliberately given a `Part` list because "a finished piece is metal *and* stones"), F170 (the
+casting sheet has no picture of the ring), F182 (the verdict is carried by colour alone, in red and
+green — a grid of thumbnails is exactly where hue-only encoding fails), F214 (the renderer cannot
+produce a product listing image), plus **N1**'s scale reference.
+
+## M18 — The sand is a recipe, not three numbers (L, 17 findings, epic #162)
+
+Accept: `SandProcess` is a serde field on `DraftSettings` with a cited source per number;
+`pattern_scale` differs by process; the design carries its intended metal; and the casting sheet's
+subtitle is derived rather than hardcoded "sand-cast pattern".
+
+Owns F6, F7 (the whole sand is three scalars asserted without a measurement, in a codebase that
+cites every other constant), F8 and **N8** (`metal.rs` models weight and shrink, not casting
+behaviour — and the fill floor is a property of the *pair* (sand, alloy, pour temperature): bronze
+fills sections sterling will not), F9≡F117 (no finishing stock: the verdict judges as-designed while
+the shop polishes 0.05–0.1 mm off, which is exactly the height of a milgrain bead), F12 (no venting
+or blind-pocket reasoning), F15≡F26 (the sheet is a sand document on every lost-wax print), F20 (say
+plainly what LostWax changes, because today it is four lines), F24 + F129 + F217 (the process is
+unreachable from the desktop's collapsed panel, from MCP, and from the kiosk — ship all three
+together or the field gets three treatments), F27 and **N3** (the sand patternmaker's allowance
+applied to a wax is about half a ring size of error, and a repeat-production master needs the whole
+ladder: master → rubber → wax → investment → metal, compounded), F31, F50, F192≡F209 (the design
+cannot say what metal it is, so the sheet cannot name one).
+
+## M19 — Gate it, sprue it, ram it up (XL, 13 findings, epic #163)
+
+The foundry half, after M18 has sourced the sand it would otherwise calibrate against. Accept: the
+app names a sprue diameter, a gate angle and a riser from the modulus scan; states pour weight in
+grams *and* dwt including sprue and button against finished weight; exports a pattern with a stub
+and a parting register beddable to a stated depth; and records an actual pour against its predicted
+verdict.
+
+Owns F1≡F124≡F242 (the gating plan — `modulus_scan` computes the whole solidification curve 64
+times per build and survives as one grey label; gate a signet at the shank and the head it already
+knows freezes last comes out spongy under the engraving), F2 + F18 (pour weight and yield: the sheet
+explicitly disclaims sprue, button and finishing loss and then computes none of them), F13≡F201 (the
+export is a ring, not a pattern: no sprue stub, no parting register, no handling boss, no print
+orientation), F14, F16, F28, F29, F119 (the parting surface is one flat `z` though `parting_line`
+already computes the contoured one), F221 (**the moat**: nothing records an actual pour against a
+predicted verdict — the claim is entirely internal), plus **N2**, the stock list and stretch-out:
+cut length is `π(ID + t)` and the app knows both exactly at every angle, and it is the most-used
+calculation at a bench.
+
+## M20 — A stone is stock with a species (XL, 22 findings, epic #164)
+
+Accept: a stone has a species with its own density and hardness; calibrated stock is quoted L×W;
+a pear's seat follows its own girdle instead of a symmetric superellipse; a half-eternity is
+authored as an arc of eleven rather than a full ring of twenty-two cropped; and the setter's sheet
+gives a bur size per seat.
+
+Owns F59≡F193 (there is no material anywhere — no grep hit for ruby, sapphire, Mohs or hardness —
+so a 6 mm sapphire cabochon reports 14% light, a CZ 62% light, and the report cannot say the one
+thing that destroys stones: the default seat style is a gypsy mound, and flush-setting an emerald is
+how you lose a client's stone), F42 and F43 (a windowed run fades its end stones' *stock* instead of
+ending the row, and every row is solved over the full 360°), F44≡F230 (no pearl — a half-drilled
+pearl on a cup and peg is one of the commonest jobs at a bench and the model refuses it), F52≡F63 (a
+channel-set ring reports no stones at all), F60, F61, F64≡F243, F65, F67 and F229 (the setter is
+handed no bearing angle, bur size, seat depth or proud height), F68≡F231, F70, F71, F73 (**the
+refusal registry** — the honest no, generalised from the two places the app already does it well),
+F74, F211, plus **F62 bar setting, which the finding itself says is provably castable in a two-part
+mould — build it rather than refuse it.**
+
+## M21 — A size is a fit, not a number (M, 11 findings, epic #165)
+
+Accept: the app accepts US, UK, EU or a measured millimetre; compensates a wide comfort-fit band by
+the trade's convention; re-solves every generator on a size change; prints a calibrated sizer at
+1:1; and takes a bangle at 60–70 mm.
+
+Owns F132 (the bore is the stated size, full stop — and the two terms pull in *opposite* directions:
+a wide standard-fit band runs tight so the cut bore goes up, while a comfort-fit dome rides easier
+so it goes down. The configurator makes it concrete by giving a 14 mm signet the same bore as a 4 mm
+court band), F133≡F142≡F228, F134 (comfort fit is a constant rise, so its feel changes with band
+width), F137 (nothing reasons about whether a design can be resized — a full eternity cannot), F138
+(a size change never re-solves stone spacing or live generators, across a 20% circumference change
+from size 5 to 9), F145≡F215, F146, F227 (**bangles are an `S` hiding in a `high|M`** — the sweep
+already works at 60–70 mm; it is a range check on `RingSize`. Do not merge this with M22's torus
+work or a one-day win is buried under a multi-week one).
+
+Land this after M10.6: wide-band compensation silently changes the bore of every existing design,
+and without the golden corpus the regression is invisible.
+
+## M22 — More than one body (XL, 19 findings, epic #166)
+
+Accept: the shipped default build reaches Free mode with no C++ toolchain; a Free-mode body gets a
+manufacturing verdict before any sink writes; the kernel sweeps a section along a path; and a mask
+pierces a band clean through with the web measured either side.
+
+Owns F33 (**Free mode is unreachable from the shipped application** — `ringdesign-gui` declares
+`default = []` and nothing in any UI ever sets `Mode::Free`; a whole documented, tested mode ships
+dark, which is the worst of the three available answers), F34, F35 (a Free-mode ring gets no
+verdict at all — `judge()` returns `Ok(None)` and every file sink writes whatever it is handed),
+F36 (twelve primitives and one hand-ported vine), F37≡F205 (the mesh importer welds on exact float
+bits, so it rejects most real-world STLs), F38, F39, F32≡F92≡F225 (piercing — stated precisely: a
+hole whose axis is ±Z casts, a hole through the band's thickness is a horizontal core and does not),
+F46 (assembly: spinner, puzzle, ring guard, stacking set, matched pair), F53 (**open, adjustable and
+cuff rings are not a casting problem** — a C-shaped band with a domed section pulls fine; it is that
+`mesh::build` hard-wires a closed torus), F54≡F69 (free-standing prong heads, baskets, peg heads,
+six-claw, tension — all need a void under the girdle that no single ±Z plane clears; these belong to
+lost wax, said out loud through M20's refusal registry), F106 (head and shank as different stock —
+the missing fourth signet construction), F107, F238 (the kernel has no loft and no sweep, the one
+primitive every reference body is built from).
+
+## M23 — The shop floor: quote it, order it, catalogue it (XL, 15 findings, epic #167)
+
+Accept: a quote states metal, stones, labour and yield; two orders from the same customer never
+collide; a kiosk order reaches the shop; and every catalogue entry is a record with an id, not a
+Rust literal.
+
+Owns F206 (an order overwrites the last one from the same customer — the slug is the name, the
+filenames are constants), F207 (the web configurator hands the customer a zip and stops: no
+submission, no contact, no price, no conversion event), F208 (an order records unstable ordinals, so
+an old order decodes to a different ring), F210≡F125 (price is `per_gram × casting_weight`
+everywhere; a real quote is metal at *pour* weight + loss + stones + casting + cleanup + setting per
+stone + polishing + plating + margin, and every input already exists), F212 (there is no catalogue —
+five hand-written collections in Rust, none of them a product with a SKU, a variant axis or a
+price), F179, F180, F198, F199, F213, F216, F218 (no production planning: nothing knows what pours
+together), F219 (no pattern inventory — a sand shop's real capital is its stock of rigid patterns),
+F222 (the sheet is not a record: no date, no identity, no digest), F131, plus **N4**: the trade
+quotes in pennyweight and spot is per troy ounce, and there is no melt/alloy calculator for the
+commonest torch-side job there is.
+
+## M24 — File doors (L, 11 findings, epic #168)
+
+Last, because it exports what the earlier milestones made true. Accept: STEP comes out of the swept
+grid; a 1:1 plan, section and unrolled band as DXF; MCP works over HTTP with no server-side paths;
+and the deviation probe is a core measurement rather than a gitignored script.
+
+Owns F186 (**STEP** — every 3D writer in the tree is a triangle writer, and a mesh ring arrives at a
+casting bureau or CNC house as something they cannot fillet, section or resize. Our surface is a
+regular closed lattice in both directions, so one `B_SPLINE_SURFACE_WITH_KNOTS` closed in u and v
+needs no trimming curves, no seam edges and no caps — hand-rolled ISO 10303-21 the way `threemf.rs`
+hand-rolls its zip), F188, F189 (MCP is missing most layer kinds and every generator), F190≡F241
+(reference-mesh import and deviation are gitignored Python, though they are the measurement that
+settled the whole lofted-head port), F191 (no 1:1 drawings of the ring at all), F194, F195, F200
+(Rhino `.3dm` is in this repo as data and as a Python dependency and not at all as a capability),
+F202, F204, plus **N6**: no document declares which way is up. One arrow — "top toward fingertip",
+seam at `TOP_DEG` — on every printed sheet.


### PR DESCRIPTION
Tracking only — no code changes. `git diff --stat` against master is three files, all docs.

## What this is

A 26-agent audit of the app: thirteen domain auditors reading the tree from a bench jeweller's and a foundry hand's chair (sand process, lost wax, ring typology, stone setting, ornament, signet heads, DFM, sizing, code, UX, interop, business, competitor parity), each finding then handed to an adversarial verifier whose brief was to stop a false "we are missing X" from reaching the roadmap. **243 findings, none dropped as already-existing.** Three were re-checked by hand against the tree and all three held exactly as reported.

## The six-sentence verdict

1. **The pull is world-class; everything after the pull is missing.** `analyze_field` answers "will it release" better than a person can. Nothing says where to gate, how much to melt, what polish eats, or whether the ring survives a week on a hand.
2. **The verdict states numbers that are not true.** `CastProcess::apply` has no else arm, so Lost wax → Sand keeps the investment floors and the ring still reads Castable. Crowding is judged against a hardcoded `CROWD_TIGHT_MM = 0.3` against a Delft floor of 0.8. The report panel prints the *retired* mesh analyzer's numbers under the field verdict's banner. And there is no CI: 474 tests, no `.github`.
3. **The model has one stage where the trade has two.** Every layer is cast geometry judged against the sand's detail floor, so bright-cut, wriggle, guilloché, inside lettering and intaglio seals are refused or measured as mush.
4. **Both wall measures are radial.** Four dimensions independently found that nothing measures metal *across* the band — exactly where the doctrine sends every deep carve.
5. **`sizing.rs` is 54 lines, US-only, zero tests**, with no wide-band and no comfort-fit compensation.
6. **Lost wax is four lines and Free mode ships dark** — `ringdesign-gui` declares `default = []`.

## What lands

- `docs/AUDIT-2026-08-30.md` — every finding with the file and symbol it was read from, the verifier's note and the corrected recommendation. Findings are cited as `F<n>` so they do not auto-link to unrelated issues.
- `docs/ROADMAP.md` — M10–M24 with dependency edges and accept criteria. The M9 parking lot is closed: every Shelf and Nicety item now has a milestone.
- `CLAUDE.md` — the two doctrine-level facts, recorded because a reader of that file would otherwise assume both are handled.

## Tracking

15 milestones M10–M24, 15 epic issues (#154–#168) carrying all 243 findings, and 20 task-group issues (#169–#188) for the first three milestones — the shape used for M0–M2. The concurrent core audit's 53 implementation tickets (#102–#153) are merged into the epics as work-item checklists, each naming the finding it closes; four were re-filed to the milestone that owns their finding, and #101 was already closed as a duplicate of #169.

Sequence is **truth (M10) → measure (M11) → variety (M12)**. The gating plan sits in M19 rather than M10 despite being critical: every input exists but they are calibrated against three unsourced sand constants, so a gate advisor shipped now manufactures a confident wrong number at the flask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)