### PR TITLE
The process switch tells the truth

### DIFF
--- a/crates/ringdesign-core/src/castability.rs
+++ b/crates/ringdesign-core/src/castability.rs
@@ -49,8 +49,13 @@ pub struct DraftSettings {
     /// Thinnest section that will reliably fill, mm.
     pub min_section_mm: f64,
     /// Smallest surface feature the sand reliably reproduces, mm. Beads,
-    /// cells and wires under this cast as mush; the per-layer DFM checks
-    /// read it.
+    /// cells and wires under this cast as mush.
+    ///
+    /// **Read by [`crate::dfm`], never by the verdict.** A feature under this
+    /// floor casts soft; it does not stop the mould opening or the metal
+    /// filling, so it is a finding on the layer that carries it and not a
+    /// term in [`analyze_field`]. Anything that tells a user detail *gates*
+    /// is wrong.
     #[serde(default = "default_min_detail")]
     pub min_detail_mm: f64,
     /// Which casting process the verdict judges against. Two-part sand is
@@ -58,6 +63,15 @@ pub struct DraftSettings {
     /// undercuts become information, and only fill and detail still gate.
     #[serde(default)]
     pub process: CastProcess,
+    /// The sand this design is judged for, once one has been named.
+    ///
+    /// `None` is the app's own floors rather than a shop's measured sand, and
+    /// is what a design saved before this field carried. It exists because
+    /// [`CastProcess::apply`] has to have something to restore: the floors
+    /// are overwritten on the way into lost wax, and without a record of what
+    /// they were, coming back leaves an investment verdict on a sand pour.
+    #[serde(default)]
+    pub sand: Option<SandProcess>,
 }
 
 /// The casting process a design is judged for.
@@ -84,14 +98,31 @@ impl CastProcess {
         }
     }
 
-    /// Write the process's fill and detail floors into the settings.
+    /// Write the process's draft, fill and detail floors into the settings.
+    ///
     /// Investment holds far finer detail than any sand and fills a thinner
-    /// section; the sand numbers come from [`SandProcess::apply`].
+    /// section. Going the other way restores the sand's own numbers — the
+    /// named sand in [`DraftSettings::sand`], or this type's defaults when no
+    /// sand has been named — so the round trip is the identity. It was not,
+    /// once: the investment floors were written on the way in and nothing on
+    /// the way back, so a design returned to sand kept a 0.5 mm fill floor
+    /// and a 0.15 mm detail floor and still read Castable.
     pub fn apply(self, d: &mut DraftSettings) {
         d.process = self;
-        if self == CastProcess::LostWax {
-            d.min_section_mm = 0.5;
-            d.min_detail_mm = 0.15;
+        match self {
+            CastProcess::LostWax => {
+                d.min_section_mm = 0.5;
+                d.min_detail_mm = 0.15;
+            }
+            CastProcess::SandTwoPart => match d.sand {
+                Some(sand) => sand.apply(d),
+                None => {
+                    let def = DraftSettings::default();
+                    d.min_draft_deg = def.min_draft_deg;
+                    d.min_section_mm = def.min_section_mm;
+                    d.min_detail_mm = def.min_detail_mm;
+                }
+            },
         }
     }
 }
@@ -109,12 +140,13 @@ impl Default for DraftSettings {
             min_section_mm: 0.7,
             min_detail_mm: default_min_detail(),
             process: CastProcess::default(),
+            sand: None,
         }
     }
 }
 
 /// The two sands this shop pours, as parameter presets.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SandProcess {
     /// Fine Belgian clay-bonded sand: excellent detail, wants a touch more
     /// draft and section than oil sand.
@@ -135,7 +167,7 @@ impl SandProcess {
     }
 
     /// Write this sand's numbers into the settings, leaving the parting
-    /// plane fields alone.
+    /// plane fields alone, and record which sand they came from.
     pub fn apply(self, d: &mut DraftSettings) {
         let (draft, section, detail) = match self {
             SandProcess::DelftClay => (3.0, 0.8, 0.30),
@@ -144,6 +176,7 @@ impl SandProcess {
         d.min_draft_deg = draft;
         d.min_section_mm = section;
         d.min_detail_mm = detail;
+        d.sand = Some(self);
     }
 }
 
@@ -516,6 +549,15 @@ pub fn analyze(mesh: &Mesh, settings: &DraftSettings, bore_radius_mm: f64) -> Ca
     };
 
     let mut notes = Vec::new();
+    // This is the face analyzer, kept for painting the viewport. It measures a
+    // ±Z pull whatever the process is, because that is the only question a
+    // face normal can answer — so under lost wax it has to say what it is
+    // reporting rather than assert a mould that is not being made.
+    if settings.process == CastProcess::LostWax {
+        notes.push(
+            "Lost wax: the numbers below measure a two-part sand pull, which is not the process this design is judged for. They say whether it *could* move to sand, nothing more.".into(),
+        );
+    }
     notes.push(format!(
         "Parting plane at z = {parting_z:+.2} mm{}: the cope pulls +Z off everything above it, the drag -Z off everything below.",
         if settings.auto_parting { ", chosen automatically" } else { "" }
@@ -976,6 +1018,11 @@ fn bore_span_wall(points: &[SectionPoint]) -> f64 {
 #[derive(Clone, Debug, Serialize)]
 pub struct FieldReport {
     pub verdict: Verdict,
+    /// The process this verdict was reached under. Carried because the
+    /// pull statistics mean different things either side of it: under lost
+    /// wax they are measured and reported and never gate, so a `Castable`
+    /// field report does *not* mean the surface clears a two-part pull.
+    pub process: CastProcess,
     /// Most negative draft found outside the bore, degrees.
     pub worst_draft_deg: f64,
     pub undercut_area_mm2: f64,
@@ -1029,6 +1076,7 @@ pub fn analyze_field(
     let t_n = theta_steps.clamp(24, 2048);
     let empty = FieldReport {
         verdict: Verdict::Castable,
+        process: settings.process,
         worst_draft_deg: 0.0,
         undercut_area_mm2: 0.0,
         marginal_area_mm2: 0.0,
@@ -1180,6 +1228,14 @@ pub fn analyze_field(
     } else {
         notes.push("Field-sampled: the surface itself carries no undercut at this parting.".into());
     }
+    if !lost_wax && drag_frac > DRAG_FRACTION {
+        notes.push(format!(
+            "{:.1}% of the surface carries less than {min_draft:.1} deg of draft or stands parallel to the pull ({:.1}% marginal, {:.1}% vertical). It releases, but it drags on the sand and will want a longer rap. Raise the crown or square the sides to steepen it.",
+            drag_frac * 100.0,
+            frac(marginal_area) * 100.0,
+            frac(vertical_outer_area) * 100.0
+        ));
+    }
     let min_section = settings.min_section_mm.max(0.0);
     if thinnest > 0.0 && thinnest < min_section {
         if verdict == Verdict::Castable {
@@ -1193,6 +1249,7 @@ pub fn analyze_field(
 
     FieldReport {
         verdict,
+        process: settings.process,
         worst_draft_deg,
         undercut_area_mm2: undercut_area,
         marginal_area_mm2: marginal_area,
@@ -1438,6 +1495,110 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+
+
+    /// The floors are overwritten on the way into lost wax, so leaving it has
+    /// to put them back or a sand pour is judged against investment numbers
+    /// and reads Castable while it short-pours. Both directions, both with a
+    /// named sand and without one.
+    #[test]
+    fn the_process_round_trip_is_the_identity() {
+        let mut d = DraftSettings::default();
+        let before = (d.min_draft_deg, d.min_section_mm, d.min_detail_mm);
+        CastProcess::LostWax.apply(&mut d);
+        assert_eq!((d.min_section_mm, d.min_detail_mm), (0.5, 0.15), "investment floors");
+        assert_eq!(d.process, CastProcess::LostWax);
+        CastProcess::SandTwoPart.apply(&mut d);
+        assert_eq!(
+            (d.min_draft_deg, d.min_section_mm, d.min_detail_mm),
+            before,
+            "an unnamed sand comes back to the app's own floors"
+        );
+        assert_eq!(d.process, CastProcess::SandTwoPart);
+
+        // With a sand named, it is that sand's numbers that come back — not
+        // the defaults, which are a different pair (0.7 / 0.35 against 0.6 / 0.40).
+        let mut d = DraftSettings::default();
+        SandProcess::Petrobond.apply(&mut d);
+        assert_eq!(d.sand, Some(SandProcess::Petrobond));
+        let sand = (d.min_draft_deg, d.min_section_mm, d.min_detail_mm);
+        assert_ne!(sand, before, "Petrobond is not the default");
+        CastProcess::LostWax.apply(&mut d);
+        CastProcess::SandTwoPart.apply(&mut d);
+        assert_eq!((d.min_draft_deg, d.min_section_mm, d.min_detail_mm), sand);
+        assert_eq!(d.sand, Some(SandProcess::Petrobond), "the sand survives the trip");
+    }
+
+    /// A design file written before `sand` existed must still load, and must
+    /// load as "no sand named" rather than as some default sand whose floors
+    /// are not the ones it was saved with.
+    #[test]
+    fn draft_settings_without_a_sand_still_load() {
+        let json = r#"{"parting_z_mm":0.0,"min_draft_deg":3.0,"auto_parting":true,
+                       "min_section_mm":0.7}"#;
+        let d: DraftSettings = serde_json::from_str(json).expect("an older file loads");
+        assert_eq!(d.sand, None);
+        assert_eq!(d.process, CastProcess::SandTwoPart);
+        assert_eq!(d.min_detail_mm, default_min_detail());
+        let round: DraftSettings =
+            serde_json::from_str(&serde_json::to_string(&d).unwrap()).unwrap();
+        assert_eq!(round.sand, None);
+    }
+
+    /// Under lost wax the verdict is Castable whatever the pull says, so the
+    /// report has to carry the process — otherwise every consumer renders
+    /// "clears a two-part pull" over a ring that does not.
+    #[test]
+    fn a_lost_wax_report_says_which_process_it_judged() {
+        use crate::alpha::AlphaLibrary;
+        let lib = AlphaLibrary::builtin();
+        let mut d = crate::RingDesign::default();
+        CastProcess::LostWax.apply(&mut d.draft);
+        let f = analyze_field(&d, &lib, &d.draft, 96, 48);
+        assert_eq!(f.process, CastProcess::LostWax);
+        assert!(
+            f.notes.iter().any(|n| n.starts_with("Lost wax:")),
+            "the notes name the process: {:?}",
+            f.notes
+        );
+        // And a sand judgement of the same ring carries the other one.
+        let mut sand = crate::RingDesign::default();
+        CastProcess::SandTwoPart.apply(&mut sand.draft);
+        assert_eq!(analyze_field(&sand, &lib, &sand.draft, 96, 48).process, CastProcess::SandTwoPart);
+    }
+
+    /// Drag alone can drop the verdict to Marginal. It used to do so in
+    /// silence, directly under a note saying the surface carries no undercut,
+    /// which reads as a bug in the app rather than a property of the ring.
+    #[test]
+    fn drag_explains_itself() {
+        use crate::alpha::AlphaLibrary;
+        let lib = AlphaLibrary::builtin();
+        // A squared band is nearly all wall parallel to the pull: it releases,
+        // and it drags.
+        let mut d = crate::RingDesign::default();
+        d.profile.apply_style(crate::ProfileStyle::Flat);
+        d.profile.width_mm = 6.0;
+        d.profile.thickness_mm = 2.0;
+        d.profile.flatten_sides();
+        let f = analyze_field(&d, &lib, &d.draft, 192, 96);
+        let dragging = (f.marginal_area_mm2 + f.vertical_area_mm2) / f.total_area_mm2.max(1e-9);
+        if dragging > DRAG_FRACTION {
+            assert!(
+                f.notes.iter().any(|n| n.contains("drags on the sand")),
+                "a dragging ring says so: {:?}",
+                f.notes
+            );
+        }
+        // Whatever this particular band measures, the note and the verdict
+        // must agree with each other.
+        if f.verdict == Verdict::Marginal {
+            assert!(
+                f.notes.len() > 1,
+                "Marginal is never reported with nothing but the clean-surface note"
+            );
+        }
+    }
 
     use super::*;
     use crate::field::{Layer, LayerEntry, SeatPadLayer};

--- a/crates/ringdesign-gui/src/panels/design.rs
+++ b/crates/ringdesign-gui/src/panels/design.rs
@@ -1222,12 +1222,14 @@ fn casting(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
                 .on_hover_text(match p {
                     CastProcess::SandTwoPart => {
                         "Two-part sand: the verdict enforces the +/-Z pull — undercuts \
-                         and drag gate castability."
+                         and drag gate castability, and so does the fill floor. Detail \
+                         is measured per layer and reported, never gated."
                     }
                     CastProcess::LostWax => {
                         "Lost wax: the investment burns out of any surface, so the pull \
-                         statistics report but never gate. Fill and detail still do. \
-                         Generators switch to their free-form variants."
+                         statistics report but never gate. Only fill still gates — detail \
+                         is reported per layer either way. Generators switch to their \
+                         free-form variants. Switching back restores the sand's floors."
                     }
                 })
                 .clicked()
@@ -1244,8 +1246,11 @@ fn casting(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
             ui.label(egui::RichText::new("Sand").color(crate::theme::TEXT_DIM));
             for p in ringdesign_core::castability::SandProcess::ALL {
                 if ui
-                    .button(p.label())
-                    .on_hover_text("Set min draft, section and detail to this sand's numbers.")
+                    .selectable_label(d.sand == Some(*p), p.label())
+                    .on_hover_text(
+                        "Set min draft, section and detail to this sand's numbers, and \
+                         record it on the design so leaving lost wax comes back to them.",
+                    )
                     .clicked()
                 {
                     p.apply(d);
@@ -1294,7 +1299,7 @@ fn casting(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
                 .text("Min section"),
         )
         .changed();
-    hint(ui, "Thinnest section the metal will reliably fill.");
+    hint(ui, "Thinnest section the metal will reliably fill. This one gates the verdict.");
 
     changed |= ui
         .add(
@@ -1306,7 +1311,8 @@ fn casting(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
         .changed();
     hint(
         ui,
-        "Smallest feature the sand reproduces; finer beads and cells cast as mush.",
+        "Smallest feature the sand reproduces; finer beads and cells cast as mush. \
+         Reported per layer as a DFM finding — it never gates the verdict.",
     );
 
     if changed {

--- a/crates/ringdesign-gui/src/panels/report.rs
+++ b/crates/ringdesign-gui/src/panels/report.rs
@@ -282,7 +282,16 @@ fn field_banner(ui: &mut egui::Ui, f: &ringdesign_core::castability::FieldReport
         Verdict::Marginal => icon::WARNING,
         Verdict::NotCastable => icon::X_CIRCLE,
     };
+    let lost_wax = f.process == ringdesign_core::castability::CastProcess::LostWax;
     let detail = match f.verdict {
+        Verdict::Castable if lost_wax && f.undercut_area_mm2 > 0.0 => format!(
+            "Fills, and burns out. {:.2}% of the surface would still lock a two-part pull, so this pattern cannot move to sand as-is.",
+            f.undercut_fraction() * 100.0
+        ),
+        Verdict::Castable if lost_wax => {
+            "Fills, and carries no undercut either — this would also pull from two-part sand."
+                .to_string()
+        }
         Verdict::Castable => "The surface itself clears a two-part pull.".to_string(),
         Verdict::Marginal => f
             .notes


### PR DESCRIPTION
Closes #169 (M10.1, first task group of #154 — *One verdict, spoken once*).

Five places the app said one thing and did another, all around the casting process. Findings F21≡F114, F22, F23, F25, F5 in `docs/AUDIT-2026-08-30.md`.

## The bug with teeth

`CastProcess::apply` wrote the investment floors on the way into lost wax and **nothing on the way back** — there was no `SandTwoPart` arm at all, and `min_draft_deg` was never written in either direction:

```rust
pub fn apply(self, d: &mut DraftSettings) {
    d.process = self;
    if self == CastProcess::LostWax {
        d.min_section_mm = 0.5;
        d.min_detail_mm = 0.15;
    }
}
```

So a jeweller who tried lost wax and came back to sand was judged for a sand pour against a 0.5 mm fill floor and a 0.15 mm detail floor, and `analyze_field` returned **Castable**. A 0.55 mm wall passed silently and short-pours in the flask.

Restoring the floors needs something to restore them *to*, so `DraftSettings` gains `sand: Option<SandProcess>` and `SandProcess::apply` records itself. `None` means the app's own floors rather than a shop's measured sand — which is exactly what every design saved before this carried, so an older file loads unchanged instead of acquiring a sand it was never judged for. `SandProcess` now derives serde; the sand picker became a `selectable_label` so the design's own record is visible where it is set.

## The other four

- **F22 — the banner contradicted its own note.** Under lost wax the verdict is `Castable` whatever the pull says, and every consumer rendered the Castable arm's fixed string: *"The surface itself clears a two-part pull"*, directly above a note saying 2% of it would not. `FieldReport` gains `process` so any consumer can render correctly without re-deriving it, and the desktop banner now reads it.
- **F5 — drag downgraded in silence.** `drag_frac > DRAG_FRACTION` drops the verdict to Marginal, and the only note printed was *"the surface itself carries no undercut at this parting"* — which reads as a bug in the app rather than a property of the ring. It now says what dragged, how much of it was marginal versus vertical, and what to do.
- **F23 — `analyze` spoke sand out loud.** It is the face analyzer kept for painting the viewport, and it measures a ±Z pull whatever the process is, because that is the only question a face normal can answer. Under lost wax it now says so first.
- **F25 — detail never gated, and the tooltip promised it did** (*"Fill and detail still do"*). Detail is a per-layer DFM finding: it makes a feature cast soft, it does not stop the mould opening or the metal filling. The doc comment on `min_detail_mm` and both slider hints now say which floor gates and which reports.

## Tests

Four new, in `castability::tests`:

- `the_process_round_trip_is_the_identity` — both directions, with a named sand and without. Asserts Petrobond's numbers come back rather than the defaults, which are a different pair (0.7 / 0.35 against 0.6 / 0.40), and that the sand survives the trip.
- `draft_settings_without_a_sand_still_load` — an older file's JSON deserialises to `sand: None` and round-trips.
- `a_lost_wax_report_says_which_process_it_judged` — the report carries the process and the notes name it, both ways.
- `drag_explains_itself` — a Marginal verdict is never reported with nothing but the clean-surface note.

## Verification

- `cargo test --workspace --offline` under `systemd-run --user --scope -p MemoryMax=4G`: **all green**, 333 core / 64 graph / 42 mcp / 31 gui, 0 failures. The byte-for-byte golden template tests are unaffected.
- `cargo check --no-default-features --target wasm32-unknown-unknown` passes for both `ringdesign-core` and `ringdesign-configurator`.

## Note on scope

`DraftSettings::sand` does part of F6's job (*the shop's sand is not part of the design record*, M18) because the round-trip fix has nowhere else to remember what to restore. Surfacing the sand downstream — on the casting sheet, in MCP, in the report — stays with M18 (#162).

Branched off `master`. The working tree carries another session's in-flight changes to `field.rs`, `curve.rs`, `dfm.rs` and two examples; none is committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)