### PR TITLE
Nothing non-finite leaves the app

### DIFF
--- a/crates/ringdesign-cli/src/main.rs
+++ b/crates/ringdesign-cli/src/main.rs
@@ -51,7 +51,7 @@ options:
   --shrink <metal>          cut patterns oversize for this metal's shrink
                             (sterling, bronze, 14k, ... — see the app's table)
   --out <dir>               output directory (default: beside the design)
-  --steps 1024x320          sweep resolution (default: the design's build)";
+  --steps 1024x320          sweep resolution; overrides a saved refine tolerance";
 
 fn run(args: &[String]) -> anyhow::Result<()> {
     if args.first().map(String::as_str) == Some("graph") {
@@ -150,6 +150,15 @@ fn export(
                     .ok_or_else(|| anyhow::anyhow!("--steps wants THETAxPROFILE, e.g. 1024x320"))?;
                 params.theta_steps = t.trim().parse()?;
                 params.profile_steps = p.trim().parse()?;
+                // A refine tolerance short-circuits the sweep in `mesh::build`,
+                // so a design carrying one swallowed this flag whole and wrote
+                // a file at a resolution nobody asked for. Naming a sweep
+                // resolution is asking for the sweep.
+                if params.refine.take().is_some() {
+                    eprintln!(
+                        "note: --steps asks for a swept build, so the design's refine tolerance is ignored for this run"
+                    );
+                }
             }
             other => anyhow::bail!("unknown option {other:?}"),
         }

--- a/crates/ringdesign-core/src/mesh.rs
+++ b/crates/ringdesign-core/src/mesh.rs
@@ -339,7 +339,12 @@ pub fn build(design: &RingDesign, lib: &AlphaLibrary, params: BuildParams) -> Bu
                 let h = if p.surface && p.weight > 0.0 {
                     let v_norm = p.v_mm / loop_i.surface_len_mm.max(1e-9);
                     let uv = Uv { u, v: v_norm * ctx.band_v_len_mm };
-                    soft_height(&design.layers, uv, &ctx, lib, params.soften_mm) * p.weight
+                    let h = soft_height(&design.layers, uv, &ctx, lib, params.soften_mm) * p.weight;
+                    // The other three consumers of this displacement already
+                    // do this; this is the one whose output is exported, and
+                    // a non-finite height here reaches the STL as NaN
+                    // coordinates in a file a caster hands to a slicer.
+                    if h.is_finite() { h } else { 0.0 }
                 } else {
                     0.0
                 };

--- a/crates/ringdesign-core/src/stl.rs
+++ b/crates/ringdesign-core/src/stl.rs
@@ -20,10 +20,21 @@ fn binary_header(name: &str) -> [u8; 80] {
 
 /// Faces whose three indices are all in range; a partial facet would corrupt
 /// the fixed 50-byte record stream.
+/// Faces whose three vertices all exist and are all finite.
+///
+/// STL, OBJ and PLY all write coordinates verbatim, so a non-finite vertex
+/// leaves the app as `nan` in a file a caster feeds to a slicer. 3MF and GLB
+/// have always dropped such faces; this is what brings the other three into
+/// line, and it is the last line of defence behind the guards in `mesh::build`,
+/// `refine::point` and `castability::section_at`.
 fn whole_faces<'a>(mesh: &'a Mesh) -> impl Iterator<Item = &'a [u32; 3]> {
-    mesh.faces
-        .iter()
-        .filter(|f| f.iter().all(|&i| (i as usize) < mesh.vertices.len()))
+    mesh.faces.iter().filter(|f| {
+        f.iter().all(|&i| {
+            mesh.vertices
+                .get(i as usize)
+                .is_some_and(|v| v.0.is_finite() && v.1.is_finite() && v.2.is_finite())
+        })
+    })
 }
 
 /// Serialize to binary STL with per-facet normals.
@@ -75,19 +86,29 @@ pub fn write_stl(path: impl AsRef<Path>, mesh: &Mesh, name: &str) -> anyhow::Res
     Ok(bytes.len())
 }
 
+/// A vertex list writes positionally, so a non-finite one cannot simply be
+/// dropped without renumbering every face. 3MF's rule is the one that works:
+/// write it as the origin and drop the faces that touch it, which keeps the
+/// indices stable and keeps `nan` out of the file.
+fn finite_or_origin(v: crate::mesh::Vec3) -> crate::mesh::Vec3 {
+    if v.is_finite() { v } else { crate::mesh::Vec3(0.0, 0.0, 0.0) }
+}
+
 /// Write an OBJ with smooth vertex normals, returning the byte count.
 pub fn write_obj(path: impl AsRef<Path>, mesh: &Mesh, name: &str) -> anyhow::Result<usize> {
     use std::fmt::Write;
     let mut s = String::with_capacity(mesh.vertices.len() * 40 + mesh.faces.len() * 30);
     let _ = writeln!(s, "o {name}");
     for v in &mesh.vertices {
+        let v = finite_or_origin(*v);
         let _ = writeln!(s, "v {} {} {}", v.0, v.1, v.2);
     }
     for n in &mesh.normals {
+        let n = finite_or_origin(*n);
         let _ = writeln!(s, "vn {} {} {}", n.0, n.1, n.2);
     }
     let has_normals = mesh.normals.len() == mesh.vertices.len();
-    for f in &mesh.faces {
+    for f in whole_faces(mesh) {
         let (a, b, c) = (f[0] + 1, f[1] + 1, f[2] + 1);
         if has_normals {
             let _ = writeln!(s, "f {a}//{a} {b}//{b} {c}//{c}");
@@ -111,24 +132,27 @@ pub fn write_ply(path: impl AsRef<Path>, mesh: &Mesh, name: &str) -> anyhow::Res
     if has_normals {
         header.push_str("property float nx\nproperty float ny\nproperty float nz\n");
     }
+    // The count is in the header, so the kept faces have to be known first.
+    let faces: Vec<&[u32; 3]> = whole_faces(mesh).collect();
     header.push_str(&format!(
         "element face {}\nproperty list uchar uint vertex_indices\nend_header\n",
-        mesh.faces.len()
+        faces.len()
     ));
     let mut out = header.into_bytes();
-    out.reserve(mesh.vertices.len() * 24 + mesh.faces.len() * 13);
+    out.reserve(mesh.vertices.len() * 24 + faces.len() * 13);
     for (i, v) in mesh.vertices.iter().enumerate() {
+        let v = finite_or_origin(*v);
         for c in [v.0, v.1, v.2] {
             out.extend_from_slice(&c.to_le_bytes());
         }
         if has_normals {
-            let n = mesh.normals[i];
+            let n = finite_or_origin(mesh.normals[i]);
             for c in [n.0, n.1, n.2] {
                 out.extend_from_slice(&c.to_le_bytes());
             }
         }
     }
-    for f in &mesh.faces {
+    for f in faces {
         out.push(3);
         for &i in f.iter() {
             out.extend_from_slice(&i.to_le_bytes());
@@ -143,6 +167,129 @@ mod tests {
     use super::*;
     use crate::mesh::{self, BuildParams, Vec3};
     use std::collections::HashMap;
+
+
+    /// A design file is data, and `opacity` and `height_mm` are unbounded
+    /// `f64`s read straight out of it. Two ways they reach a writer:
+    /// a NaN opacity makes the height itself NaN, and a merely enormous
+    /// height is a perfectly finite `f64` that overflows on the way to `f32`.
+    /// The first is caught in `mesh::build`, the second only at the writer —
+    /// so both are checked here, on every format that writes coordinates
+    /// verbatim.
+    #[test]
+    fn no_export_carries_a_non_finite_coordinate() {
+        use crate::field::{BorderLayer, BorderProfile, Layer, LayerEntry};
+
+        let hostile = |opacity: f64, height_mm: f64| {
+            let mut d = crate::RingDesign::default();
+            let mut e = LayerEntry::new(
+                "hostile",
+                Layer::Border(BorderLayer {
+                    v_mm: d.field_context().band_v_len_mm * 0.5,
+                    width_mm: 0.8,
+                    height_mm,
+                    profile: BorderProfile::Round,
+                    mirror: false,
+                    rope_twists: 0,
+                }),
+            );
+            e.opacity = opacity;
+            d.layers.layers.push(e);
+            let lib = crate::AlphaLibrary::builtin();
+            let params = BuildParams { theta_steps: 64, profile_steps: 48, ..Default::default() };
+            mesh::build(&d, &lib, params).mesh
+        };
+
+        let dir = std::env::temp_dir().join("ringdesign-finite-test");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // `mesh::build` zeroes a non-finite height, so a NaN opacity produces a
+        // clean mesh; an overflowing height is finite as an `f64` and only goes
+        // bad in the cast to `f32`, so that one must reach the writers dirty or
+        // this test is checking nothing.
+        let overflow = hostile(1.0, 1e308);
+        assert!(
+            overflow.vertices.iter().any(|v| !v.is_finite()),
+            "the overflow case must actually put a non-finite vertex in the mesh"
+        );
+        assert!(
+            hostile(f64::NAN, 0.4).vertices.iter().all(|v| v.is_finite()),
+            "a NaN height is caught in mesh::build, before any writer sees it"
+        );
+
+        for (label, m) in [
+            ("nan opacity", hostile(f64::NAN, 0.4)),
+            ("overflowing height", overflow),
+            ("infinite opacity", hostile(f64::INFINITY, 0.4)),
+        ] {
+            // Binary STL: 84-byte header, then 50 bytes per facet, of which
+            // the first 48 are twelve f32s. Every one must be finite.
+            let stl = to_stl_binary(&m, "hostile");
+            let count = u32::from_le_bytes(stl[80..84].try_into().unwrap()) as usize;
+            assert!(count > 0, "{label}: the whole mesh was dropped");
+            for f in 0..count {
+                let base = 84 + f * 50;
+                for k in 0..12 {
+                    let o = base + k * 4;
+                    let c = f32::from_le_bytes(stl[o..o + 4].try_into().unwrap());
+                    assert!(c.is_finite(), "{label}: STL facet {f} coord {k} is {c}");
+                }
+            }
+
+            let obj = dir.join("h.obj");
+            write_obj(&obj, &m, "hostile").unwrap();
+            let text = std::fs::read_to_string(&obj).unwrap();
+            assert!(
+                !text.contains("NaN") && !text.contains("nan") && !text.contains("inf"),
+                "{label}: OBJ carries a non-finite coordinate"
+            );
+            assert!(text.contains("\nf "), "{label}: OBJ kept no faces at all");
+
+            // ASCII STL goes through the same face filter.
+            let ascii = to_stl_ascii(&m, "hostile");
+            assert!(
+                !ascii.contains("NaN") && !ascii.contains("nan") && !ascii.contains("inf"),
+                "{label}: ASCII STL carries a non-finite coordinate"
+            );
+
+            // PLY declares its face count in the header, so the header and the
+            // body have to agree after filtering.
+            let ply = dir.join("h.ply");
+            write_ply(&ply, &m, "hostile").unwrap();
+            let bytes = std::fs::read(&ply).unwrap();
+            let end = b"end_header\n";
+            let at = bytes
+                .windows(end.len())
+                .position(|w| w == end)
+                .expect("a header end")
+                + end.len();
+            let header = String::from_utf8_lossy(&bytes[..at]).to_string();
+            let nv: usize = header
+                .lines()
+                .find_map(|l| l.strip_prefix("element vertex "))
+                .unwrap()
+                .parse()
+                .unwrap();
+            let nf: usize = header
+                .lines()
+                .find_map(|l| l.strip_prefix("element face "))
+                .unwrap()
+                .parse()
+                .unwrap();
+            let stride = if m.normals.len() == m.vertices.len() { 24 } else { 12 };
+            assert_eq!(
+                bytes.len(),
+                at + nv * stride + nf * 13,
+                "{label}: PLY header face count disagrees with the body"
+            );
+            for i in 0..nv * (stride / 4) {
+                let o = at + i * 4;
+                let c = f32::from_le_bytes(bytes[o..o + 4].try_into().unwrap());
+                assert!(c.is_finite(), "{label}: PLY value {i} is {c}");
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     fn small_build() -> Mesh {
         let design = crate::RingDesign::default();

--- a/crates/ringdesign-gui/src/export.rs
+++ b/crates/ringdesign-gui/src/export.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use ringdesign_core::castability::Verdict;
 use ringdesign_core::{library, metal, stl, threemf};
 
 use crate::app::RingDesignerApp;
@@ -13,6 +14,10 @@ struct ExportJob {
     lib: std::sync::Arc<ringdesign_core::AlphaLibrary>,
     params: ringdesign_core::BuildParams,
     shrink: Option<usize>,
+    /// The last settled field verdict. Snapshotted rather than recomputed:
+    /// the worker already pays for it on every settled build, and an export
+    /// that silently re-judged could disagree with the banner on screen.
+    verdict: Option<Verdict>,
 }
 
 impl ExportJob {
@@ -22,7 +27,38 @@ impl ExportJob {
             lib: app.lib.clone(),
             params: app.export_params,
             shrink: app.shrink_metal,
+            verdict: app.field.as_ref().map(|f| f.verdict),
         }
+    }
+
+    /// What the caster needs told before they cut a flask, appended to every
+    /// success line. The export used to build, write, and report the byte
+    /// count — so a `NotCastable` ring and a refinement that never reached its
+    /// tolerance both left the app looking like a clean export.
+    fn caveats(&self, out: &ringdesign_core::BuildResult) -> String {
+        let mut w: Vec<String> = Vec::new();
+        match self.verdict {
+            Some(Verdict::NotCastable) => {
+                w.push("the field verdict says this will NOT release".into())
+            }
+            Some(Verdict::Marginal) => w.push("the field verdict is marginal".into()),
+            Some(Verdict::Castable) => {}
+            None => w.push("not yet judged".into()),
+        }
+        if let Some(r) = &out.report.refine {
+            if r.hit_cap {
+                w.push("refinement hit its leaf cap, so the tolerance was not reached".into());
+            } else if r.saturated_leaves > 0 {
+                w.push(format!(
+                    "{} leaves hit the depth limit — the worst-error figure is a floor, not a bound",
+                    r.saturated_leaves
+                ));
+            }
+        }
+        if !out.report.validation.watertight {
+            w.push("NOT watertight".into());
+        }
+        if w.is_empty() { String::new() } else { format!(" • {}", w.join(" • ")) }
     }
 
     fn build(&self) -> ringdesign_core::BuildResult {
@@ -95,16 +131,11 @@ pub fn export_stl(app: &mut RingDesignerApp) {
         let (mesh, name) = job.pattern(&out.mesh);
         match stl::write_stl(&path, &mesh, &name) {
             Ok(bytes) => {
-                let v = out.report.validation;
-                let warn = if v.watertight {
-                    ""
-                } else {
-                    " • NOT watertight"
-                };
+                let warn = job.caveats(&out);
                 format!(
                     "Wrote {} • {} tris • {:.1} KB{warn}",
                     path.display(),
-                    v.triangle_count,
+                    out.report.validation.triangle_count,
                     bytes as f64 / 1024.0
                 )
             }
@@ -128,10 +159,11 @@ pub fn export_obj(app: &mut RingDesignerApp) {
         let (mesh, name) = job.pattern(&out.mesh);
         match stl::write_obj(&path, &mesh, &name) {
             Ok(bytes) => format!(
-                "Wrote {} • {} tris • {:.1} KB",
+                "Wrote {} • {} tris • {:.1} KB{}",
                 path.display(),
                 out.report.validation.triangle_count,
-                bytes as f64 / 1024.0
+                bytes as f64 / 1024.0,
+                job.caveats(&out)
             ),
             Err(e) => format!("OBJ export failed: {e}"),
         }
@@ -154,10 +186,11 @@ pub fn export_3mf(app: &mut RingDesignerApp) {
         let (mesh, name) = job.pattern(&out.mesh);
         match threemf::write_3mf(&path, &mesh, &name, &size) {
             Ok(bytes) => format!(
-                "Wrote {} • {} tris • {:.1} KB • units mm stated",
+                "Wrote {} • {} tris • {:.1} KB • units mm stated{}",
                 path.display(),
                 out.report.validation.triangle_count,
-                bytes as f64 / 1024.0
+                bytes as f64 / 1024.0,
+                job.caveats(&out)
             ),
             Err(e) => format!("3MF export failed: {e}"),
         }
@@ -220,9 +253,10 @@ pub fn export_glb(app: &mut RingDesignerApp) {
         let (mesh, name) = job.pattern(&out.mesh);
         match ringdesign_core::gltf::write_glb(&path, &mesh, &name, tint) {
             Ok(bytes) => format!(
-                "Wrote {} • {:.1} MB • metres, as glTF wants",
+                "Wrote {} • {:.1} MB • metres, as glTF wants{}",
                 path.display(),
-                bytes as f64 / 1048576.0
+                bytes as f64 / 1048576.0,
+                job.caveats(&out)
             ),
             Err(e) => format!("GLB export failed: {e}"),
         }


### PR DESCRIPTION
Part of #173 (M10.5), under #154 — *One verdict, spoken once*. Findings F149, F196, F197, F156.

## The bug

Four sites displace a sampled profile point by `h(u, v)`. Three of them zero a non-finite height — `refine.rs:299`, `castability.rs:810`, and the adaptive path. `mesh::build`, **the one whose output is exported**, did not.

That is only half the door, and the more interesting half is the other one: `opacity` and `height_mm` are unbounded `f64`s read straight out of a `.ring.json`, and a merely *enormous* height is perfectly finite as an `f64` and overflows on the way to `f32`. The mesh guard cannot see that one — only the writer can.

3MF and GLB have always dropped faces touching a non-finite vertex. STL, OBJ and PLY wrote coordinates verbatim, so the file a caster feeds to a slicer was full of `nan`.

## The fix

- `mesh::build` guards its height, matching its three siblings.
- `whole_faces` now requires vertices to exist **and** be finite, which covers both STL writers.
- OBJ and PLY index into a vertex list, so a bad vertex cannot be dropped without renumbering every face. They take 3MF's rule instead — write it as the origin, drop the faces that touch it. PLY declares its face count in the header, so the kept faces are counted before the header is built.
- **`--steps` was silently ignored** on any design carrying a refine tolerance, because `mesh::build` returns `build_refined` before reading either field. Naming a sweep resolution is asking for the sweep: it now clears the tolerance and says so on stderr.
- **An export never checked anything.** It built, wrote, and reported the byte count — a `NotCastable` ring and a refinement that never reached its tolerance both left the app looking like a clean export. `ExportJob::caveats` appends the field verdict (snapshotted rather than recomputed, so it cannot disagree with the banner on screen), `RefineStats::hit_cap`, `saturated_leaves` — which makes the worst-error figure a floor rather than a bound — and the watertight flag the STL path used to carry alone. Wired into STL, OBJ, 3MF and GLB.

## The test has teeth

`no_export_carries_a_non_finite_coordinate` builds a hostile design three ways — NaN opacity, infinite opacity, and a `1e308` height — and walks binary STL facet by facet, ASCII STL and OBJ as text, and PLY against its own declared vertex and face counts.

It asserts up front that the two halves are actually being exercised:

```rust
assert!(overflow.vertices.iter().any(|v| !v.is_finite()),
    "the overflow case must actually put a non-finite vertex in the mesh");
assert!(hostile(f64::NAN, 0.4).vertices.iter().all(|v| v.is_finite()),
    "a NaN height is caught in mesh::build, before any writer sees it");
```

So neither guard can pass by doing nothing.

## Still open on #173

The four-copies-to-one refactor (F150). The issue's own guidance is that a correctness fix must not ship behind a refactor, and the three call sites are not quite identical — `mesh::build` applies `soft_height` with `soften_mm` and a `min_wall` clamp the others do not — so unifying them wants its own change with the sweep-vs-refine equivalence pinned.

## Verification

- `cargo test --workspace --offline` under `systemd-run --user --scope -p MemoryMax=4G`: 19 suites, **all ok, 0 failures**.
- `cargo check -p ringdesign-core --no-default-features --target wasm32-unknown-unknown` passes.

Branched off `master`, independent of #190. The working tree carries another session's in-flight changes to `field.rs`, `curve.rs`, `dfm.rs` and two examples; none is committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)