### PR TITLE
Stop losing work

### DIFF
--- a/crates/ringdesign-core/src/alpha.rs
+++ b/crates/ringdesign-core/src/alpha.rs
@@ -1461,10 +1461,27 @@ impl AlphaLibrary {
         lib
     }
 
+    /// Most entries a library will hold.
+    ///
+    /// `drawn`, `texts`, `svgs` and `recipes` are `Vec`s read straight out of
+    /// a design file, and every one of them rasterizes into here on load. The
+    /// per-alpha size is already capped; the *count* was not, so a file with
+    /// ten thousand one-glyph inscriptions was a memory bomb with no loop to
+    /// blame. The 67 GB lesson, applied to the other door.
+    pub const MAX_ENTRIES: usize = 4096;
+
     pub fn insert(&mut self, alpha: Alpha) {
         match self.index.get(&alpha.name).copied() {
             Some(i) => self.entries[i] = alpha,
             None => {
+                if self.entries.len() >= Self::MAX_ENTRIES {
+                    log::warn!(
+                        "alpha library is full at {} entries; dropping {:?}",
+                        Self::MAX_ENTRIES,
+                        alpha.name
+                    );
+                    return;
+                }
                 self.index.insert(alpha.name.clone(), self.entries.len());
                 self.entries.push(alpha);
             }

--- a/crates/ringdesign-core/src/lib.rs
+++ b/crates/ringdesign-core/src/lib.rs
@@ -234,9 +234,13 @@ impl RingDesign {
     pub fn unpack_embedded(&self, lib: &mut AlphaLibrary) {
         use base64::Engine as _;
         for e in &self.embedded {
-            if lib.get(&e.name).is_some() {
-                continue;
-            }
+            // A design's own embedded copy is authoritative *for that
+            // design*, and the library accumulates for the whole session.
+            // Skipping a name already present meant that opening a second
+            // design carrying its own "band" or "sketch" silently rendered
+            // the first one's art. `embed_alphas` never embeds anything
+            // regenerable — no procedural builtin, no stroke, no inscription —
+            // so replacing here cannot clobber one of those.
             let decoded = base64::engine::general_purpose::STANDARD
                 .decode(&e.png)
                 .map_err(anyhow::Error::from)
@@ -286,5 +290,74 @@ impl RingDesign {
             bore_radius_mm: self.inner_radius_mm(),
             side_faces_cache: Default::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod losing_work_tests {
+    use super::*;
+
+    /// `fs::write` truncates before it writes, so an interrupted save of a
+    /// design carrying embedded PNGs left nothing at all where a stale file
+    /// would have been fine. The write is atomic now, and it keeps one
+    /// generation back.
+    #[test]
+    fn a_save_is_atomic_and_leaves_a_backup() {
+        let dir = std::env::temp_dir().join("ringdesign-atomic-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("ring.ring.json");
+
+        let mut first = RingDesign::default();
+        first.name = "first".into();
+        library::save_design(&path, &first).unwrap();
+        assert!(path.exists());
+        assert!(!path.with_extension("json.bak").exists(), "nothing to back up yet");
+
+        let mut second = RingDesign::default();
+        second.name = "second".into();
+        library::save_design(&path, &second).unwrap();
+
+        let now = std::fs::read_to_string(&path).unwrap();
+        assert!(now.contains("second"));
+        let bak = std::fs::read_to_string(path.with_extension("json.bak")).unwrap();
+        assert!(bak.contains("first"), "the previous save is recoverable");
+        // No temp left behind.
+        assert!(!path.with_extension("json.tmp").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The library accumulates for a whole session, and `unpack_embedded`
+    /// skipped any name already present — so opening a second design that
+    /// carries its own alpha under a name the first one used rendered the
+    /// first one's art, silently.
+    #[test]
+    fn a_second_design_brings_its_own_art() {
+        let mut lib = AlphaLibrary::builtin();
+        let art = |name: &str, v: f32| {
+            crate::alpha::Alpha::new(name.to_string(), 4, 4, vec![v; 16])
+        };
+
+        let mut a = RingDesign::default();
+        lib.insert(art("shared", 0.25));
+        a.layers.layers.push(LayerEntry::new(
+            "t",
+            Layer::Tiling(crate::tiling::TilingLayer::default_for("shared", &a.field_context())),
+        ));
+        a.embed_alphas(&lib);
+        assert_eq!(a.embedded.len(), 1, "the design carries its own copy");
+
+        // A different design, same name, different art.
+        let mut b = a.clone();
+        lib.insert(art("shared", 0.75));
+        b.embed_alphas(&lib);
+
+        // Open A again into the session's library, which still holds B's.
+        a.unpack_embedded(&mut lib);
+        let got = lib.get("shared").expect("present");
+        assert!(
+            (got.data[0] - 0.25).abs() < 1e-3,
+            "A's own art, not the one already in the library: {}",
+            got.data[0]
+        );
     }
 }

--- a/crates/ringdesign-core/src/library.rs
+++ b/crates/ringdesign-core/src/library.rs
@@ -60,7 +60,41 @@ pub fn design_json(design: &RingDesign) -> anyhow::Result<String> {
 }
 
 pub fn save_design(path: impl AsRef<Path>, design: &RingDesign) -> anyhow::Result<()> {
-    std::fs::write(path, design_json(design)?)?;
+    write_atomic(path, design_json(design)?.as_bytes())
+}
+
+/// Write a file without a window in which it is half a file.
+///
+/// A design carrying embedded 16-bit PNGs and hand-drawn strokes is a large
+/// single write, and `fs::write` truncates before it writes: interrupt it —
+/// full disk, power, a panic in the middle — and the design is gone, not
+/// stale. Write a sibling temp, fsync it, keep the previous file as `.bak`,
+/// then rename. Rename is atomic on every filesystem this runs on, so the
+/// path either names the old file or the new one and never a truncated one.
+pub fn write_atomic(path: impl AsRef<Path>, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write;
+    let path = path.as_ref();
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(dir)?;
+    let tmp = path.with_extension(format!(
+        "{}.tmp",
+        path.extension().and_then(|e| e.to_str()).unwrap_or("part")
+    ));
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    // One generation back, so a bad save is recoverable by renaming a file.
+    if path.exists() {
+        let _ = std::fs::rename(path, path.with_extension(format!(
+            "{}.bak",
+            path.extension().and_then(|e| e.to_str()).unwrap_or("old")
+        )));
+    }
+    std::fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })?;
     Ok(())
 }
 
@@ -202,7 +236,7 @@ pub fn save_outline_in(dir: &Path, outline: &crate::CustomOutline) -> anyhow::Re
     }
     std::fs::create_dir_all(dir)?;
     let path = dir.join(format!("{stem}.outline.json"));
-    std::fs::write(&path, serde_json::to_string(outline)?)?;
+    write_atomic(&path, serde_json::to_string(outline)?.as_bytes())?;
     Ok(path)
 }
 
@@ -229,7 +263,7 @@ pub fn save_profile_in(
     std::fs::create_dir_all(dir)?;
     let path = dir.join(format!("{stem}.profile.json"));
     let text = serde_json::to_string_pretty(profile)?;
-    std::fs::write(&path, text)?;
+    write_atomic(&path, text.as_bytes())?;
     Ok(path)
 }
 

--- a/crates/ringdesign-gui/src/app.rs
+++ b/crates/ringdesign-gui/src/app.rs
@@ -249,6 +249,11 @@ impl RingDesignerApp {
             .and_then(|s| s.get_string(DESIGN_STORAGE_KEY))
             .and_then(|j| serde_json::from_str::<RingDesign>(&j).ok())
             .unwrap_or_default();
+        // `open_design_path` unpacks first and bakes second. This path only
+        // baked, so a design restored by restarting the app came back without
+        // the embedded art it was saved with — the strokes and imported masks
+        // simply were not in the library any more.
+        design.unpack_embedded(&mut lib);
         design.bake_all(&mut lib);
 
         let workspace = cc
@@ -432,7 +437,16 @@ impl RingDesignerApp {
         }
 
         match self.worker.done.try_recv() {
-            Ok(mut done) => {
+            Ok(WorkerMsg::Failed { generation, message }) => {
+                self.in_flight = false;
+                if generation == self.generation {
+                    self.set_status(format!(
+                        "Build failed: {message}. The design is unchanged — the last good \
+                         geometry is still on screen."
+                    ));
+                }
+            }
+            Ok(WorkerMsg::Done(mut done)) => {
                 self.in_flight = false;
                 if done.generation == self.generation {
                     let r = &done.result.report;
@@ -603,6 +617,12 @@ impl RingDesignerApp {
     /// restore is not itself recorded as an edit.
     fn apply_history(&mut self, design: RingDesign, what: &str) {
         self.design = design;
+        // Strokes, inscriptions and SVG art travel in the design as source
+        // data and live in the shared library as rasters. Restoring the one
+        // without re-deriving the other left painted metal on the band after
+        // Ctrl+Z, because the old raster was still what the layers read.
+        let restored = self.design.clone();
+        restored.bake_all(self.library_mut());
         if self
             .selected_layer
             .is_some_and(|i| i >= self.design.layers.layers.len())
@@ -918,15 +938,27 @@ struct Done {
     graph: Option<GraphDone>,
 }
 
+/// What comes back from the build thread.
+///
+/// The loop used to be unguarded, so a panic anywhere in `mesh::build`,
+/// `attribute_undercuts`, `stones::report` or the gem preview killed the
+/// thread; `jobs_tx.send` then failed for the rest of the session and the app
+/// simply stopped rebuilding, with no error and no way back short of a
+/// restart. A panic is now one failed build.
+enum WorkerMsg {
+    Done(Box<Done>),
+    Failed { generation: u64, message: String },
+}
+
 struct Worker {
     jobs: Sender<Job>,
-    done: Receiver<Done>,
+    done: Receiver<WorkerMsg>,
 }
 
 impl Worker {
     fn spawn() -> Self {
         let (jobs_tx, jobs_rx) = channel::<Job>();
-        let (done_tx, done_rx) = channel::<Done>();
+        let (done_tx, done_rx) = channel::<WorkerMsg>();
         std::thread::Builder::new()
             .name("ring-build".into())
             .spawn(move || {
@@ -937,63 +969,68 @@ impl Worker {
                     while let Ok(newer) = jobs_rx.try_recv() {
                         job = newer;
                     }
-                    // A graph-driven design is evaluated first; the library's
-                    // identity is its epoch, so a replaced library re-runs it.
-                    let mut graph_done = None;
-                    let mut field_from_graph = None;
-                    if let Some(g) = &job.graph {
-                        let epoch = Arc::as_ptr(&job.lib) as usize as u64;
-                        match evaluate_design(&mut evaluator, g, &reg, &job.lib, epoch) {
-                            Ok(out) => {
-                                let mut d = (*out.design).clone();
-                                d.graph = job.design.graph.clone();
-                                let values = out
-                                    .report
-                                    .values
-                                    .iter()
-                                    .map(|(id, outs)| (*id, outs.iter().map(|(k, v)| (k.clone(), v.summary())).collect()))
-                                    .collect();
-                                let notes = out
-                                    .report
-                                    .status
-                                    .iter()
-                                    .filter(|(_, s)| !s.errors.is_empty() || !s.warnings.is_empty())
-                                    .map(|(id, s)| {
-                                        let mut lines: Vec<String> = s.errors.iter().map(|(i, m)| if s.items > 1 { format!("item {i}: {m}") } else { m.clone() }).collect();
-                                        lines.extend(s.warnings.iter().cloned());
-                                        (*id, lines)
-                                    })
-                                    .collect();
-                                graph_done = Some(GraphDone { design: d.clone(), values, notes, errors: Vec::new(), ok: true });
-                                field_from_graph = Some(out.field);
-                                job.design = d;
-                            }
-                            Err(e) => {
-                                graph_done = Some(GraphDone { design: job.design.clone(), values: BTreeMap::new(), notes: BTreeMap::new(), errors: vec![e], ok: false });
+                    let generation = job.generation;
+                    // One panic used to end the session's rebuilding: the
+                    // thread died, `jobs_tx.send` failed from then on, and
+                    // the app went quietly read-only. Now it is one failed
+                    // build with a message.
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        // A graph-driven design is evaluated first; the library's
+                        // identity is its epoch, so a replaced library re-runs it.
+                        let mut graph_done = None;
+                        let mut field_from_graph = None;
+                        if let Some(g) = &job.graph {
+                            let epoch = Arc::as_ptr(&job.lib) as usize as u64;
+                            match evaluate_design(&mut evaluator, g, &reg, &job.lib, epoch) {
+                                Ok(out) => {
+                                    let mut d = (*out.design).clone();
+                                    d.graph = job.design.graph.clone();
+                                    let values = out
+                                        .report
+                                        .values
+                                        .iter()
+                                        .map(|(id, outs)| (*id, outs.iter().map(|(k, v)| (k.clone(), v.summary())).collect()))
+                                        .collect();
+                                    let notes = out
+                                        .report
+                                        .status
+                                        .iter()
+                                        .filter(|(_, s)| !s.errors.is_empty() || !s.warnings.is_empty())
+                                        .map(|(id, s)| {
+                                            let mut lines: Vec<String> = s.errors.iter().map(|(i, m)| if s.items > 1 { format!("item {i}: {m}") } else { m.clone() }).collect();
+                                            lines.extend(s.warnings.iter().cloned());
+                                            (*id, lines)
+                                        })
+                                        .collect();
+                                    graph_done = Some(GraphDone { design: d.clone(), values, notes, errors: Vec::new(), ok: true });
+                                    field_from_graph = Some(out.field);
+                                    job.design = d;
+                                }
+                                Err(e) => {
+                                    graph_done = Some(GraphDone { design: job.design.clone(), values: BTreeMap::new(), notes: BTreeMap::new(), errors: vec![e], ok: false });
+                                }
                             }
                         }
-                    }
-                    let result = ringdesign_core::mesh::build(&job.design, &job.lib, job.params);
-                    let cast = castability::analyze(
-                        &result.mesh,
-                        &job.design.draft,
-                        job.design.inner_radius_mm(),
-                    );
-                    // The verdict itself comes from the surface, at a fixed
-                    // sampling so it cannot wobble with preview quality; any
-                    // undercut arrives located and blamed.
-                    let field = match field_from_graph {
-                        Some(f) => f,
-                        None => castability::attributed_field_report(&job.design, &job.lib, &job.design.draft, 192, 128),
-                    };
-                    let stones = ringdesign_core::stones::report(&job.design, field.parting_z_mm);
-                    let hot_spot = castability::modulus_scan(&job.design, &job.lib, 64)
-                        .into_iter()
-                        .max_by(|a, b| a.1.total_cmp(&b.1));
-                    let gems = crate::gems::preview_vertices(&job.design, &job.lib);
-                    if done_tx
-                        .send(Done {
-                            generation: job.generation,
+                        let result = ringdesign_core::mesh::build(&job.design, &job.lib, job.params);
+                        let cast = castability::analyze(
+                            &result.mesh,
+                            &job.design.draft,
+                            job.design.inner_radius_mm(),
+                        );
+                        // The verdict itself comes from the surface, at a fixed
+                        // sampling so it cannot wobble with preview quality; any
+                        // undercut arrives located and blamed.
+                        let field = match field_from_graph {
+                            Some(f) => f,
+                            None => castability::attributed_field_report(&job.design, &job.lib, &job.design.draft, 192, 128),
+                        };
+                        let stones = ringdesign_core::stones::report(&job.design, field.parting_z_mm);
+                        let hot_spot = castability::modulus_scan(&job.design, &job.lib, 64)
+                            .into_iter()
+                            .max_by(|a, b| a.1.total_cmp(&b.1));
+                        let gems = crate::gems::preview_vertices(&job.design, &job.lib);
+        Done {
+                            generation,
                             result,
                             cast,
                             field,
@@ -1001,9 +1038,20 @@ impl Worker {
                             stones,
                             gems,
                             graph: graph_done,
-                        })
-                        .is_err()
-                    {
+                        }
+                    }));
+                    let msg = match outcome {
+                        Ok(done) => WorkerMsg::Done(Box::new(done)),
+                        Err(p) => WorkerMsg::Failed {
+                            generation,
+                            message: p
+                                .downcast_ref::<&str>()
+                                .map(|s| s.to_string())
+                                .or_else(|| p.downcast_ref::<String>().cloned())
+                                .unwrap_or_else(|| "panicked".into()),
+                        },
+                    };
+                    if done_tx.send(msg).is_err() {
                         break;
                     }
                 }


### PR DESCRIPTION
Part of #172 (M10.4), under #154. Findings F152, F153, F154, F163, F165, F167.

Six ways the app could destroy or silently corrupt what a user had made.

## The save could take the file with it

`library::save_design` was `fs::write`, which **truncates before it writes**. A design carrying embedded 16-bit PNGs and hand-drawn strokes is a large single write, so interrupting it — full disk, power, a panic — left nothing at all where a stale file would have been fine.

`write_atomic` writes a sibling temp, `sync_all`s it, moves the previous file to `.bak`, then renames. Rename is atomic on every filesystem this runs on, so the path names the old file or the new one and never half of one. The outline and profile writers use it too.

## Art vanished on restart

`open_design_path` unpacks embedded alphas then bakes. The session-restore path in `RingDesignerApp::new` **only baked** — so a design reopened by restarting the app came back without the art it was saved with.

## Painted metal survived Ctrl+Z

Strokes, inscriptions and SVG art travel in the design as source data and live in the shared `AlphaLibrary` as rasters. `apply_history` restored the design and not the rasters, so the layers went on reading the raster the stroke had already made. It re-bakes now.

## Two designs, one name, the wrong art

`unpack_embedded` skipped any name already present, and the library accumulates for the whole session — so opening a second design carrying its own `band` or `sketch` rendered the **first** design's art, silently. A design's embedded copy is authoritative for that design, and `embed_alphas` never embeds anything regenerable (no procedural builtin, no stroke, no inscription), so replacing cannot clobber one.

## One panic ended the session's rebuilding

The build worker was an unguarded loop on a single thread. A panic anywhere in `mesh::build`, `attribute_undercuts`, `stones::report` or the gem preview killed it; `jobs_tx.send` then failed for the rest of the session and the app went **quietly read-only** — no error, no way back short of a restart.

A job is wrapped in `catch_unwind` now, and the channel carries a `WorkerMsg::Failed { generation, message }`. A panic is one failed build with a message, the last good geometry still on screen.

## A design file could rasterize without limit

`AlphaLibrary::insert` had no entry cap, though `drawn`, `texts`, `svgs` and `recipes` are all `Vec`s read straight out of a design file and every one rasterizes in on load. The per-alpha *size* was capped; the *count* was not, so a file with ten thousand one-glyph inscriptions was a memory bomb with no loop to blame — the 67 GB lesson, applied to the other door. `MAX_ENTRIES = 4096`.

## Tests

- `a_save_is_atomic_and_leaves_a_backup` — the second save is readable, the first is recoverable from `.bak`, no `.tmp` left behind.
- `a_second_design_brings_its_own_art` — two designs sharing an alpha name, and the one being opened wins.

## Two of the eight stay open

- **F203** — profile and outline library files carry no version ladder.
- **F164** — `FORMAT_VERSION` has not moved through any format addition. That is defensible for serde-defaulted fields (nothing needs migrating), so it wants a decision recorded rather than a bump for its own sake.

## Verification

`cargo test --workspace --offline` under `systemd-run --user --scope -p MemoryMax=4G`: **331 core, 19 suites, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)