### PR TITLE
One verdict, spoken once

### DIFF
--- a/crates/ringdesign-core/src/castability.rs
+++ b/crates/ringdesign-core/src/castability.rs
@@ -1890,17 +1890,47 @@ mod tests {
         assert_eq!(rep.undercut_fraction(), 0.0);
         assert_eq!(rep.verdict, Verdict::Castable, "{:?}", rep.notes);
         assert!((2..=6).contains(&rep.notes.len()), "{:?}", rep.notes);
+        // The verdict is the field's. A guarantee pinned only by the retired
+        // face analyzer is pinned by the measure the doctrine says not to
+        // judge from.
+        let lib = crate::alpha::AlphaLibrary::builtin();
+        let f = analyze_field(&d, &lib, &d.draft, 192, 96);
+        assert_eq!(f.verdict, Verdict::Castable, "{:?}", f.notes);
+        assert_eq!(f.undercut_area_mm2, 0.0, "{:?}", f.notes);
     }
 
+    /// The superellipse drop is monotone from a single crest for any `a, b > 0`,
+    /// so no base profile can undercut a ±Z pull. That is a construction
+    /// guarantee, and it is checked here on the surface itself as well as on
+    /// one tessellation of it.
     #[test]
     fn every_profile_style_is_free_of_undercuts() {
+        let lib = crate::alpha::AlphaLibrary::builtin();
         for &style in crate::profile::ProfileStyle::ALL {
             let mut d = RingDesign::default();
             d.profile.apply_style(style);
             let out = built(&d);
             let rep = analyze(&out.mesh, &d.draft, d.inner_radius_mm());
             assert_eq!(rep.undercut, 0, "{:?} undercuts: {:?}", style, rep.notes);
+            let f = analyze_field(&d, &lib, &d.draft, 192, 96);
+            assert_eq!(
+                f.undercut_area_mm2, 0.0,
+                "{:?} undercuts the field too: {:?}",
+                style, f.notes
+            );
         }
+    }
+
+    /// The other half of the same claim: the field must *find* a real
+    /// undercut, or its silence on every profile above means nothing.
+    #[test]
+    fn the_field_refuses_a_straight_walled_boss() {
+        let d = undercutting_design();
+        let lib = crate::alpha::AlphaLibrary::builtin();
+        let f = analyze_field(&d, &lib, &d.draft, 256, 128);
+        assert!(f.undercut_area_mm2 > 0.0, "the field missed it: {:?}", f.notes);
+        assert!(f.worst_draft_deg < -10.0, "worst draft {}", f.worst_draft_deg);
+        assert_ne!(f.verdict, Verdict::Castable, "{:?}", f.notes);
     }
 
     #[test]

--- a/crates/ringdesign-gui/src/panels/mod.rs
+++ b/crates/ringdesign-gui/src/panels/mod.rs
@@ -1004,7 +1004,16 @@ fn quality_label(params: &BuildParams) -> String {
 fn status_bar(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
     ui.add_space(2.0);
     ui.horizontal(|ui| {
-        let (glyph, color) = match app.cast.as_ref().map(|c| c.verdict) {
+        // The field-sampled verdict, not the mesh analyzer's. A refined build
+        // reports a phantom on the crest line that does not fall with the
+        // tolerance, so the chip used to disagree with the banner six inches
+        // above it on exactly the designs that most need a clear answer.
+        let verdict = app
+            .field
+            .as_ref()
+            .map(|f| f.verdict)
+            .or_else(|| app.cast.as_ref().map(|c| c.verdict));
+        let (glyph, color) = match verdict {
             Some(v) => (
                 match v {
                     ringdesign_core::castability::Verdict::Castable => icon::CHECK_CIRCLE,
@@ -1014,11 +1023,12 @@ fn status_bar(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
             ),
             None => (icon::CIRCLE_DASHED, theme::TEXT_DIM),
         };
-        if let Some(c) = app.cast.as_ref() {
-            ui.label(egui::RichText::new(format!("{glyph} {}", c.verdict.label())).color(color));
-        } else {
-            ui.label(egui::RichText::new(format!("{glyph} —")).color(color));
-        }
+        match verdict {
+            Some(v) => {
+                ui.label(egui::RichText::new(format!("{glyph} {}", v.label())).color(color))
+            }
+            None => ui.label(egui::RichText::new(format!("{glyph} —")).color(color)),
+        };
 
         ui.separator();
         ui.label(egui::RichText::new(&app.status).color(theme::TEXT_DIM));

--- a/crates/ringdesign-gui/src/panels/report.rs
+++ b/crates/ringdesign-gui/src/panels/report.rs
@@ -146,8 +146,9 @@ fn castability(
 
     ui.horizontal(|ui| {
         ui.label(egui::RichText::new("Parting plane").color(theme::TEXT_DIM));
+        let parting = field.map_or(cast.parting_z_mm, |f| f.parting_z_mm);
         ui.add(
-            egui::Label::new(egui::RichText::new(format!("{:+.2} mm", cast.parting_z_mm)).strong())
+            egui::Label::new(egui::RichText::new(format!("{parting:+.2} mm")).strong())
                 .selectable(true),
         );
         let tag = if draft.auto_parting {
@@ -162,8 +163,101 @@ fn castability(
         "Height of the split between cope and drag; the mould pulls +Z above it and -Z below it.",
     );
 
-    let areas = class_areas(cast);
     ui.add_space(4.0);
+    // The verdict's own numbers. `cast` is the mesh face analyzer, kept for
+    // painting the viewport: on a signet every swept build reports 0.000%
+    // while refined builds report 0.10-0.18% at up to -15 deg, and it does not
+    // fall with the tolerance. Quoting it here put a figure under the field
+    // banner that the banner disagreed with.
+    if let Some(f) = field {
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("Worst draft").color(theme::TEXT_DIM));
+            ui.add(
+                egui::Label::new(
+                    egui::RichText::new(format!("{:+.1}°", f.worst_draft_deg))
+                        .strong()
+                        .color(draft_color(f.worst_draft_deg, draft.min_draft_deg)),
+                )
+                .selectable(true),
+            );
+            ui.label(
+                egui::RichText::new(format!(
+                    "min {:.1}° • {:.3}% undercuts",
+                    draft.min_draft_deg,
+                    f.undercut_fraction() * 100.0
+                ))
+                .small()
+                .color(theme::TEXT_DIM),
+            );
+        })
+        .response
+        .on_hover_text(
+            "Read off the surface itself on a (theta, s) grid, not off any one tessellation of it \
+             — so no build kind or resolution can put a phantom in it.",
+        );
+        ui.add_space(4.0);
+    }
+
+    if let Some(f) = field {
+        for n in f
+            .notes
+            .iter()
+            .filter(|n| !n.starts_with("Field-sampled: the surface itself"))
+        {
+            ui.horizontal_top(|ui| {
+                ui.label(egui::RichText::new("•").color(theme::ACCENT));
+                ui.add(egui::Label::new(egui::RichText::new(n)).wrap());
+            });
+        }
+    }
+    for f in dfm {
+        ui.horizontal_top(|ui| {
+            ui.label(egui::RichText::new(icon::WARNING).color(theme::WARN));
+            ui.add(
+                egui::Label::new(
+                    egui::RichText::new(format!("{}: {}", f.label, f.message))
+                        .small()
+                        .color(theme::WARN),
+                )
+                .wrap(),
+            );
+        });
+    }
+
+    ui.add_space(6.0);
+    let census_open = field.is_none();
+    egui::CollapsingHeader::new(format!("{} Face census — this build's mesh", icon::TRIANGLE))
+        .default_open(census_open)
+        .show(ui, |ui| face_census(ui, cast, draft, field.is_some()));
+
+    clicked_draft_button(ui, already_draft)
+}
+
+/// The mesh face analyzer's own numbers, boxed off from the verdict.
+///
+/// It is what paints the Draft view, so it earns a place; it is not what
+/// decides anything, so it does not get the headline. Both facts are said on
+/// screen rather than left to be inferred.
+fn face_census(
+    ui: &mut egui::Ui,
+    cast: &CastReport,
+    draft: &DraftSettings,
+    field_present: bool,
+) {
+    if field_present {
+        ui.label(
+            egui::RichText::new(
+                "Face normals of the mesh that is drawn, and the source of the draft colours. \
+                 An irregular mesh reports a small phantom along the crest line that does not \
+                 fall with the tolerance, so the verdict above is sampled from the surface \
+                 instead.",
+            )
+            .small()
+            .color(theme::TEXT_DIM),
+        );
+        ui.add_space(4.0);
+    }
+    let areas = class_areas(cast);
     class_bar(ui, cast, &areas);
     ui.add_space(3.0);
 
@@ -210,7 +304,7 @@ fn castability(
 
     ui.add_space(5.0);
     ui.horizontal(|ui| {
-        ui.label(egui::RichText::new("Worst draft").color(theme::TEXT_DIM));
+        ui.label(egui::RichText::new("Worst face").color(theme::TEXT_DIM));
         ui.add(
             egui::Label::new(
                 egui::RichText::new(format!("{:+.1}°", cast.worst_draft_deg))
@@ -226,37 +320,13 @@ fn castability(
         );
     })
     .response
-    .on_hover_text("Most negative draft on the mesh. Below zero the face leans back under itself and locks in the sand.");
+    .on_hover_text("Most negative draft on this tessellation. Below zero the face leans back under itself.");
 
     notes(ui, &cast.notes);
-    if let Some(f) = field {
-        // The field's own findings: the noise-band line and any located,
-        // blamed undercut arcs.
-        for n in f
-            .notes
-            .iter()
-            .filter(|n| !n.starts_with("Field-sampled: the surface itself"))
-        {
-            ui.horizontal_top(|ui| {
-                ui.label(egui::RichText::new("•").color(theme::ACCENT));
-                ui.add(egui::Label::new(egui::RichText::new(n)).wrap());
-            });
-        }
-    }
-    for f in dfm {
-        ui.horizontal_top(|ui| {
-            ui.label(egui::RichText::new(icon::WARNING).color(theme::WARN));
-            ui.add(
-                egui::Label::new(
-                    egui::RichText::new(format!("{}: {}", f.label, f.message))
-                        .small()
-                        .color(theme::WARN),
-                )
-                .wrap(),
-            );
-        });
-    }
+}
 
+/// The button that turns the draft colours on, and whether it was pressed.
+fn clicked_draft_button(ui: &mut egui::Ui, already_draft: bool) -> bool {
     ui.add_space(6.0);
     let button = egui::Button::new(format!("{} Show draft colours", icon::PALETTE));
     let clicked = ui

--- a/crates/ringdesign-gui/src/viewport.rs
+++ b/crates/ringdesign-gui/src/viewport.rs
@@ -850,6 +850,10 @@ fn draw_legend(app: &RingDesignerApp, shade: ShadeMode, painter: &egui::Painter,
                     theme::TEXT,
                 ));
             }
+            // These are this build's faces, which is the right thing to paint
+            // and the wrong thing to judge from: an irregular mesh reports a
+            // phantom along the crest line that does not fall with resolution.
+            rows.push((None, "mesh faces — the verdict is field-sampled".into(), theme::TEXT_DIM));
         }
         (ShadeMode::Wall, _) => {
             let m = app.design.draft.min_section_mm;


### PR DESCRIPTION
Closes #170 (M10.2), under #154. Findings F123≡F166, F127.

*(Reopened as a new PR: this was #193, stacked on #190. Merging #190 with `--delete-branch` removed its base branch and GitHub auto-closed it. Same branch, same commit, retargeted to `master`.)*

## The problem

CLAUDE.md's doctrine is that `analyze_field` is the verdict, and that a refined mesh reports a phantom along the crest line which **does not fall with the tolerance** — 0.10–0.18% at up to −15° on a signet, against 0.000% on every swept build of the same ring.

The app then showed both numbers, disagreeing, and gave the headline to the one it says not to trust:

- The report panel drew the field-sampled banner and, directly beneath it, the retired analyzer's class bar, four class counts and a bold **Worst draft**.
- The status chip in the footer read `app.cast`.
- The Draft legend gave counts with no indication of where they came from.

So on exactly the designs that most need a clear answer, the chip, the banner and the figure under it could each say something different.

## The fix

- The panel's headline draft figure and undercut fraction are **the field's**, with a hover explaining they are read off the surface on a `(theta, s)` grid rather than off any one tessellation.
- The parting plane shown is the one the verdict was actually reached at.
- The face census — class bar, counts, mesh notes, and its own worst face, relabelled **Worst face** — moves into a collapsed section that says on screen what it is for: painting the Draft view. It opens by default only when there is no field report yet.
- The status chip reads the field, falling back to the mesh only before the first field report exists.
- The Draft legend gains a dim line: *mesh faces — the verdict is field-sampled*.

## The guarantees were pinned by the retired measure

The doctrine's central claim is *"nothing needs judging from any build now"*, and yet `plain_domed_band_is_castable` and `every_profile_style_is_free_of_undercuts` — the superellipse drop, which is a **construction guarantee**, not a tuning result — asserted only against `analyze`.

Both now assert on the surface itself as well. And `the_field_refuses_a_straight_walled_boss` is the other half: the field has to *find* a real undercut, or its silence across nine profiles means nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)