### PR TITLE
Hygiene, the hot path, and two things the doctrine said that were not so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,12 +562,19 @@ crest in the wrong place — measured at 1.44% undercut on a shield before this,
 0.011% after. It also subsumes the old crest-levelling: the crest sits at the
 parting plane by construction rather than by a correction term.
 
-`HEAD_FACE_DRAFT` uses it to draft the head's flanks by 9%, so the table is a
-slightly smaller copy of the outline that carries it — which is what the
-reference does (16.0 mm body, 14.7 mm table) and what a two-part mould wants of
-the one surface it has to slide off. Proportional, not a distance: insetting by
-a distance drafts a narrow station to nothing and leaves a fin standing off the
-end of the head, which a heart does first.
+`HEAD_FACE_DRAFT` uses it to draft the head's flanks by **2%**, so the table is
+a slightly smaller copy of the outline that carries it — a token draft rather
+than a look, which is what a two-part mould wants of the one surface it has to
+slide off. Proportional, not a distance: insetting by a distance drafts a
+narrow station to nothing and leaves a fin standing off the end of the head,
+which a heart does first.
+
+The reference's own 16.0 mm body under a 14.7 mm table is an 8% inset, and that
+is **not** this constant: the body is wider than the face because
+`SignetOutline::body_extent` fairs the face's hollows out with the rolling
+ball, not because the flanks are drafted. Conflating the two is what put 0.09
+here originally — see the measurement table above, which records the correction
+to 0.02.
 
 #### The shank is flat, and the swell is what makes it read
 
@@ -978,8 +985,10 @@ automatically, because `u` wraps at the circumference. That is why
 `BorderLayer::rope_twists` are all `u32`. Do not make them floats.
 
 Alphas must also tile seamlessly in themselves — `Procedural::generate` builds
-every pattern from functions periodic in both axes, and `Alpha::make_seamless`
-cross-fades imported images.
+every pattern from functions periodic in both axes. An **imported** image is
+used as drawn, seam and all: `Alpha::make_seamless` exists and is tested and
+nothing calls it, which is a gap rather than a mechanism — it becomes an
+`alpha.transform` op in M16.
 
 ### Stability under shank modulation
 

--- a/crates/ringdesign-core/src/alpha.rs
+++ b/crates/ringdesign-core/src/alpha.rs
@@ -279,6 +279,15 @@ impl Alpha {
 
     /// Cross-fade opposite edges so adjacent tiles butt without a visible seam.
     /// `blend` is the fraction of the image blended, 0..0.5.
+    /// Cross-fade the opposite edges of a tile into each other so an imported
+    /// image tiles without a seam.
+    ///
+    /// **Nothing in the app calls this.** CLAUDE.md named it as the mechanism
+    /// imports go through and it never was one; an imported image is used as
+    /// drawn, seam and all. It is kept because it is correct and tested, and
+    /// because the alpha-operator work (M16) wants it as one of the ops in
+    /// `alpha.transform`, where it belongs — a per-alpha choice rather than
+    /// something done silently to everything that comes in.
     pub fn make_seamless(&self, blend: f64) -> Alpha {
         if self.is_empty() || self.data.len() != self.width * self.height {
             return self.clone();

--- a/crates/ringdesign-core/src/castability.rs
+++ b/crates/ringdesign-core/src/castability.rs
@@ -1361,10 +1361,15 @@ pub fn attribute_undercuts(
         .map(|(i, _)| i)
         .collect();
     let mut masked: Vec<(usize, Vec<(f64, f64, f64, f64)>)> = Vec::new();
+    // One clone, toggled in place. It used to be a clone of the whole
+    // `RingDesign` per enabled layer — base64 embedded PNGs, drawn strokes,
+    // inscriptions, SVG art, the graph and all — to change a single bool, on
+    // every settled build that carries undercut to explain.
+    let mut probe = design.clone();
     for &i in &enabled {
-        let mut d = design.clone();
-        d.layers.layers[i].enabled = false;
-        masked.push((i, field_undercuts(&d, lib, min_draft, parting_z, T, P)));
+        probe.layers.layers[i].enabled = false;
+        masked.push((i, field_undercuts(&probe, lib, min_draft, parting_z, T, P)));
+        probe.layers.layers[i].enabled = true;
     }
 
     regions

--- a/crates/ringdesign-core/src/sizing.rs
+++ b/crates/ringdesign-core/src/sizing.rs
@@ -5,14 +5,34 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct RingSize(pub f64);
 
+/// Smallest and largest finger size the app will take.
+///
+/// Not a style limit — a sanity one. `RingSize` is a bare `pub f64` that
+/// anything can construct, and it feeds `inner_radius_mm`, which feeds every
+/// sweep and every clamp in the builder. A NaN or a 1e300 arriving from a
+/// file, an interpolation or an MCP call used to travel all the way to the
+/// vertices.
+pub const MIN_SIZE: f64 = 0.5;
+pub const MAX_SIZE: f64 = 20.0;
+
 impl RingSize {
-    /// Round to the nearest quarter size.
+    /// Round to the nearest quarter size, and refuse a number that is not one.
+    ///
+    /// The quarter-size rounding was documented and then bypassed on every
+    /// path that built `RingSize(x)` directly, which is most of them.
     pub fn new(size: f64) -> Self {
-        RingSize((size * 4.0).round() / 4.0)
+        let size = if size.is_nan() { 7.0 } else { size };
+        RingSize((size.clamp(MIN_SIZE, MAX_SIZE) * 4.0).round() / 4.0)
+    }
+
+    /// The size as a number the rest of the engine can divide by: finite and
+    /// inside the range, whatever was put in the tuple.
+    pub fn sane(self) -> f64 {
+        if self.0.is_nan() { 7.0 } else { self.0.clamp(MIN_SIZE, MAX_SIZE) }
     }
 
     pub fn inner_circumference_mm(&self) -> f64 {
-        36.5 + self.0 * 2.55
+        36.5 + self.sane() * 2.55
     }
 
     pub fn inner_diameter_mm(&self) -> f64 {
@@ -50,5 +70,42 @@ impl RingSize {
 impl std::fmt::Display for RingSize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.display())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The only module in core with no tests, on the one number a customer
+    /// gives you.
+    #[test]
+    fn a_size_round_trips_through_its_own_geometry() {
+        for s in RingSize::common() {
+            let back = RingSize::from_circumference_mm(s.inner_circumference_mm());
+            assert!((back.0 - s.0).abs() < 1e-9, "{s} -> {back}");
+            let d = RingSize::from_diameter_mm(s.inner_diameter_mm());
+            assert!((d.0 - s.0).abs() < 1e-9, "{s} by diameter -> {d}");
+        }
+    }
+
+    /// A bare `pub f64` that feeds every clamp in the builder needs a floor
+    /// and a ceiling, or a NaN out of a file reaches the vertices.
+    #[test]
+    fn a_hostile_size_cannot_reach_the_geometry() {
+        assert_eq!(RingSize::new(f64::NAN).0, 7.0);
+        assert_eq!(RingSize::new(f64::INFINITY).0, MAX_SIZE);
+        assert_eq!(RingSize::new(-1e300).0, MIN_SIZE);
+        assert!(RingSize(f64::NAN).inner_circumference_mm().is_finite());
+        assert!(RingSize(1e300).inner_diameter_mm().is_finite());
+        assert!(RingSize(f64::NEG_INFINITY).inner_diameter_mm() > 0.0);
+    }
+
+    #[test]
+    fn new_rounds_to_the_quarter_it_documents() {
+        assert_eq!(RingSize::new(7.1).0, 7.0);
+        assert_eq!(RingSize::new(7.2).0, 7.25);
+        assert_eq!(RingSize::new(7.4).0, 7.5);
+        assert_eq!(RingSize::new(7.9).0, 8.0);
     }
 }


### PR DESCRIPTION
Part of #175 (M10.7), under #154. Findings F157, F160, F81, F161.

## The hot path

`attribute_undercuts` cloned the entire `RingDesign` **once per enabled layer** — base64 embedded PNGs, drawn strokes, inscriptions, SVG art, the graph and all — in order to flip a single bool. It runs on every settled build that has undercut to explain. One clone now, toggled in place and restored.

## `sizing.rs` had no tests, on the one number a customer gives you

It was the only module in core with none. `RingSize` is a bare `pub f64` that anything can construct, and it feeds `inner_radius_mm`, which feeds every sweep and every clamp in the builder — so a NaN or a `1e300` arriving from a file, an interpolation or an MCP call travelled all the way to the vertices.

`MIN_SIZE` / `MAX_SIZE` and a `sane()` read. `new` refuses a NaN and *clamps* an infinity rather than treating both as nonsense, because an infinity does mean "as large as possible" — that distinction is what the first draft of the test caught.

Four tests: the geometry round-trips through circumference and diameter for every common size, the quarter-size rounding it documents actually happens, and a hostile size cannot reach the mesh.

## Two doc drifts, both in the load-bearing document

**`Alpha::make_seamless`.** CLAUDE.md said it *"cross-fades imported images"* as the seamlessness mechanism for imports. Nothing calls it — an imported image is used as drawn, seam and all. That is a gap, not a mechanism, and it is exactly where M16's `alpha.transform` op belongs. Now said in both the doc and the function.

**`HEAD_FACE_DRAFT`.** The doc said it *"drafts the head's flanks by 9%"* — fifty lines after its own measurement table records the correction from 0.09 to **0.02**. Self-contradictory in one document.

Worth stating why the 9% was ever there: the reference's 16.0 mm body under a 14.7 mm table is an 8% inset, and that is **not this constant**. The body is wider than the face because `SignetOutline::body_extent` fairs the face's hollows out with the rolling ball, not because the flanks are drafted. Conflating the two is what put 0.09 there originally.

## Five of the ten stay open, and why

- **F159** (cut `outline.rs` out of `field.rs`, `signet.rs` out of `profile.rs`) and **F158** (resolve each layer's alpha once per build rather than a SipHash of the name per sample) are refactors — the second changes `height`'s signature through the whole layer tree — and want their own change with the sweep-vs-refine equivalence pinned.
- **F17≡F30** (two disagreeing hard wall floors across 39 sites) and **F172** (the default band is a `HalfRound` the doctrine says "honestly has no side", so the first thing a new user does produces an uncastable ring) both **move geometry**, and the golden corpus that would catch a mistake there is still unmerged on #192.
- **F162** — *track `tools/harvest/`, the evidence for the doctrine* — **contradicts an explicit rule in CLAUDE.md**: *"Nothing derived from proprietary assets enters the repository (`assets/`, `tools/harvest/`, decoded material stay gitignored)."* The auditor was right that losing those 42 scripts makes every measured claim unreproducible, and also wrong to propose committing them wholesale. The resolvable version is probably *our decoders committed, decoded output still ignored* — but that is your call, not a hygiene task. Flagged rather than done.

## Verification

Full `cargo clean` and rebuild, then `cargo test --workspace --offline` under `systemd-run --user --scope -p MemoryMax=6G`: **332 core, 19 suites, 0 failures.**

The clean was not optional: repeated branch switching had left the target directory mixed enough to produce `undefined hidden symbol` link failures in `ringdesign-core` and `ringdesign-mcp` that were not code errors. Worth knowing if you see one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)