### PR TITLE
The DFM reads the band it is on, and each head its own construction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1062,11 +1062,31 @@ pins both directions. On top of that:
   is wide — and the measurement replaces the footprint's 15%-of-size
   guess, which called a 2.25 mm hook with a 0.45 mm stroke mush. Run on
   the shipped templates (`dfm::measured_tests::the_templates_measured`,
-  `--nocapture`) it names three: Waves at 0.10 mm strokes on the waved
-  hexagon signet's 11.8 × 1.8 mm cells, Chevron at 0.07 mm gaps on the
-  shouldered cushion's shoulders, Braid at 0.04 mm gaps on the braided
-  band — all castable by the field, all casting softer than drawn, which
-  is what the chip now says instead of nothing.
+  `--nocapture`) it names three: Waves at 0.04 mm strokes on the waved
+  hexagon signet's 11.8 × 0.8 mm cells, Chevron at 0.03 mm gaps on the
+  shouldered cushion's 7.6 × 0.6 mm shoulders, Braid at 0.04 mm gaps on
+  the braided band — all castable by the field, all casting softer than
+  drawn, which is what the chip now says instead of nothing.
+
+  **A tiling is measured at the tightest station its window covers**, not
+  against the reference section. The chart's `v` is the section's own arc
+  normalized, so a cell is the reference height only where the band is the
+  reference thickness; a shoulder that narrows to a third of it carries
+  cells a third as tall, and the mask's strokes with them. Reading the
+  reference context alone under-reported both signets by about 2.5x — the
+  two figures above moved from 0.10 and 0.07 when `worst_arc_ratio` was
+  added, and the finding now names the angle (185° on both). A *decal* had
+  always done this per station; a tiling covers an arc, so what matters is
+  the worst one in it.
+
+  A **flute** is measured *around* the ring, not across the band. It was
+  filed as a `FeatureFootprint::across` — whose own doc named a flute —
+  which sets `feature_u_mm` to infinity, and `metal_feature_mm` scales only
+  the `u` side by the arc ratio. So reeding was the one ornament that
+  evaded the arc-scale correction entirely, reported 15-20% coarser than
+  the metal it becomes. `FeatureFootprint::along` is the right shape, and
+  the **land** between two flutes counts as well as the cut: a dense
+  reeding fails on its land first, and only the cut was ever measured.
 - **Undercut attribution** (`castability::attribute_undercuts`): undercut
   arcs are clustered in theta off the field samples, then each enabled layer
   is muted in turn at the *same parting plane* — the culprit is the layer

--- a/crates/ringdesign-core/src/dfm.rs
+++ b/crates/ringdesign-core/src/dfm.rs
@@ -102,17 +102,24 @@ pub fn findings_in(design: &RingDesign, lib: &crate::AlphaLibrary) -> Vec<DfmFin
         let mut ts = Vec::new();
         let one = crate::field::LayerStack { layers: vec![entry.clone()] };
         tilings(&one, &mut ts);
+        let (ratio, at_deg) = worst_arc_ratio(design, entry, &ctx);
         for t in ts {
-            let Some((finest, what)) = tiling_finest_mm(t, lib, &ctx) else { continue };
+            let Some((finest, what)) = tiling_finest_mm_at(t, lib, &ctx, ratio) else { continue };
             let (cw, ch) = t.cell_size(&ctx);
+            let ch = ch * ratio;
             if finest >= min {
                 continue;
             }
+            let where_ = if ratio < 0.98 {
+                format!(" at its tightest station, {at_deg:.0}°,")
+            } else {
+                String::new()
+            };
             out.push(DfmFinding {
                 layer: i,
                 label: entry.name.clone(),
                 message: format!(
-                    "the {} texture's finest {what} measure {finest:.2} mm on {cw:.1} x {ch:.1} mm cells against the sand's {min:.2} mm floor — they will cast as mush. Coarsen the pattern, use fewer repeats, or accept the softness.",
+                    "the {} texture's finest {what}{where_} measure {finest:.2} mm on {cw:.1} x {ch:.1} mm cells against the sand's {min:.2} mm floor — they will cast as mush. Coarsen the pattern, use fewer repeats, or accept the softness.",
                     t.alpha
                 ),
             });
@@ -384,12 +391,67 @@ pub fn tiling_finest_mm(
     lib: &crate::alpha::AlphaLibrary,
     ctx: &crate::field::FieldContext,
 ) -> Option<(f64, &'static str)> {
+    tiling_finest_mm_at(t, lib, ctx, 1.0)
+}
+
+/// [`tiling_finest_mm`] with the cell's height taken at `v_scale` of the
+/// reference section's arc.
+///
+/// The chart's `v` is the section's own arc normalized, so a layer's cell is
+/// only the reference height where the band is the reference thickness. A
+/// shoulder that narrows to two thirds of it carries cells two thirds as tall,
+/// and the mask's strokes with them — which the measurement missed entirely
+/// while it read the reference context alone. A *decal* already did this per
+/// station; a tiling covers an arc, so what matters is the tightest station
+/// in it.
+pub fn tiling_finest_mm_at(
+    t: &crate::tiling::TilingLayer,
+    lib: &crate::alpha::AlphaLibrary,
+    ctx: &crate::field::FieldContext,
+    v_scale: f64,
+) -> Option<(f64, &'static str)> {
     let (ink_px, gap_px) = tiling_feature_px(t, lib)?;
     let alpha = lib.get(&t.alpha)?;
     let (cw, ch) = t.cell_size(ctx);
+    let ch = ch * v_scale.clamp(0.05, 8.0);
     let scale = (cw / alpha.width.max(1) as f64).min(ch / alpha.height.max(1) as f64);
     let (ink, gap) = (ink_px * scale, gap_px * scale);
     Some(if ink <= gap { (ink, "strokes") } else { (gap, "gaps") })
+}
+
+/// The tightest section a layer's window covers, as a ratio of the reference
+/// section's arc, and the angle it is at.
+///
+/// A modulated band is not one section: `sample_mod`'s `surface_len_mm` moves
+/// with the shank, and every layer measured against the reference alone was
+/// judged on a band it does not sit on everywhere.
+fn worst_arc_ratio(
+    design: &RingDesign,
+    entry: &crate::field::LayerEntry,
+    ctx: &crate::field::FieldContext,
+) -> (f64, f64) {
+    const STATIONS: usize = 72;
+    let inner_r = design.inner_radius_mm();
+    let crest_r = inner_r + design.profile.thickness_mm;
+    let reference = ctx.band_v_len_mm.max(1e-9);
+    let mut worst = (1.0f64, 0.0f64);
+    for k in 0..STATIONS {
+        let theta = k as f64 / STATIONS as f64 * 360.0;
+        // The layer's own gate, read through the mask it actually uses: a
+        // station the window keeps out cannot be the one that fails.
+        let u = theta / 360.0 * ctx.circumference_mm;
+        let uv = crate::field::Uv { u, v: ctx.band_v_len_mm * 0.5 };
+        if entry.window.enabled && entry.window.mask(uv, ctx) <= 1e-6 {
+            continue;
+        }
+        let m = design.modulation_at(theta, inner_r, crest_r);
+        let len = design.profile.sample_mod(inner_r, 96, &m).surface_len_mm;
+        let ratio = len / reference;
+        if ratio.is_finite() && ratio < worst.0 {
+            worst = (ratio, theta);
+        }
+    }
+    worst
 }
 
 /// The mask's finest ink and gap in texels, after the layer's own shaping.
@@ -452,4 +514,77 @@ pub fn fit_to_floor(
     }
     t.repeats_around = (n as i64).clamp(1, 4096) as u32;
     FloorFit::Repeats(t.repeats_around)
+}
+
+#[cfg(test)]
+mod flute_tests {
+    use crate::field::{FlutesLayer, FluteProfile, Layer, LayerEntry};
+    use crate::RingDesign;
+
+    /// `FeatureFootprint::across` sets `feature_u_mm = INFINITY`, and
+    /// `metal_feature_mm` scales only the `u` side by the arc ratio — so a
+    /// flute filed as `across` was reported at its chart width, never at the
+    /// metal width. `u` is arc at the crest radius and everything else sits
+    /// inside it: on a squared band the side face runs at ~0.85 of that, so
+    /// the figure was 15-20% optimistic, in the unsafe direction, on the
+    /// surface the doctrine sends all ornament to.
+    #[test]
+    fn a_flute_is_measured_around_the_ring_and_at_its_metal_width() {
+        let mut d = RingDesign::default();
+        d.profile.apply_style(crate::ProfileStyle::Flat);
+        d.profile.width_mm = 6.0;
+        d.profile.thickness_mm = 3.0;
+        d.profile.flatten_sides();
+        let ctx = d.field_context();
+
+        let flutes = FlutesLayer {
+            count: 30,
+            profile: FluteProfile::Round,
+            width_mm: 1.2,
+            height_mm: 0.3,
+            ..Default::default()
+        };
+        let entry = LayerEntry::new("reeding", Layer::Flutes(flutes));
+        let fp = entry.layer.feature_footprints(&ctx);
+        assert_eq!(fp.len(), 1);
+
+        // Narrow around the ring, unlimited across the band — the other way
+        // round from a rail or a milgrain line.
+        assert!(fp[0].feature_u_mm.is_finite(), "a flute is narrow in u");
+        assert!(fp[0].feature_v_mm.is_infinite(), "and runs the band in v");
+
+        // And the arc correction now actually reaches it.
+        let chart = fp[0].min_feature_mm();
+        let metal = fp[0].metal_feature_mm(&ctx);
+        assert!(
+            metal < chart * 0.999,
+            "metal {metal:.4} must be under the chart figure {chart:.4}"
+        );
+    }
+
+    /// A dense reeding fails on the bare band between two cuts long before it
+    /// fails on the cut, and only the cut was ever measured.
+    #[test]
+    fn the_land_between_flutes_is_a_feature_too() {
+        let d = RingDesign::default();
+        let ctx = d.field_context();
+        let pitch = ctx.circumference_mm / 60.0;
+        // Cuts wide enough that the land between them is the finer of the two.
+        let width = pitch * 0.85;
+        let flutes = FlutesLayer {
+            count: 60,
+            profile: FluteProfile::Round,
+            width_mm: width,
+            height_mm: 0.25,
+            ..Default::default()
+        };
+        let entry = LayerEntry::new("dense", Layer::Flutes(flutes));
+        let fp = entry.layer.feature_footprints(&ctx);
+        let land = pitch - width;
+        assert!(
+            (fp[0].feature_u_mm - land).abs() < 1e-6,
+            "the land ({land:.4}) is finer than the cut ({width:.4}) and must be what is reported, got {:.4}",
+            fp[0].feature_u_mm
+        );
+    }
 }

--- a/crates/ringdesign-core/src/field.rs
+++ b/crates/ringdesign-core/src/field.rs
@@ -621,11 +621,20 @@ impl Layer {
             }
             Layer::Group(g) => g.stack.feature_footprints(ctx),
             Layer::Curve(l) => l.feature_footprints(ctx),
-            Layer::Flutes(l) => vec![FeatureFootprint::across(
-                l.width_mm.max(0.1),
-                None,
-                (0.0, ctx.band_v_len_mm),
-            )],
+            Layer::Flutes(l) => {
+                // Two features, not one: the flute and the land between two
+                // of them. A dense reeding fails on its land long before its
+                // cut, and only the cut was ever measured.
+                let width = l.width_mm.max(0.0);
+                let pitch = ctx.circumference_mm / l.count.max(1) as f64;
+                let land = (pitch - width).max(0.0);
+                let finest = if land > 0.0 { width.min(land) } else { width };
+                vec![FeatureFootprint::along(
+                    finest.max(0.1),
+                    None,
+                    (0.0, ctx.band_v_len_mm),
+                )]
+            }
             Layer::Decals(l) => l.feature_footprints(ctx),
             Layer::SeatRun(l) => l.feature_footprints(ctx),
             Layer::Openwork(l) => l.tiling.feature_footprints_as_tiling(ctx),
@@ -708,10 +717,30 @@ impl FeatureFootprint {
         Self { feature_u_mm: mm, feature_v_mm: mm, u_mm, v_mm }
     }
 
-    /// A feature measured only across the section — a rail, a flute, a
-    /// milgrain line: it runs the whole way round, so `u` does not limit it.
+    /// A feature measured only across the section — a rail or a milgrain
+    /// line: it runs the whole way round, so `u` does not limit it.
+    ///
+    /// Not a flute. A flute is `count` of them *around* the ring, each narrow
+    /// in `u` and running the full band in `v` — that is [`along`], and
+    /// calling it `across` cost reeding the arc-scale correction entirely.
+    ///
+    /// [`along`]: FeatureFootprint::along
     pub fn across(mm: f64, u_mm: Option<(f64, f64)>, v_mm: (f64, f64)) -> Self {
         Self { feature_u_mm: f64::INFINITY, feature_v_mm: mm, u_mm, v_mm }
+    }
+
+    /// A feature measured only around the ring — a flute, a reed, a cut that
+    /// runs the full width of the band and repeats along it.
+    ///
+    /// `u` is arc at the crest radius, and everything else sits inside that,
+    /// so this is the direction [`metal_feature_mm`] has to scale. A footprint
+    /// that puts a flute's width on the `v` side reports it at face value,
+    /// which is 15-20% optimistic on exactly the surfaces the doctrine sends
+    /// ornament to.
+    ///
+    /// [`metal_feature_mm`]: FeatureFootprint::metal_feature_mm
+    pub fn along(mm: f64, u_mm: Option<(f64, f64)>, v_mm: (f64, f64)) -> Self {
+        Self { feature_u_mm: mm, feature_v_mm: f64::INFINITY, u_mm, v_mm }
     }
 
     /// The finest feature in the chart, mm — what refinement seeds on.

--- a/crates/ringdesign-core/src/profile.rs
+++ b/crates/ringdesign-core/src/profile.rs
@@ -2229,13 +2229,24 @@ fn blend_span(from: (f64, f64), to: (f64, f64), t: f64) -> (f64, f64) {
 /// from both faces, where every read has converged to the shank and the
 /// switch changes nothing.
 fn pick_dominant(reads: &[HeadAt]) -> HeadAt {
-    *reads
+    reads[dominant_index(reads)]
+}
+
+/// Which head owns this angle. Separate from [`pick_dominant`] because the
+/// *construction* has to come from the same head as the section does: a toi et
+/// moi can carry a lofted oval beside a cut-dome clover, and reading
+/// `self.head.mix()` built the second head's whole arc with the first head's
+/// construction — a dome where a loft was asked for, or the reverse.
+fn dominant_index(reads: &[HeadAt]) -> usize {
+    reads
         .iter()
-        .max_by(|a, b| {
+        .enumerate()
+        .max_by(|(_, a), (_, b)| {
             (a.on_head, a.outer_r)
                 .partial_cmp(&(b.on_head, b.outer_r))
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
+        .map(|(i, _)| i)
         .expect("at least the primary head")
 }
 
@@ -2648,10 +2659,19 @@ impl ShankStyle {
                     .all_heads()
                     .map(|h| self.head_at_for(h, theta_deg, inner_r, base_outer_r, band))
                     .collect();
-                let a = pick_dominant(&reads);
+                let dominant = dominant_index(&reads);
+                let a = reads[dominant];
                 let span = self.signet_span(theta_deg, inner_r, base_outer_r, band);
                 let (w, centre) = ((span.1 - span.0) * 0.5, (span.1 + span.0) * 0.5);
-                let (loft_k, dome_k) = self.head.mix();
+                // The construction comes from the head that owns this angle,
+                // not from the primary. Presences cross far from both faces,
+                // where every read has converged to the shank, so the switch
+                // is as invisible as the section switch above it.
+                let (loft_k, dome_k) = self
+                    .all_heads()
+                    .nth(dominant)
+                    .unwrap_or(&self.head)
+                    .mix();
                 // The table is the face's own outline, not the body's: the two
                 // are different extents, and that difference is the head's
                 // drafted flank. The cut dome hands the crown the whole span
@@ -2665,8 +2685,21 @@ impl ShankStyle {
                 // The shank rounds off toward a wire as it narrows, so a flat
                 // head sits on a round shank. The crown clamp caps it at a full
                 // dome, so a large value only ever means "more domed here".
-                // The lofted head's shank stays the band's own flat-topped
-                // section all the way round, as the factory presets' do.
+                //
+                // A lofted head's shank keeps the band's own section instead,
+                // unrounded — `crown_scale` comes out exactly 1.0, measured by
+                // `probe_signet_shank_crown`. That is deliberate: the factory
+                // shank is the top of a tall ellipse, 3.0 x 1.49 mm on a
+                // 6 x 1.75 band, and the preset builder puts that shape in the
+                // *profile*, so adding rounding here would round it twice.
+                //
+                // It does mean the shank is only as domed as the band it came
+                // from, and `apply_signet` does not set one — so a signet built
+                // on a squared band (which `templates::signet` does on purpose,
+                // for the side faces) gets a squared shank. That is a choice,
+                // not the flat-topped factory section an earlier version of
+                // this comment claimed: CLAUDE.md measured that one and found
+                // "not flat-topped; forcing it flat put the shank 0.35 mm off".
                 let shank_crown = 1.0
                     + SIGNET_SHANK_ROUNDING * k * (1.0 - w) * (1.0 - loft_k);
                 let table_crown = 1.0 - self.head.table_flat.clamp(0.0, 1.0);
@@ -5498,4 +5531,135 @@ mod hollow_tests {
         assert!(bore_of(&deep) < crest_of(&deep) - MIN_EDGE_MM, "a wall survives the deepest scoop");
     }
 
+}
+
+#[cfg(test)]
+mod signet_shank_probe {
+    use super::*;
+
+    /// What a new signet's shank section actually is, at the palm.
+    ///
+    /// A probe, in the house sense: it asserts the one invariant worth holding
+    /// and prints the rest for a person to read. The invariant is that a
+    /// lofted head leaves the band's own section alone — `crown_scale` is
+    /// exactly 1 — because the factory's tall-ellipse shank lives in the
+    /// profile, and rounding it here would round it twice.
+    #[test]
+    fn probe_signet_shank_crown() {
+        for (name, style, flatten) in [
+            ("default HalfRound", crate::ProfileStyle::HalfRound, false),
+            ("squared Flat (what templates::signet uses)", crate::ProfileStyle::Flat, true),
+        ] {
+            let mut d = crate::RingDesign::default();
+            d.profile.apply_style(style);
+            d.profile.width_mm = 9.0;
+            d.profile.thickness_mm = 2.6;
+            if flatten {
+                d.profile.flatten_sides();
+            }
+            let before = d.profile.crown_mm;
+            d.shank.apply_signet(d.profile.width_mm);
+            let inner_r = d.inner_radius_mm();
+            let crest_r = inner_r + d.profile.thickness_mm;
+            // 270 deg is the palm, the far side from the head.
+            let m = d.shank.modulation(270.0, inner_r, crest_r, &d.profile);
+            let loop_ = d.profile.sample_mod(inner_r, 96, &m);
+            let z: Vec<f64> = loop_.pts.iter().filter(|p| p.surface).map(|p| p.z).collect();
+            let r: Vec<f64> = loop_.pts.iter().filter(|p| p.surface).map(|p| p.r).collect();
+            let (zmin, zmax) = (z.iter().cloned().fold(f64::MAX, f64::min), z.iter().cloned().fold(f64::MIN, f64::max));
+            let rmax = r.iter().cloned().fold(f64::MIN, f64::max);
+            // Crown = how far the crest stands over the section's edges.
+            let edge_r = r.first().copied().unwrap_or(0.0).max(r.last().copied().unwrap_or(0.0));
+            println!(
+                "{name:44} crown_mm {before:.3} -> crown_scale {:.3}  section z {zmin:.2}..{zmax:.2}  crest r {rmax:.3}  edge r {edge_r:.3}  rise {:.3}",
+                m.crown_scale,
+                rmax - edge_r
+            );
+            assert!(
+                (m.crown_scale - 1.0).abs() < 1e-9,
+                "{name}: a lofted head must leave the band's crown alone, got {:.6}",
+                m.crown_scale
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod toi_et_moi_tests {
+    use super::*;
+    use crate::field::SignetOutline;
+
+    /// A toi et moi is two heads on one band, and they need not be the same
+    /// construction — a lofted oval beside a cut-dome clover is exactly the
+    /// case `suggest_dome` exists to produce. The section switched to whichever
+    /// head owned the angle and then read the *primary's* construction weights
+    /// for it, so the second head was built as a copy of the first's kind.
+    #[test]
+    fn each_head_is_built_with_its_own_construction() {
+        let mut d = crate::RingDesign::default();
+        d.profile.apply_style(crate::ProfileStyle::Flat);
+        d.profile.width_mm = 9.0;
+        d.profile.thickness_mm = 2.6;
+        d.profile.flatten_sides();
+        d.shank.apply_signet(d.profile.width_mm);
+
+        // Primary: a lofted oval at the top. Second: a cut dome, a quarter turn away.
+        d.shank.head.outline = SignetOutline::Oval;
+        d.shank.head.loft = 1.0;
+        d.shank.head.dome = 0.0;
+        d.shank.head.theta_deg = TOP_DEG;
+
+        let mut second = SignetHead::lofted();
+        second.outline = SignetOutline::Round;
+        second.loft = 0.0;
+        second.dome = 1.0;
+        second.theta_deg = TOP_DEG + 90.0;
+        second.length_mm = d.shank.head.length_mm;
+        d.shank.extra_heads.push(second);
+
+        let inner_r = d.inner_radius_mm();
+        let crest_r = inner_r + d.profile.thickness_mm;
+        let at = |deg: f64| d.shank.modulation(deg, inner_r, crest_r, &d.profile);
+
+        // Over the primary the cut dome's cap must be absent; over the second
+        // it must be present. `outer_max_r` is set only when dome_k > 0.
+        let over_primary = at(TOP_DEG);
+        let over_second = at(TOP_DEG + 90.0);
+        assert!(
+            over_primary.outer_max_r.is_none(),
+            "the lofted head must not be given the other head's dome cap"
+        );
+        assert!(
+            over_second.outer_max_r.is_some(),
+            "the cut-dome head must get its own cap, not the primary's loft"
+        );
+    }
+
+    /// And the whole thing still pulls, which is the only reason the switch is
+    /// allowed to exist.
+    #[test]
+    fn a_mixed_construction_toi_et_moi_still_fields_clean() {
+        let lib = crate::AlphaLibrary::builtin();
+        let mut d = crate::RingDesign::default();
+        d.profile.apply_style(crate::ProfileStyle::Flat);
+        d.profile.width_mm = 9.0;
+        d.profile.thickness_mm = 2.6;
+        d.profile.flatten_sides();
+        d.shank.apply_signet(d.profile.width_mm);
+        d.shank.head.theta_deg = TOP_DEG - 28.0;
+        let mut second = SignetHead::lofted();
+        second.loft = 0.0;
+        second.dome = 1.0;
+        second.outline = SignetOutline::Round;
+        second.theta_deg = TOP_DEG + 28.0;
+        d.shank.extra_heads.push(second);
+
+        let f = crate::castability::analyze_field(&d, &lib, &d.draft, 256, 128);
+        assert_ne!(
+            f.verdict,
+            crate::castability::Verdict::NotCastable,
+            "{:?}",
+            f.notes
+        );
+    }
 }


### PR DESCRIPTION
Closes #171 (M10.3) — its remaining four findings, unblocked now that the pattern-band work is on master. F83, F109, F105, F110.

## A flute was the one ornament that evaded the arc-scale correction

It was filed as `FeatureFootprint::across` — whose own doc comment named a flute — and `across` sets `feature_u_mm = INFINITY`, while `metal_feature_mm` scales **only the `u` side** by the arc ratio:

```rust
pub fn metal_feature_mm(&self, ctx: &FieldContext) -> f64 {
    let k = ctx.arc_scale_min(self.v_mm.0, self.v_mm.1);
    (self.feature_u_mm * k).min(self.feature_v_mm)
}
```

A rail or a milgrain line *is* `across` — narrow in `v`, running the whole way round. A flute is the opposite: `count` of them **around** the ring, each narrow in `u`, running the full band in `v`. So reeding was reported at its chart width where every other layer is reported at its metal width — 15–20% optimistic, in the unsafe direction, on exactly the surfaces the doctrine sends all ornament to.

`FeatureFootprint::along` is the right shape. And the **land** between two flutes now counts as well as the cut: a dense reeding fails on its land long before its cut, and only the cut was ever measured.

## A tiling was measured against a band it does not sit on

The chart's `v` is the section's own arc normalized, so a cell is the reference height only where the band is the reference thickness. A shoulder that narrows carries cells that narrow with it, and the mask's strokes with them.

A *decal* already read `modulation_at` per station. A tiling covers an arc, so what matters is the tightest station in it — `worst_arc_ratio` walks the layer's own window, gated through the window's own `mask()`.

The two shipped signet templates were the case the audit named, and they moved by ~2.5×:

| | before | after |
|---|---|---|
| Waved hexagon signet · Waves | 0.10 mm strokes on 11.8 × **1.8** mm cells | 0.04 mm on 11.8 × **0.8**, at 185° |
| Shouldered cushion signet · Chevron | 0.07 mm gaps | 0.03 mm on 7.6 × **0.6**, at 185° |

The finding now names the angle. CLAUDE.md's measured table is corrected to match.

## Each head is built with its own construction

`modulation` picked the head that owns an angle — and then read `self.head.mix()` for it, **always the primary's**:

```rust
let a = pick_dominant(&reads);
let (loft_k, dome_k) = self.head.mix();   // ← not `a`'s
```

A toi et moi carrying a lofted oval beside a cut-dome clover — which is exactly what `suggest_dome` produces for a lobed plan — built the second head as a copy of the first's kind. It reads the dominant head's now, via `dominant_index`.

It is a **no-op where both heads share a construction**, which is why the golden corpus does not move.

## F105 turned out to be the comment, not the geometry

`probe_signet_shank_crown` measures it and asserts the invariant: a lofted head leaves the band's own section alone, `crown_scale` exactly 1.0. That is deliberate — the factory's tall-ellipse shank lives in the *profile*, so rounding it here would round it twice.

What was wrong is the comment above it, which called the factory section *"flat-topped ... as the factory presets' do"* — while CLAUDE.md measured that same section and recorded **"not flat-topped; forcing it flat put the shank 0.35 mm off"**. The code was right and its explanation was not.

It does remain true that `apply_signet` sets no profile, so a signet built on a squared band gets a squared shank. That is `templates::signet`'s deliberate choice, for the side faces, and the comment now says so rather than misattributing it to the factory.

## Verification

`cargo test --workspace --offline` under `systemd-run --user --scope -p MemoryMax=6G`: **20 suites, 0 failures, golden corpus unmoved.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)