### PR TITLE
Numbers that are not true

### DIFF
--- a/crates/ringdesign-cli/src/main.rs
+++ b/crates/ringdesign-cli/src/main.rs
@@ -244,7 +244,21 @@ fn export(
                 "obj" => stl::write_obj(&file, &mesh, &name)?,
                 "glb" => ringdesign_core::gltf::write_glb(&file, &mesh, &name, ringdesign_core::render::GOLD)?,
                 "ply" => stl::write_ply(&file, &mesh, &name)?,
-                _ => threemf::write_3mf(&file, &mesh, &name, &d.size.display())?,
+                _ => {
+                    // The mesh is scaled for shrink, bore and all — an
+                    // oversize file stamped with the nominal size is a ring
+                    // that comes out a size small.
+                    let label = match scale {
+                        Some((m, _)) => format!(
+                            "{} pattern, cut +{:.1}% for {}",
+                            d.size.display(),
+                            m.shrink_pct,
+                            m.name
+                        ),
+                        None => d.size.display(),
+                    };
+                    threemf::write_3mf(&file, &mesh, &name, &label)?
+                }
             };
             manifest.push_str(&format!(
                 "{},{},{},{},{},{},{:?},{:.4},{:.2},{:.2},{},{}\n",

--- a/crates/ringdesign-core/src/lib.rs
+++ b/crates/ringdesign-core/src/lib.rs
@@ -187,6 +187,30 @@ impl RingDesign {
         walk(&self.layers, lib);
     }
 
+    /// Whether any layer reading a distance field is missing one.
+    ///
+    /// `TilingLayer::height` falls back to brightness-as-height when the
+    /// `##sdf` entry is absent, silently — so turning "Crisp edge" on in the
+    /// editor produced a layer that looked like the old one and nobody could
+    /// say why. Cheap: a walk of the stack and a map lookup per edge-enabled
+    /// layer, so an editor can ask on every edit and only pay for the bake
+    /// when the answer is yes.
+    pub fn sdfs_missing(&self, lib: &AlphaLibrary) -> bool {
+        fn walk(stack: &LayerStack, lib: &AlphaLibrary) -> bool {
+            stack.layers.iter().any(|e| match &e.layer {
+                field::Layer::Tiling(t) if t.edge_mm > 1e-9 => {
+                    lib.get(&crate::alpha::sdf_name(&t.alpha)).is_none()
+                }
+                field::Layer::Openwork(o) if o.tiling.edge_mm > 1e-9 => {
+                    lib.get(&crate::alpha::sdf_name(&o.tiling.alpha)).is_none()
+                }
+                field::Layer::Group(g) => walk(&g.stack, lib),
+                _ => false,
+            })
+        }
+        walk(&self.layers, lib)
+    }
+
     /// Rasterize every parameterized generator recipe into `lib`.
     pub fn bake_recipes(&self, lib: &mut AlphaLibrary) {
         for r in &self.recipes {
@@ -359,5 +383,35 @@ mod losing_work_tests {
             "A's own art, not the one already in the library: {}",
             got.data[0]
         );
+    }
+}
+
+#[cfg(test)]
+mod design_tests {
+    use super::*;
+
+    /// Turning `edge_mm` on made a layer read a distance field that nothing
+    /// had baked, and `TilingLayer::height` falls back to brightness-as-height
+    /// without saying so — the crisp edge simply did not appear. The editor
+    /// needs a cheap way to ask, so the bake can run only when one is absent.
+    #[test]
+    fn a_layer_that_wants_a_distance_field_says_when_it_has_none() {
+        let mut lib = crate::AlphaLibrary::builtin();
+        let mut d = RingDesign::default();
+        let ctx = d.field_context();
+        let mut t = crate::tiling::TilingLayer::default_for("Beads", &ctx);
+        t.edge_mm = 0.0;
+        d.layers
+            .layers
+            .push(crate::LayerEntry::new("beads", crate::Layer::Tiling(t)));
+        assert!(!d.sdfs_missing(&lib), "a layer with no crisp edge wants nothing");
+
+        // The edit a user makes in the panel.
+        if let crate::Layer::Tiling(t) = &mut d.layers.layers[0].layer {
+            t.edge_mm = 0.35;
+        }
+        assert!(d.sdfs_missing(&lib), "now it wants one and has none");
+        d.bake_sdfs(&mut lib);
+        assert!(!d.sdfs_missing(&lib), "and the bake satisfies it");
     }
 }

--- a/crates/ringdesign-core/src/mesh.rs
+++ b/crates/ringdesign-core/src/mesh.rs
@@ -266,6 +266,10 @@ pub struct Report {
     pub surface_area_mm2: f64,
     /// Overall size (x, y, z) in mm.
     pub bounds_mm: [f64; 3],
+    /// Measured off the built mesh — twice the smallest radius any vertex
+    /// reaches — not the nominal size echoed back. The two differ whenever
+    /// anything moves the bore: a comfort dome, a hollowed head's bore lift,
+    /// or the min-wall clamp pushing a displaced point outward.
     pub inner_diameter_mm: f64,
     pub outer_diameter_mm: f64,
     pub band_width_mm: f64,
@@ -291,6 +295,23 @@ pub struct BuildResult {
 }
 
 /// Build the ring mesh from a design.
+/// Twice the smallest radius any vertex reaches — the finger hole as built.
+///
+/// `Report::inner_diameter_mm` used to be `design.size.inner_diameter_mm()`,
+/// the nominal figure echoed straight back, so it agreed with itself no matter
+/// what the geometry did. A comfort dome, a hollowed head's bore lift and the
+/// min-wall clamp all move the bore; a jeweller reading the report wants the
+/// hole they will get.
+fn measured_bore_diameter_mm(mesh: &Mesh, nominal: f64) -> f64 {
+    let min_r = mesh
+        .vertices
+        .iter()
+        .filter(|v| v.0.is_finite() && v.1.is_finite())
+        .map(|v| (v.0 as f64).hypot(v.1 as f64))
+        .fold(f64::MAX, f64::min);
+    if min_r.is_finite() && min_r > 0.0 { 2.0 * min_r } else { nominal }
+}
+
 pub fn build(design: &RingDesign, lib: &AlphaLibrary, params: BuildParams) -> BuildResult {
     let started = BuildClock::start();
     if let Some(rp) = params.refine {
@@ -399,7 +420,7 @@ pub fn build(design: &RingDesign, lib: &AlphaLibrary, params: BuildParams) -> Bu
         volume_mm3: volume,
         surface_area_mm2: mesh.surface_area_mm2(),
         bounds_mm,
-        inner_diameter_mm: design.size.inner_diameter_mm(),
+        inner_diameter_mm: measured_bore_diameter_mm(&mesh, design.size.inner_diameter_mm()),
         outer_diameter_mm: bounds_mm[0].max(bounds_mm[1]),
         band_width_mm: bounds_mm[2],
         max_relief_mm: max_relief,
@@ -438,7 +459,7 @@ fn build_refined(
         volume_mm3: volume,
         surface_area_mm2: mesh.surface_area_mm2(),
         bounds_mm,
-        inner_diameter_mm: design.size.inner_diameter_mm(),
+        inner_diameter_mm: measured_bore_diameter_mm(&mesh, design.size.inner_diameter_mm()),
         outer_diameter_mm: bounds_mm[0].max(bounds_mm[1]),
         band_width_mm: bounds_mm[2],
         max_relief_mm: out.relief.0,
@@ -691,6 +712,35 @@ mod tests {
         }
         // f32 vertices are the only reason this is not exact.
         assert!(worst < 2e-3, "worst disagreement {worst:.6} mm");
+    }
+
+    /// The report's inside diameter was `design.size.inner_diameter_mm()` —
+    /// the nominal figure echoed straight back, which agreed with itself
+    /// whatever the geometry did. It is measured off the built mesh now, so a
+    /// change that ate into the finger hole would show up in the one number a
+    /// customer checks.
+    #[test]
+    fn the_inside_diameter_is_measured_not_declared() {
+        let lib = crate::AlphaLibrary::builtin();
+        let d = crate::RingDesign::default();
+        let out = super::build(
+            &d,
+            &lib,
+            super::BuildParams { theta_steps: 192, profile_steps: 96, ..Default::default() },
+        );
+        let nominal = d.size.inner_diameter_mm();
+        assert!(
+            (out.report.inner_diameter_mm - nominal).abs() < 1e-6,
+            "a plain band's bore is its nominal size: {:.4} vs {nominal:.4}",
+            out.report.inner_diameter_mm
+        );
+        // And it really is a measurement: scale the mesh and it follows,
+        // where the declared figure would not have moved.
+        let scaled = out.mesh.scaled(1.05);
+        assert!(
+            (super::measured_bore_diameter_mm(&scaled, nominal) - nominal * 1.05).abs() < 1e-4,
+            "the measure follows the metal"
+        );
     }
 
     use super::*;

--- a/crates/ringdesign-core/src/sizing.rs
+++ b/crates/ringdesign-core/src/sizing.rs
@@ -47,12 +47,14 @@ impl RingSize {
         Self::from_circumference_mm(diameter * std::f64::consts::PI)
     }
 
+    /// `US 7`, `US 7.25`, `US 7.5` — never `US 7.`, which is what trimming
+    /// the zeros off `{:.2}` gives for a size that is a whisker off an
+    /// integer. A size arriving from a file or an interpolation is rarely
+    /// exactly 7.0, so `fract() == 0.0` is not the test it looks like.
     pub fn display(&self) -> String {
-        if self.0.fract() == 0.0 {
-            format!("US {}", self.0 as i32)
-        } else {
-            format!("US {:.2}", self.0).trim_end_matches('0').to_string()
-        }
+        let s = format!("US {:.2}", self.0);
+        let s = s.trim_end_matches('0');
+        s.strip_suffix('.').unwrap_or(s).to_string()
     }
 
     /// Sizes from 3 to 15 in half-size steps.

--- a/crates/ringdesign-core/src/spec.rs
+++ b/crates/ringdesign-core/src/spec.rs
@@ -9,7 +9,6 @@
 use crate::castability::{FieldReport, Verdict};
 use crate::dfm::DfmFinding;
 use crate::mesh::Report;
-use crate::profile::MIN_EDGE_MM;
 use crate::stones::{SeatFooting, StonesReport};
 use crate::RingDesign;
 
@@ -173,10 +172,10 @@ pub fn html(
                 "<h3>Spacing</h3><div>{} pair{} under {:.2} mm.</div>                 <table><tr><th>Pair</th><th>At</th><th>At the girdle</th><th>At the culet</th></tr>",
                 s.tight_pairs,
                 if s.tight_pairs == 1 { "" } else { "s" },
-                crate::stones::CROWD_TIGHT_MM
+                s.tight_mm()
             ));
             for p in &s.crowding {
-                let cls = if p.worst_mm() < MIN_EDGE_MM { " class=\"warn\"" } else { "" };
+                let cls = if p.worst_mm() < s.will_not_fill_mm() { " class=\"warn\"" } else { "" };
                 h.push_str(&format!(
                     "<tr{cls}><td>{} &middot; {}</td><td>{:.0}&deg; / {:.0}&deg;</td>                     <td>{:.2} mm</td><td>{:.2} mm</td></tr>",
                     esc(&p.a),

--- a/crates/ringdesign-core/src/stones.rs
+++ b/crates/ringdesign-core/src/stones.rs
@@ -109,6 +109,10 @@ pub struct StonesReport {
     /// The closest two stones in the design whether or not they are tight —
     /// the headline number, and the one a probe or a banner wants.
     pub closest: Option<StonePair>,
+    /// The fill floor these numbers were judged against, mm — the design's
+    /// own `min_section_mm`. Carried so the sheet and the setter's map quote
+    /// the same figure the census used, instead of each printing a constant.
+    pub fill_floor_mm: f64,
 }
 
 impl StonesReport {
@@ -116,10 +120,20 @@ impl StonesReport {
         self.seats.iter().any(|s| !s.warnings.is_empty()) || self.tight_pairs > 0
     }
 
+    /// Metal below which the sand will not fill at all, mm.
+    pub fn will_not_fill_mm(&self) -> f64 {
+        self.fill_floor_mm
+    }
+
+    /// Metal the pour fills but the bench should know about, mm.
+    pub fn tight_mm(&self) -> f64 {
+        self.fill_floor_mm * TIGHT_MULTIPLE
+    }
+
     /// The one line the sheet and the banner want.
     pub fn crowding_note(&self) -> Option<String> {
         let worst = self.crowding.first()?;
-        (worst.worst_mm() < CROWD_TIGHT_MM).then(|| {
+        (worst.worst_mm() < self.tight_mm()).then(|| {
             format!(
                 "{} tight pair{}: {} and {} leave {:.2} mm at the girdle, {:.2} mm at depth",
                 self.tight_pairs,
@@ -133,9 +147,16 @@ impl StonesReport {
     }
 }
 
-/// Metal between two stones the sand still fills, mm. Under this the report
-/// says so; under [`MIN_EDGE_MM`] it will not fill at all.
-pub const CROWD_TIGHT_MM: f64 = 0.3;
+/// How far above the fill floor a bridge is still worth remarking on.
+///
+/// The census used to judge stone-to-stone metal against a hardcoded 0.3 mm
+/// and the run bridge against [`MIN_EDGE_MM`], neither of which has anything
+/// to do with the sand the ring is cast in — Delft clay's own floor is 0.8 mm
+/// and Petrobond's 0.6. So a 0.35 mm bridge was reported as merely "tight"
+/// when the sand physically cannot fill it, which is the unsafe direction on
+/// a check whose own doctrine says it is *said in the `min_section_mm`
+/// voice*. Both thresholds now come off the design's floor.
+pub const TIGHT_MULTIPLE: f64 = 1.5;
 
 /// Every seat in the design, checked. `None` when the stack carries no seats.
 ///
@@ -160,7 +181,15 @@ pub fn report(design: &RingDesign, parting_z_mm: f64) -> Option<StonesReport> {
     let total_carats = seats.iter().map(|s| s.carats()).sum();
     let (crowding, tight_pairs, closest) =
         crowding(design, &ctx, inner_r, crest_r, &stations);
-    Some(StonesReport { seats, stone_count, total_carats, crowding, tight_pairs, closest })
+    Some(StonesReport {
+        seats,
+        stone_count,
+        total_carats,
+        crowding,
+        tight_pairs,
+        closest,
+        fill_floor_mm: design.draft.min_section_mm.max(0.0),
+    })
 }
 
 #[derive(Default)]
@@ -179,6 +208,7 @@ fn walk(
     prefix: &str,
     acc: &mut Acc,
 ) {
+    let fill_floor = design.draft.min_section_mm.max(0.0);
     for entry in &stack.layers {
         if !entry.enabled {
             continue;
@@ -232,14 +262,15 @@ fn walk(
                 }
                 let bridge = run.bridge_at(ctx);
                 check.bridge_mm = Some(bridge);
-                if bridge < MIN_EDGE_MM {
+                if bridge < fill_floor {
                     check.warnings.push(format!(
-                        "bridge {bridge:.2} mm between stones will not fill (min {MIN_EDGE_MM} mm)"
+                        "bridge {bridge:.2} mm between stones will not fill (this sand fills {fill_floor:.2} mm)"
                     ));
-                } else if bridge < 0.3 {
-                    check
-                        .warnings
-                        .push(format!("bridge {bridge:.2} mm is tight for sand — 0.3 mm is safer"));
+                } else if bridge < fill_floor * TIGHT_MULTIPLE {
+                    check.warnings.push(format!(
+                        "bridge {bridge:.2} mm is tight — {:.2} mm is safer in this sand",
+                        fill_floor * TIGHT_MULTIPLE
+                    ));
                 }
                 if check.count == 0 {
                     check.warnings.push("window keeps no stations — not on the ring".into());
@@ -345,6 +376,9 @@ fn crowding(
         .map(|st| frame_at(design, ctx, inner_r, crest_r, st))
         .collect();
 
+    // Both thresholds come off the sand the design is judged for, not off a
+    // constant: Delft fills 0.8 mm and Petrobond 0.6, and the default is 0.7.
+    let tight_floor = design.draft.min_section_mm.max(0.0) * TIGHT_MULTIPLE;
     let mut pairs: Vec<StonePair> = Vec::new();
     let mut tight = 0usize;
     let mut closest: Option<StonePair> = None;
@@ -357,7 +391,7 @@ fn crowding(
             // anything further apart than a stone is not a neighbour.
             let floor = dist - fa.reach - fb.reach;
             if floor > closest.as_ref().map_or(f64::MAX, |c| c.worst_mm())
-                && floor > CROWD_TIGHT_MM
+                && floor > tight_floor
             {
                 continue;
             }
@@ -378,7 +412,7 @@ fn crowding(
             if closest.as_ref().is_none_or(|c| pair.worst_mm() < c.worst_mm()) {
                 closest = Some(pair.clone());
             }
-            if pair.worst_mm() >= CROWD_TIGHT_MM {
+            if pair.worst_mm() >= tight_floor {
                 continue;
             }
             tight += 1;
@@ -704,6 +738,51 @@ fn base_at(
 
 #[cfg(test)]
 mod tests {
+    /// The census is a *fill* rule — a thin bridge does not lock the mould, it
+    /// comes out of the flask as two stones sharing a hole — so it has to move
+    /// with the sand. It used to be a hardcoded 0.3 mm, which is under every
+    /// sand this shop pours and so reported "tight" where the metal will not
+    /// go at all.
+    #[test]
+    fn the_census_moves_with_the_sand() {
+        use crate::castability::SandProcess;
+        use crate::field::{Layer, LayerEntry, SeatRunLayer};
+        use crate::gem::{Gem, GemCut};
+
+        let build = |sand: SandProcess| {
+            let mut d = crate::RingDesign::default();
+            d.profile.apply_style(crate::ProfileStyle::LowDome);
+            sand.apply(&mut d.draft);
+            let ctx = d.field_context();
+            let mut run = SeatRunLayer::default();
+            run.gem = Gem::calibrated(GemCut::Emerald, 2.5);
+            run.seat.v_mm = ctx.crest_v_mm;
+            run.count = 16;
+            run.seat.fit_stone(run.gem);
+            d.layers.layers.push(LayerEntry::new("Step row", Layer::SeatRun(run)));
+            super::report(&d, 0.0).unwrap()
+        };
+
+        let coarse = build(SandProcess::Petrobond);
+        let fine = build(SandProcess::DelftClay);
+        assert_eq!(coarse.fill_floor_mm, 0.6);
+        assert_eq!(fine.fill_floor_mm, 0.8);
+        // Identical geometry, different sand: the finer sand's higher fill
+        // floor has to make the same row read tighter, not the same.
+        assert!(
+            fine.tight_pairs >= coarse.tight_pairs,
+            "Delft ({} pairs at a {:.2} mm floor) cannot be more forgiving than \
+             Petrobond ({} at {:.2})",
+            fine.tight_pairs,
+            fine.fill_floor_mm,
+            coarse.tight_pairs,
+            coarse.fill_floor_mm
+        );
+        assert!(fine.tight_mm() > coarse.tight_mm());
+        // And the sheet's heading and the census must quote one number.
+        assert_eq!(fine.tight_mm(), fine.fill_floor_mm * super::TIGHT_MULTIPLE);
+    }
+
     use super::*;
     use crate::field::{Blend, SeatRunLayer, VGate, Window};
     use crate::gem::{Gem, GemCut};
@@ -871,8 +950,14 @@ mod tests {
         d.layers.layers.push(LayerEntry::new("Step row", Layer::SeatRun(run)));
         let r = report(&d, 0.0).unwrap();
         let hit = r.crowding.first().expect("the row is tight at depth");
-        assert!(hit.gap_mm > CROWD_TIGHT_MM, "clears at the girdle: {:.3}", hit.gap_mm);
-        assert!(hit.gap_deep_mm < CROWD_TIGHT_MM, "and not at depth: {:.3}", hit.gap_deep_mm);
+        // The subject here is the arc loss, not the threshold: the ring's own
+        // curvature closes the gap between the girdle and the culet, and the
+        // culet is the one that decides. Measured on this row, 0.51 mm at the
+        // girdle against 0.26 at depth — and against a real sand floor of
+        // 0.70 mm *both* are tight, which is the whole point of judging them
+        // against the process instead of against 0.3.
+        assert!(hit.gap_mm > hit.gap_deep_mm, "the arc closes: {:.3} -> {:.3}", hit.gap_mm, hit.gap_deep_mm);
+        assert!(hit.gap_deep_mm < r.will_not_fill_mm(), "at depth: {:.3}", hit.gap_deep_mm);
         let pitch = ctx.circumference_mm / 16.0;
         let loss = pitch * run.gem.pavilion_mm() / ctx.crest_radius_mm;
         assert!(
@@ -1034,10 +1119,15 @@ mod tests {
         let per = Gem::calibrated(GemCut::Round, 2.0).carats();
         assert!((r.total_carats - per * s.count as f64).abs() < 1e-9);
         assert!(s.bridge_mm.unwrap() > 0.0);
-        // A gypsy run over the crest of a plain band sits fine.
+        // The one warning it does carry is the truth this check was blind to
+        // while the threshold was a hardcoded 0.3 mm: `SeatRunLayer::default()`
+        // asks for a 0.4 mm bridge, and no sand this shop pours fills that —
+        // Delft is 0.8, Petrobond 0.6, the default 0.7. The default row is
+        // asking for metal the process cannot give it.
+        assert_eq!(s.warnings.len(), 1, "{:?}", s.warnings);
         assert!(
-            s.warnings.is_empty(),
-            "unexpected warnings: {:?}",
+            s.warnings[0].contains("will not fill"),
+            "the default bridge is under the sand's floor: {:?}",
             s.warnings
         );
     }

--- a/crates/ringdesign-gui/src/app.rs
+++ b/crates/ringdesign-gui/src/app.rs
@@ -384,6 +384,15 @@ impl RingDesignerApp {
     /// Queue a rebuild after the debounce window and publish the design to the
     /// MCP engine.
     pub fn mark_dirty(&mut self) {
+        // A layer that reads a distance field and has not got one falls back
+        // to brightness-as-height without a word, so turning "Crisp edge" on
+        // looked like it did nothing. The check is a map lookup per
+        // edge-enabled layer; the bake — which deep-copies the library
+        // through `Arc::make_mut` — only runs when one is actually absent.
+        if self.design.sdfs_missing(&self.lib) {
+            let design = self.design.clone();
+            design.bake_sdfs(self.library_mut());
+        }
         // Live generator groups own their stacks: any edit that moves the
         // ground under one — the profile, the shank, the process, or the
         // recipe itself — re-solves it here, at edit time. Builds never

--- a/crates/ringdesign-gui/src/export.rs
+++ b/crates/ringdesign-gui/src/export.rs
@@ -182,7 +182,18 @@ pub fn export_3mf(app: &mut RingDesignerApp) {
     let job = ExportJob::snapshot(app);
     spawn_export(app, "3MF", move || {
         let out = job.build();
-        let size = job.design.size.display();
+        // The mesh in this file is scaled for the metal's shrink, bore and
+        // all, so stamping it with the nominal size is the one mistake the
+        // filename convention exists to prevent. Say which it is.
+        let size = match job.shrink.and_then(|i| metal::METALS.get(i)) {
+            Some(m) => format!(
+                "{} pattern, cut +{:.1}% for {}",
+                job.design.size.display(),
+                m.shrink_pct,
+                m.name
+            ),
+            None => job.design.size.display(),
+        };
         let (mesh, name) = job.pattern(&out.mesh);
         match threemf::write_3mf(&path, &mesh, &name, &size) {
             Ok(bytes) => format!(


### PR DESCRIPTION
Part of #171 (M10.3), under #154. Findings F58, F143, F144, F147, F151.

Six figures the app printed that were not the thing they claimed to be.

## Stone-to-stone metal was judged against a constant unrelated to the sand

`CROWD_TIGHT_MM = 0.3` and `MIN_EDGE_MM = 0.2`, against fill floors of:

| | fill floor |
| --- | --- |
| Delft clay | 0.80 mm |
| Petrobond | 0.60 mm |
| default | 0.70 mm |

So a 0.35 mm bridge read as merely *tight* where the metal physically will not go — the unsafe direction, on the check whose own doc comment says it is *"said in the `min_section_mm` voice"*. Both thresholds now come off the design's floor: under it **will not fill**, under 1.5× it is **tight**. `StonesReport` carries `fill_floor_mm` so the casting sheet, the setter's map and the census quote one number instead of three constants — the sheet's `<h3>Spacing</h3>` heading and its red-row rule both read it now.

`the_census_moves_with_the_sand` pins the coupling: identical geometry judged as Petrobond and as Delft must not read the same.

### It immediately found something

`SeatRunLayer::default()` asks for `bridge_mm: 0.4`, which **no sand this shop pours will fill**, and `solve_spacing` faithfully solves a station count to deliver it. Until now nothing said so, because 0.4 > 0.3.

Two tests changed to assert that rather than the silence they used to get for free. The default itself is untouched and filed as **#194** on M20 — moving it moves every generated row, and that is a stones decision, not a truth-telling one.

## The rest

- **The inside diameter was the nominal size echoed back.** `design.size.inner_diameter_mm()`, so it agreed with itself whatever the geometry did. Measured off the built mesh now, and `the_inside_diameter_is_measured_not_declared` proves it is a measurement by scaling the mesh and watching it follow.
- **`RingSize::display()` printed `US 7.`** — `{:.2}` with the trailing zeros trimmed and not the point behind them. `fract() == 0.0` is not the test it looks like for a size arriving from a file or an interpolation.
- **A shrink-scaled 3MF was stamped with the nominal size** while the mesh inside was cut oversize, bore and all. The filename convention exists to prevent exactly that and the metadata undid it. GUI and CLI both now say `US 7 pattern, cut +1.9% for Silver 925`.
- **Turning "Crisp edge" on did nothing, silently.** `TilingLayer::height` reads an `##sdf` entry and falls back to brightness-as-height when absent *without a word*, and nothing baked one on the edit — the Openwork add-path bakes it inline, which is the workaround that proves the gap. `RingDesign::sdfs_missing` is the cheap question (one map lookup per edge-enabled layer) so `mark_dirty` pays for the bake — which deep-copies the library through `Arc::make_mut` — only when one is actually absent.

## Four of the ten stay open, and why

- **F83** (transposed Flutes DFM footprint) and **F109** (tiling DFM ignores the shank modulation) live in `dfm.rs` and `field.rs`, which carry **another session's uncommitted work** in this tree. Staging them would commit that work under this change.
- **F105** (a new lofted signet gets a flat square-edged shank — a shipped M0.4 accept criterion that is now false) and **F110** (a toi et moi's second head judged by the primary's construction) change signet geometry, and the golden corpus that would catch a mistake there is still unmerged on #192. They want that net under them first.

## Verification

`cargo test --workspace --offline` under `systemd-run --user --scope -p MemoryMax=4G`: **332 core, 19 suites, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)