### PR TITLE
The clamp says when it bit, Tiling lands where its neighbours do, and coverage walks the registry

### DIFF
--- a/crates/ringdesign-core/examples/serpentarium.rs
+++ b/crates/ringdesign-core/examples/serpentarium.rs
@@ -1,0 +1,659 @@
+// Serpentarium: six snakes, each a different read of the same animal —
+// a bypass with gem eyes on its passing heads, a cigar band in warped
+// scale mail, a viper-head signet on a drawn plan, a keyframed ouroboros
+// swallowing its own tail, a graded diamondback, and a twin-head
+// toi et moi. Every ring is held to the field verdict, rendered with its
+// stones, given its sheet and setter's map, and saved so it opens in
+// the app. Only builtin generators and SVG carried in the design file,
+// so every piece is portable to an empty machine.
+//
+//   cargo run --release --example serpentarium [out_dir]
+use ringdesign_core::alpha::{AlphaLibrary, ProcRecipe, Procedural};
+use ringdesign_core::castability::{self, Verdict};
+use ringdesign_core::field::{
+    Blend, FieldContext, FluteProfile, FlutesLayer, Layer, LayerEntry, MilgrainLayer, Remap,
+    SeatPadLayer, SeatRunLayer, SeatStyle, SideFacePick, VGate, Window, SIDE_FACE_MIN_DRAFT_DEG,
+};
+use ringdesign_core::gem::{Gem, GemCut};
+use ringdesign_core::mesh::{self, BuildParams};
+use ringdesign_core::profile::{ShankKey, ShankKind, TOP_DEG};
+use ringdesign_core::render::{self, Part};
+use ringdesign_core::svg::SvgAlpha;
+use ringdesign_core::tiling::{TilingLayer, WarpField};
+use ringdesign_core::{gems, library, stonemap, stones, CustomOutline, ProfileStyle, RingDesign};
+
+const YELLOW: [f32; 3] = [0.86, 0.70, 0.42];
+const ROSE: [f32; 3] = [0.84, 0.60, 0.49];
+const SILVER: [f32; 3] = [0.79, 0.80, 0.81];
+const WHITE: [f32; 3] = [0.83, 0.83, 0.80];
+const PLATINUM: [f32; 3] = [0.75, 0.76, 0.78];
+
+struct Shots {
+    hero_pitch: f64,
+    /// Face-on view of the side-face annulus; true flips to the -Z face.
+    face: Option<bool>,
+    top: bool,
+    gif: bool,
+}
+
+const HERO: Shots = Shots { hero_pitch: 1.12, face: None, top: false, gif: false };
+
+fn squared(width: f64, thickness: f64) -> RingDesign {
+    let mut d = RingDesign::default();
+    d.profile.apply_style(ProfileStyle::Flat);
+    d.profile.width_mm = width;
+    d.profile.thickness_mm = thickness;
+    d.profile.flatten_sides();
+    d
+}
+
+/// Whether the wider side face is the low (-Z) one. The tie on a symmetric
+/// band breaks on float noise, so it is read per design, never assumed.
+fn wider_is_low(d: &RingDesign) -> bool {
+    let ctx = d.field_context();
+    ctx.side_faces_std()
+        .and_then(|f| f.wider())
+        .map(|(lo, hi)| 0.5 * (lo + hi) < ctx.crest_v_mm)
+        .unwrap_or(false)
+}
+
+/// Chart `v` of the taller hump in one half of a modulated section — where a
+/// bypass arm's own crest runs at this angle.
+fn hump_v(d: &RingDesign, ctx: &FieldContext, theta: f64, low_half: bool) -> f64 {
+    let inner = d.inner_radius_mm();
+    let crest_r = inner + d.profile.thickness_mm;
+    let m = d.modulation_at(theta, inner, crest_r);
+    let l = d.profile.sample_mod(inner, 256, &m);
+    let mid = 0.5 * l.surface_len_mm;
+    let mut best = (f64::MIN, mid);
+    for p in l.pts.iter().filter(|p| p.surface && ((p.v_mm < mid) == low_half)) {
+        if p.r > best.0 {
+            best = (p.r, p.v_mm);
+        }
+    }
+    best.1 / l.surface_len_mm.max(1e-9) * ctx.band_v_len_mm
+}
+
+/// Chart `v` of the midpoint of the side-facing wall run in one half of a
+/// modulated section — a cheek on a signet head's flank.
+fn cheek_v(d: &RingDesign, ctx: &FieldContext, theta: f64, low_half: bool) -> f64 {
+    let inner = d.inner_radius_mm();
+    let crest_r = inner + d.profile.thickness_mm;
+    let m = d.modulation_at(theta, inner, crest_r);
+    let l = d.profile.sample_mod(inner, 384, &m);
+    let mid = 0.5 * l.surface_len_mm;
+    let steep = (80.0f64).to_radians().sin();
+    let (mut lo, mut hi) = (f64::MAX, f64::MIN);
+    for p in l.pts.iter().filter(|p| p.surface && ((p.v_mm < mid) == low_half)) {
+        if p.nz.abs() >= steep {
+            lo = lo.min(p.v_mm);
+            hi = hi.max(p.v_mm);
+        }
+    }
+    let v = if hi > lo { 0.5 * (lo + hi) } else { 0.25 * mid };
+    v / l.surface_len_mm.max(1e-9) * ctx.band_v_len_mm
+}
+
+/// Seamless imbricated scale mail, shaded so each scale is its own dome:
+/// rows of circles at half-period offsets, painted top row last, each filled
+/// with a radial gradient darkest low in the scale. The SVG rasterizer reads
+/// darkness as height, so the crescents come out as overlapping shingles.
+/// Two scales per tile edge; rows are drawn from a period beyond each tile
+/// edge so the painting order wraps in both axes.
+fn scale_mail_svg() -> String {
+    let mut circles = String::new();
+    let mut y: f64 = 150.0;
+    while y >= -50.0 {
+        let k = (y / 25.0).round() as i64;
+        let off = if k.rem_euclid(2) == 1 { 25.0 } else { 0.0 };
+        for cx0 in [-100.0, 0.0, 100.0] {
+            for i in 0..2 {
+                let cx = cx0 + off + i as f64 * 50.0;
+                circles.push_str(&format!(
+                    r#"<circle cx="{cx}" cy="{y}" r="29" fill="url(#s)"/>"#
+                ));
+            }
+        }
+        y -= 25.0;
+    }
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><radialGradient id="s" cx="50%" cy="58%" r="62%"><stop offset="0%" stop-color="#0a0a0a"/><stop offset="55%" stop-color="#4e4e4e"/><stop offset="100%" stop-color="#cfcfcf"/></radialGradient></defs>{circles}</svg>"##
+    )
+}
+
+/// A viper-head plan: rounded skull base, jaw lobes, tapering snout. `dir`
+/// flips the snout along the ring; `aspect` is length over width.
+fn viper_outline(name: &str, dir: f64, aspect: f64) -> CustomOutline {
+    let smooth = |t: f64| t * t * (3.0 - 2.0 * t);
+    let n = 96;
+    let half = |x: f64| -> f64 {
+        if x < -0.55 {
+            let t = ((x + 1.0) / 0.45).clamp(0.0, 1.0);
+            0.62 * (1.0 - (1.0 - t) * (1.0 - t)).max(0.0).sqrt()
+        } else if x < -0.05 {
+            let t = ((x + 0.55) / 0.5).clamp(0.0, 1.0);
+            0.62 + 0.38 * smooth(t)
+        } else {
+            let t = ((x + 0.05) / 1.05).clamp(0.0, 1.0);
+            (1.0 - t.powf(1.7)).max(0.0).powf(1.25)
+        }
+    };
+    let mut pts: Vec<[f64; 2]> = Vec::new();
+    for i in 0..=n {
+        let x = -1.0 + 2.0 * i as f64 / n as f64;
+        pts.push([dir * x * aspect, half(x)]);
+    }
+    for i in (1..n).rev() {
+        let x = -1.0 + 2.0 * i as f64 / n as f64;
+        pts.push([dir * x * aspect, -half(x)]);
+    }
+    CustomOutline::from_points(name, &pts).expect("a viper head closes into an outline")
+}
+
+/// Field-check, render with stones, sheet, map, save. Refuses to ship an
+/// uncastable ring.
+fn finish(
+    dir: &str,
+    slug: &str,
+    blurb: &str,
+    tint: [f32; 3],
+    shots: Shots,
+    mut d: RingDesign,
+    lib: &mut AlphaLibrary,
+) {
+    d.name = slug
+        .split_once('-')
+        .map(|(_, r)| r.replace('-', " "))
+        .unwrap_or_else(|| slug.into());
+    d.bake_all(lib);
+    let field = castability::attributed_field_report(&d, lib, &d.draft, 256, 128);
+    println!("{slug:<24} {blurb}");
+    println!(
+        "{:<24} {} under {}: {:.3}% undercut, worst {:+.1} deg, thinnest wall {:.2} mm",
+        "",
+        field.verdict.label(),
+        d.draft.process.label(),
+        field.undercut_fraction() * 100.0,
+        field.worst_draft_deg,
+        field.thinnest_wall_mm
+    );
+    for n in &field.notes {
+        println!("{:<24}   note: {n}", "");
+    }
+    let dfm = ringdesign_core::dfm::findings_in(&d, lib);
+    for f in &dfm {
+        println!("{:<24}   dfm: {}: {}", "", f.label, f.message);
+    }
+    let report = stones::report(&d, field.parting_z_mm);
+    if let Some(s) = &report {
+        println!("{:<24}   stones: {} stones, {:.2} ct", "", s.stone_count, s.total_carats);
+        if let Some(p) = &s.closest {
+            println!(
+                "{:<24}   closest pair: {} / {} — {:.2} mm at the girdle, {:.2} mm at the culet",
+                "", p.a, p.b, p.gap_mm, p.gap_deep_mm
+            );
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for seat in &s.seats {
+            for w in &seat.warnings {
+                if seen.insert(w.clone()) {
+                    println!("{:<24}   stone warning: {w}", "");
+                }
+            }
+        }
+    }
+    assert_ne!(field.verdict, Verdict::NotCastable, "{slug} must not ship uncastable");
+
+    let out = mesh::build(
+        &d,
+        lib,
+        BuildParams { theta_steps: 1600, profile_steps: 360, ..Default::default() },
+    );
+    assert!(out.report.validation.watertight, "{slug} not watertight");
+    for m in out.report.metals.iter().take(1) {
+        println!("{:<24}   {}: {:.2} g", "", m.metal, m.grams);
+    }
+    let stones_mesh = gems::preview_mesh(&d, lib);
+    let mut parts = vec![Part::metal(&out.mesh, tint)];
+    if let Some(g) = &stones_mesh {
+        parts.push(Part::stone(g));
+    }
+    let pi = std::f64::consts::PI;
+    render::write_png_parts(format!("{dir}/{slug}-hero.png"), &parts, 0.55, shots.hero_pitch, 900)
+        .unwrap();
+    if let Some(flip) = shots.face {
+        let (yaw, pitch) = if flip { (pi, pi - 0.35) } else { (0.0, 0.35) };
+        render::write_png_parts(format!("{dir}/{slug}-face.png"), &parts, yaw, pitch, 900).unwrap();
+    }
+    if shots.top {
+        render::write_png_parts(format!("{dir}/{slug}-top.png"), &parts, 0.0, 1.55, 800).unwrap();
+    }
+    if shots.gif {
+        render::write_turntable_gif(format!("{dir}/{slug}.gif"), &out.mesh, 36, 480, tint).unwrap();
+    }
+    let sheet = ringdesign_core::spec::html(&d, &out.report, &field, report.as_ref(), &dfm, "serpentarium");
+    std::fs::write(format!("{dir}/{slug}-sheet.html"), sheet).unwrap();
+    if report.as_ref().is_some_and(|s| s.stone_count > 0) {
+        stonemap::write_stone_map_svg(format!("{dir}/{slug}-stones.svg"), &d, report.as_ref())
+            .unwrap();
+    }
+    let designs = library::default_design_dir().join("serpentarium");
+    std::fs::create_dir_all(&designs).unwrap();
+    library::save_design(designs.join(format!("{slug}.ring.json")), &d).unwrap();
+    println!();
+}
+
+fn main() {
+    let dir = std::env::args().nth(1).unwrap_or_else(|| "/tmp/serpentarium".into());
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut lib = AlphaLibrary::builtin();
+
+    // --- 01. Uraeus: the two-headed bypass. --------------------------------
+    // The Victorian snake ring is a bypass: two arms passing over the top,
+    // each ending in a head. A marquise cabochon bridges the crossing (a cab
+    // has no pavilion, so the crossing wedge costs it nothing), and each
+    // arm carries a small gem eye on its own crest — probed from the
+    // modulated section, because the arms slide off the mid-plane and a
+    // fixed-v seat would land on a flank.
+    let mut d = RingDesign::default();
+    d.profile.apply_style(ProfileStyle::LowDome);
+    d.profile.width_mm = 5.0;
+    d.profile.thickness_mm = 2.3;
+    d.shank.kind = ShankKind::Bypass;
+    d.shank.amount = 1.0;
+    let ctx = d.field_context();
+    // Past the tip at +35 deg only the through arm remains; its hump's half
+    // says which side each arm runs, and the eyes go on the tip arms.
+    let through_is_low = {
+        let inner = d.inner_radius_mm();
+        let crest_r = inner + d.profile.thickness_mm;
+        let m = d.modulation_at(TOP_DEG + 45.0, inner, crest_r);
+        let l = d.profile.sample_mod(inner, 256, &m);
+        let mid = 0.5 * l.surface_len_mm;
+        let mut best = (f64::MIN, mid);
+        for p in l.pts.iter().filter(|p| p.surface) {
+            if p.r > best.0 {
+                best = (p.r, p.v_mm);
+            }
+        }
+        best.1 < mid
+    };
+    for (label, theta, low) in [
+        ("Eye east", TOP_DEG + 20.0, !through_is_low),
+        ("Eye west", TOP_DEG - 20.0, through_is_low),
+    ] {
+        let v = hump_v(&d, &ctx, theta, low);
+        let mut eye = SeatPadLayer {
+            theta_deg: theta,
+            v_mm: v,
+            style: SeatStyle::GypsyMound,
+            height_mm: 0.32,
+            crown: 1.0,
+            blend_mm: 0.4,
+            ..Default::default()
+        };
+        eye.fit_stone(Gem::calibrated(GemCut::Round, 1.25));
+        d.layers.layers.push(LayerEntry::new(label, Layer::SeatPad(eye)));
+    }
+    let mut head = SeatPadLayer {
+        theta_deg: TOP_DEG,
+        v_mm: ctx.crest_v_mm,
+        style: SeatStyle::GypsyMound,
+        height_mm: 0.55,
+        crown: 1.0,
+        blend_mm: 0.45,
+        ..Default::default()
+    };
+    head.fit_stone(Gem::cabochon(GemCut::Marquise, 3.2));
+    d.layers.layers.push(LayerEntry::new("Head cab", Layer::SeatPad(head)));
+    // Snakeskin shimmer on the flanks only: a polished crest ribbon between,
+    // the hammered-bombe lesson in scale form. The gradient mail, not the
+    // builtin Scales — its seven scallops per tile leave 0.01 mm gaps at any
+    // cell a 1.5 mm strip holds.
+    d.svgs.push(SvgAlpha { name: "Scale mail".into(), svg: scale_mail_svg(), invert: false });
+    d.bake_all(&mut lib);
+    for (label, side) in [("Skin low", -1.0), ("Skin high", 1.0)] {
+        let mut t = TilingLayer::default_for("Scale mail", &ctx);
+        t.height_mm = 0.05;
+        t.rows = 1;
+        t.v_center_mm = ctx.crest_v_mm + side * 1.6;
+        t.v_span_mm = 1.5;
+        t.feather_mm = 0.5;
+        t.repeats_around = t.repeats_for_square_cells(&ctx);
+        d.layers.layers.push(LayerEntry::new(label, Layer::Tiling(t)));
+    }
+    finish(
+        &dir,
+        "01-uraeus-bypass",
+        "two arms passing under a marquise cab, a gem eye on each head",
+        YELLOW,
+        Shots { gif: true, ..HERO },
+        d,
+        &mut lib,
+    );
+
+    // --- 02. Scute: warped scale mail on a cigar band. ---------------------
+    // The scales are an SVG carried in the design: gradient-shaded circles
+    // painted in row order, so each scale is its own dome and the shingle
+    // step between rows is a wall across the band — parallel to the pull on
+    // a side face, which is the one place that step is free. The warp bends
+    // the rows along a three-period wave and the shear leans the columns,
+    // so the mail flows like a moving body instead of running level.
+    let mut d = squared(8.0, 4.5);
+    d.svgs.push(SvgAlpha { name: "Scale mail".into(), svg: scale_mail_svg(), invert: false });
+    d.bake_all(&mut lib);
+    let ctx = d.field_context();
+    let mut t = TilingLayer::default_for("Scale mail", &ctx);
+    t.height_mm = 0.5;
+    assert!(t.fit_to_side_faces(&ctx, SIDE_FACE_MIN_DRAFT_DEG));
+    let face_c = t.v_center_mm;
+    t.warp = Some(WarpField {
+        points: (0..12)
+            .map(|i| {
+                let f = i as f64 / 12.0;
+                [f, face_c + 0.8 * (3.0 * std::f64::consts::TAU * f).sin()]
+            })
+            .collect(),
+        strength: 0.85,
+        falloff_mm: 3.0,
+    });
+    t.shear = 0.35;
+    let mut e = LayerEntry::new("Scale mail", Layer::Tiling(t));
+    e.blend = Blend::SmoothMax;
+    e.soft_mm = 0.25;
+    // The warp moves the sampling `v`, so tile relief can reach past the
+    // face's edge onto the shoulder — measured 0.89% at -45 deg without the
+    // gate. The gate reads the true `v` and kills it there.
+    e.window.v_gate = VGate::SideFaces(SideFacePick::Both);
+    d.layers.layers.push(e);
+    let beads = (ctx.circumference_mm / 0.5).round() as u32;
+    d.layers.layers.push(LayerEntry::new(
+        "Milgrain",
+        Layer::Milgrain(MilgrainLayer {
+            v_mm: ctx.crest_v_mm,
+            bead_diameter_mm: 0.5,
+            beads_around: beads,
+            height_mm: 0.2,
+            mirror: false,
+        }),
+    ));
+    let low = wider_is_low(&d);
+    finish(
+        &dir,
+        "02-scute-mail",
+        "gradient-domed scale mail warped along a wave, bead line on the crest",
+        SILVER,
+        Shots { face: Some(low), gif: true, ..HERO },
+        d,
+        &mut lib,
+    );
+
+    // --- 03. Basilisk: a viper-head signet on a drawn plan. ----------------
+    // The head is the band: a custom outline — skull, jaw lobes, snout —
+    // through the same lofted construction as every factory preset, with a
+    // low dome on the skull, the belly hollowed from the finger hole, and
+    // an eye dot on each cheek. The cheeks are the head's side-facing wall
+    // runs, probed from the modulated section; relief there pulls straight
+    // out. Ventral scutes — flutes across the band — ride the back arc.
+    // 2.0 thick and a 0.55 hollow: at 1.9 / 0.7 the scoop left a 0.63 mm
+    // wall over the shoulder, under the 0.7 mm fill floor.
+    let mut d = squared(11.0, 2.0);
+    d.shank.apply_signet(11.0);
+    let outline = viper_outline("Viper", 1.0, 1.25);
+    let o = d.shank.adopt_outline(outline);
+    d.shank.head.outline = o;
+    d.shank.head.dome = d.shank.suggest_dome(o);
+    d.shank.head.length_mm = 13.0;
+    d.shank.head.rise_mm = 0.6;
+    d.shank.head.rim_round_mm = 0.5;
+    d.shank.head.table_dome_mm = 1.1;
+    d.shank.head.hollow_mm = 0.55;
+    let ctx = d.field_context();
+    for (label, theta, low) in
+        [("Eye low", TOP_DEG + 8.0, true), ("Eye high", TOP_DEG + 8.0, false)]
+    {
+        let v = cheek_v(&d, &ctx, theta, low);
+        let eye = SeatPadLayer {
+            theta_deg: theta,
+            v_mm: v,
+            diameter_mm: 1.2,
+            style: SeatStyle::Boss,
+            height_mm: 0.25,
+            crown: 1.0,
+            blend_mm: 0.4,
+            ..Default::default()
+        };
+        d.layers.layers.push(LayerEntry::new(label, Layer::SeatPad(eye)));
+    }
+    let count = (ctx.circumference_mm / 0.86).round() as u32;
+    let pitch = ctx.circumference_mm / count as f64;
+    let mut e = LayerEntry::new(
+        "Ventral scutes",
+        Layer::Flutes(FlutesLayer {
+            count,
+            profile: FluteProfile::Round,
+            width_mm: pitch - 0.37,
+            height_mm: 0.15,
+            lean: 0.0,
+            along: false,
+        }),
+    );
+    e.window = Window::except(TOP_DEG, 170.0);
+    e.window.fade_deg = 20.0;
+    d.layers.layers.push(e);
+    finish(
+        &dir,
+        "03-basilisk-signet",
+        "lofted viper-head signet, domed skull, cheek eyes, scutes down the back",
+        YELLOW,
+        Shots { top: true, gif: true, ..HERO },
+        d,
+        &mut lib,
+    );
+
+    // --- 04. Ouroboros: the band is the snake. -----------------------------
+    // Keyframed stations taper the body around the whole circle — broad head
+    // at the top, thinning all the way round to a tail that runs back under
+    // the head's jaw, the swallow being the one steep ramp between the last
+    // tail station and the head. The scale mail follows the band as it
+    // tapers because layers evaluate against the reference section, so the
+    // scales shrink toward the tail without any per-station bookkeeping.
+    let mut d = squared(6.0, 3.4);
+    d.shank.kind = ShankKind::Keyframes;
+    d.shank.amount = 1.0;
+    let key = |off: f64, w: f64, t: f64, c: f64| ShankKey {
+        theta_deg: TOP_DEG + off,
+        width_scale: w,
+        thickness_scale: t,
+        crown_scale: c,
+    };
+    d.shank.keys = vec![
+        key(14.0, 1.30, 1.16, 0.90),
+        key(42.0, 1.18, 1.10, 1.0),
+        key(95.0, 1.06, 1.04, 1.0),
+        key(160.0, 0.97, 1.00, 1.0),
+        key(225.0, 0.88, 0.95, 1.0),
+        key(285.0, 0.80, 0.90, 1.0),
+        key(330.0, 0.73, 0.86, 1.0),
+        key(352.0, 0.70, 0.84, 1.0),
+    ];
+    d.svgs.push(SvgAlpha { name: "Scale mail".into(), svg: scale_mail_svg(), invert: false });
+    d.bake_all(&mut lib);
+    let ctx = d.field_context();
+    let mut t = TilingLayer::default_for("Scale mail", &ctx);
+    t.height_mm = 0.4;
+    assert!(t.fit_to_side_faces(&ctx, SIDE_FACE_MIN_DRAFT_DEG));
+    t.shear = 0.25;
+    let mut e = LayerEntry::new("Scale mail", Layer::Tiling(t));
+    e.blend = Blend::SmoothMax;
+    e.soft_mm = 0.25;
+    e.window = Window::except(TOP_DEG + 8.0, 60.0);
+    e.window.fade_deg = 14.0;
+    e.window.v_gate = VGate::SideFaces(SideFacePick::Both);
+    d.layers.layers.push(e);
+    // Eye dots on both side faces at the head, cast proud and left bright.
+    let (lo, hi) = ctx.side_faces_std().and_then(|f| f.wider()).unwrap();
+    let vc = 0.5 * (lo + hi);
+    for (label, v) in [("Eye low", vc), ("Eye high", ctx.band_v_len_mm - vc)] {
+        let eye = SeatPadLayer {
+            theta_deg: TOP_DEG + 20.0,
+            v_mm: v,
+            diameter_mm: 1.3,
+            style: SeatStyle::Boss,
+            height_mm: 0.22,
+            crown: 1.0,
+            blend_mm: 0.4,
+            ..Default::default()
+        };
+        d.layers.layers.push(LayerEntry::new(label, Layer::SeatPad(eye)));
+    }
+    let beads = (ctx.circumference_mm / 0.45).round() as u32;
+    d.layers.layers.push(LayerEntry::new(
+        "Spine beads",
+        Layer::Milgrain(MilgrainLayer {
+            v_mm: ctx.crest_v_mm,
+            bead_diameter_mm: 0.45,
+            beads_around: beads,
+            height_mm: 0.18,
+            mirror: false,
+        }),
+    ));
+    finish(
+        &dir,
+        "04-ouroboros",
+        "keyframed body tapering the whole way round to the tail under its own jaw",
+        ROSE,
+        Shots { gif: true, top: true, ..HERO },
+        d,
+        &mut lib,
+    );
+
+    // --- 05. Diamondback: the graded, turned eternity. ---------------------
+    // Princess cuts turned 45 degrees make the diamondback's pattern down
+    // the spine, graded toward the tail; the rattle is a short leaning
+    // reeding at the bottom of the finger, and the flanks carry the Diamonds
+    // generator cushioned so the pyramids read as keeled scales.
+    let mut d = RingDesign::default();
+    d.profile.apply_style(ProfileStyle::Beveled);
+    d.profile.width_mm = 5.2;
+    d.profile.thickness_mm = 2.9;
+    d.profile.flatten_sides();
+    let ctx = d.field_context();
+    let mut run = SeatRunLayer {
+        gem: Gem::calibrated(GemCut::Princess, 2.0),
+        bridge_mm: 0.5,
+        taper: 0.55,
+        taper_theta_deg: TOP_DEG,
+        tilt_deg: 45.0,
+        ..Default::default()
+    };
+    run.seat.style = SeatStyle::GypsyMound;
+    run.seat.height_mm = 0.55;
+    run.seat.crown = 1.0;
+    run.seat.blend_mm = 0.45;
+    run.seat.v_mm = ctx.crest_v_mm;
+    run.solve_spacing(&ctx);
+    let mut e = LayerEntry::new("Spine row", Layer::SeatRun(run));
+    e.window = Window::around(TOP_DEG, 210.0);
+    d.layers.layers.push(e);
+    let count = (ctx.circumference_mm / 0.82).round() as u32;
+    let pitch = ctx.circumference_mm / count as f64;
+    let mut e = LayerEntry::new(
+        "Rattle",
+        Layer::Flutes(FlutesLayer {
+            count,
+            profile: FluteProfile::Round,
+            width_mm: pitch - 0.37,
+            height_mm: 0.16,
+            lean: 0.4,
+            along: false,
+        }),
+    );
+    e.window = Window::around(TOP_DEG + 180.0, 46.0);
+    e.window.fade_deg = 8.0;
+    d.layers.layers.push(e);
+    d.recipes.push(ProcRecipe {
+        name: "Keels".into(),
+        kind: Procedural::Diamonds,
+        repeats: 1,
+        quarter_turns: 0,
+        gamma: 1.2,
+        invert: false,
+    });
+    let mut t = TilingLayer::default_for("Keels", &ctx);
+    t.height_mm = 0.28;
+    assert!(t.fit_to_side_faces(&ctx, SIDE_FACE_MIN_DRAFT_DEG));
+    let mut e = LayerEntry::new("Keels", Layer::Tiling(t));
+    e.blend = Blend::SmoothMax;
+    e.soft_mm = 0.2;
+    e.remap = Remap::cushion(0.28);
+    e.window = Window::except(TOP_DEG + 180.0, 60.0);
+    e.window.fade_deg = 10.0;
+    e.window.v_gate = VGate::SideFaces(SideFacePick::Both);
+    d.layers.layers.push(e);
+    finish(
+        &dir,
+        "05-diamondback",
+        "graded princesses on the diagonal, keeled flanks, a rattle at the palm",
+        PLATINUM,
+        Shots { top: true, ..HERO },
+        d,
+        &mut lib,
+    );
+
+    // --- 06. Hydra: twin heads, one band. ----------------------------------
+    // A toi et moi of two lofted viper heads facing each other across the
+    // top — the second head is `extra_heads`, the band the union of both.
+    // Mirrored outlines point the snouts together; both bellies hollow with
+    // the primary's setting.
+    let mut d = squared(9.5, 1.9);
+    d.shank.apply_signet(9.5);
+    let east = d.shank.adopt_outline(viper_outline("Viper east", 1.0, 1.05));
+    let west = d.shank.adopt_outline(viper_outline("Viper west", -1.0, 1.05));
+    d.shank.head.outline = west;
+    d.shank.head.theta_deg = TOP_DEG - 27.0;
+    d.shank.head.length_mm = 8.0;
+    d.shank.head.rise_mm = 0.5;
+    d.shank.head.rim_round_mm = 0.45;
+    d.shank.head.table_dome_mm = 0.7;
+    d.shank.head.hollow_mm = 0.5;
+    let mut second = ringdesign_core::profile::SignetHead::lofted();
+    second.outline = east;
+    second.theta_deg = TOP_DEG + 27.0;
+    second.length_mm = 8.0;
+    second.rise_mm = 0.5;
+    second.rim_round_mm = 0.45;
+    second.table_dome_mm = 0.7;
+    d.shank.extra_heads.push(second);
+    let ctx = d.field_context();
+    let count = (ctx.circumference_mm / 0.9).round() as u32;
+    let pitch = ctx.circumference_mm / count as f64;
+    let mut e = LayerEntry::new(
+        "Ventral scutes",
+        Layer::Flutes(FlutesLayer {
+            count,
+            profile: FluteProfile::Round,
+            width_mm: pitch - 0.37,
+            height_mm: 0.14,
+            lean: 0.0,
+            along: false,
+        }),
+    );
+    e.window = Window::around(TOP_DEG + 180.0, 150.0);
+    e.window.fade_deg = 18.0;
+    d.layers.layers.push(e);
+    finish(
+        &dir,
+        "06-hydra-twins",
+        "toi et moi: two lofted viper heads nose to nose, hollowed bellies",
+        WHITE,
+        Shots { top: true, gif: true, ..HERO },
+        d,
+        &mut lib,
+    );
+
+    println!(
+        "renders in {dir}, designs in {}",
+        library::default_design_dir().join("serpentarium").display()
+    );
+}

--- a/crates/ringdesign-core/src/alpha.rs
+++ b/crates/ringdesign-core/src/alpha.rs
@@ -559,8 +559,11 @@ impl Alpha {
 }
 
 /// Library name a mask's derived signed-distance field lands under.
+/// Suffix marking a derived distance field.
+pub const SDF_SUFFIX: &str = "##sdf";
+
 pub fn sdf_name(name: &str) -> String {
-    format!("{name}##sdf")
+    format!("{name}{SDF_SUFFIX}")
 }
 
 /// In-place exact squared Euclidean distance transform (Felzenszwalb &
@@ -1458,6 +1461,15 @@ fn guilloche_weave(x: f64, y: f64) -> f64 {
 pub struct AlphaLibrary {
     entries: Vec<Alpha>,
     index: HashMap<String, usize>,
+    /// Distance fields, keyed by the alpha they were derived from.
+    ///
+    /// `TilingLayer::height` needs one per sample when `edge_mm` is set, and
+    /// it used to reach it through `sdf_name(&self.alpha)` — a `format!`, so a
+    /// heap allocation and a free per sample, in the innermost loop of every
+    /// bevelled tiling. The field is evaluated at least five times per settled
+    /// build (the mesh, the attributed field report, the modulus scan, the
+    /// section view, the stones report), so the multiplier is real.
+    sdf_index: HashMap<String, usize>,
 }
 
 impl AlphaLibrary {
@@ -1480,6 +1492,22 @@ impl AlphaLibrary {
     pub const MAX_ENTRIES: usize = 4096;
 
     pub fn insert(&mut self, alpha: Alpha) {
+        // Keep the derived-field index in step, so the hot path is one lookup
+        // on the base name with nothing allocated.
+        if let Some(base) = alpha.name.strip_suffix(SDF_SUFFIX) {
+            let base = base.to_string();
+            match self.index.get(&alpha.name).copied() {
+                Some(i) => {
+                    self.entries[i] = alpha;
+                    return;
+                }
+                None => {
+                    if self.entries.len() < Self::MAX_ENTRIES {
+                        self.sdf_index.insert(base, self.entries.len());
+                    }
+                }
+            }
+        }
         match self.index.get(&alpha.name).copied() {
             Some(i) => self.entries[i] = alpha,
             None => {
@@ -1513,6 +1541,14 @@ impl AlphaLibrary {
 
     pub fn get(&self, name: &str) -> Option<&Alpha> {
         self.index.get(name).and_then(|&i| self.entries.get(i))
+    }
+
+    /// The distance field derived from `base`, without building its name.
+    ///
+    /// `get(&sdf_name(base))` allocates a `String` per call, and the caller is
+    /// `TilingLayer::height` — once per sample.
+    pub fn sdf_of(&self, base: &str) -> Option<&Alpha> {
+        self.sdf_index.get(base).and_then(|&i| self.entries.get(i))
     }
 
     pub fn get_index(&self, i: usize) -> Option<&Alpha> {
@@ -2925,5 +2961,36 @@ mod feature_tests {
         let disc: Vec<f32> = (0..n * n).map(|i| { let (x, y) = ((i % n) as f64 - 32.0, (i / n) as f64 - 32.0); if x * x + y * y < 100.0 { 1.0 } else { 0.0 } }).collect();
         let (ink, _) = Alpha::new("disc", n, n, disc).min_feature_px().unwrap();
         assert!((ink - 20.0).abs() <= 2.0, "a 20 px disc: {ink}");
+    }
+}
+
+#[cfg(test)]
+mod sdf_index_tests {
+    use super::*;
+
+    /// `TilingLayer::height` reached its distance field through
+    /// `get(&sdf_name(base))` — a `format!` per sample, in the innermost loop
+    /// of every bevelled tiling, five field evaluations deep per settled
+    /// build. The index has to stay in step with `insert`, including when an
+    /// alpha is re-baked under the same name.
+    #[test]
+    fn the_sdf_index_finds_what_insert_put_there() {
+        let mut lib = AlphaLibrary::builtin();
+        let src = Alpha::new("probe".to_string(), 8, 8, vec![0.0; 64]);
+        lib.insert(src.clone());
+        assert!(lib.sdf_of("probe").is_none(), "nothing derived yet");
+
+        lib.insert(src.signed_distance_px());
+        let by_index = lib.sdf_of("probe").expect("derived field found");
+        let by_name = lib.get(&sdf_name("probe")).expect("and found the old way");
+        assert_eq!(by_index.name, by_name.name);
+        assert_eq!(by_index.data, by_name.data);
+
+        // Re-baking under the same name replaces rather than duplicating, and
+        // the index still points at it.
+        let redrawn = Alpha::new("probe".to_string(), 8, 8, vec![1.0; 64]);
+        lib.insert(redrawn.signed_distance_px());
+        let again = lib.sdf_of("probe").expect("still found after a re-bake");
+        assert_eq!(again.data, lib.get(&sdf_name("probe")).unwrap().data);
     }
 }

--- a/crates/ringdesign-core/src/castability.rs
+++ b/crates/ringdesign-core/src/castability.rs
@@ -1233,6 +1233,21 @@ pub fn analyze_field(
             frac(vertical_outer_area) * 100.0
         ));
     }
+    // The builder floors the radial wall at `BuildParams::min_wall_mm` — a
+    // constant, 0.5 by default — while the verdict judges the same geometry
+    // against `min_section_mm`, which is 0.7 by default and 0.8 under Delft
+    // clay. Nothing connects the two, so the builder can manufacture a wall
+    // the chosen sand cannot fill and the verdict only catches it after the
+    // fact. Deriving one from the other would silently move metal the moment
+    // a user switched sand, so the clamp stays where it is and says when it
+    // was what produced the thinnest wall.
+    let clamp = design.build.min_wall_mm.max(0.05);
+    if thinnest > 0.0 && (thinnest - clamp).abs() < 1e-3 && clamp < settings.min_section_mm {
+        notes.push(format!(
+            "The wall at {thinnest_at:.0} deg is sitting on the build's {clamp:.2} mm floor, under the {:.2} mm this sand fills — that metal was clamped, not designed. Raise the clamp or cut the relief that drove it there.",
+            settings.min_section_mm
+        ));
+    }
     let min_section = settings.min_section_mm.max(0.0);
     if thinnest > 0.0 && thinnest < min_section {
         if verdict == Verdict::Castable {

--- a/crates/ringdesign-core/src/tiling.rs
+++ b/crates/ringdesign-core/src/tiling.rs
@@ -358,9 +358,7 @@ impl TilingLayer {
         let sy = x * sin + y * cos + 0.5;
 
         let edge = fin(self.edge_mm).max(0.0);
-        let sdf = (edge > 1e-9)
-            .then(|| lib.get(&crate::alpha::sdf_name(&self.alpha)))
-            .flatten();
+        let sdf = (edge > 1e-9).then(|| lib.sdf_of(&self.alpha)).flatten();
         let mut h = match sdf {
             Some(sdf) if !sdf.is_empty() => {
                 // mm-true edge: the distance field is in source pixels, and

--- a/crates/ringdesign-graph/src/nodes/mod.rs
+++ b/crates/ringdesign-graph/src/nodes/mod.rs
@@ -52,6 +52,33 @@ mod tests {
     use crate::value::ValueKind;
     use std::collections::BTreeSet;
 
+    /// Every real node covers its struct.
+    ///
+    /// CLAUDE.md credits the `struct_node!` guard with making it so "a field
+    /// added to the core cannot go unnoticed", and the guard was a
+    /// `debug_assert!` inside `StructNode::build` — compiled out in release,
+    /// and never walked by any test. `coverage_names_what_a_node_forgot_or_invented`
+    /// checks the *helper* against two synthetic nodes and passed the whole
+    /// time `head` was missing `crest_round_mm`; what actually caught that was
+    /// the registry panicking inside an unrelated test.
+    ///
+    /// This is the assertion that should have caught it: build the real
+    /// registry and read the failures back by name.
+    #[test]
+    fn every_node_covers_its_struct() {
+        let log = crate::nodes::structs::coverage_failures();
+        log.lock().expect("coverage log").clear();
+        let reg = Registry::builtin();
+        assert!(reg.len() >= 40, "the registry built: {} kinds", reg.len());
+        let failures = log.lock().expect("coverage log").clone();
+        assert!(
+            failures.is_empty(),
+            "{} node(s) do not cover their struct:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+
     /// The table is consistent: every spec documented, pins uniquely named,
     /// every scalar item input given a default so an unwired node still runs.
     #[test]

--- a/crates/ringdesign-graph/src/nodes/structs.rs
+++ b/crates/ringdesign-graph/src/nodes/structs.rs
@@ -46,6 +46,15 @@ pub struct StructNode<T> {
     finish: Option<FinishFn<T>>,
 }
 
+/// Every coverage failure seen while building node specs this process.
+///
+/// A `Vec` behind a `Mutex` rather than a counter, because what a test needs
+/// is the message: which node, and which field it forgot or invented.
+pub fn coverage_failures() -> &'static std::sync::Mutex<Vec<String>> {
+    static LOG: std::sync::OnceLock<std::sync::Mutex<Vec<String>>> = std::sync::OnceLock::new();
+    LOG.get_or_init(Default::default)
+}
+
 impl<T> StructNode<T>
 where
     T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
@@ -130,9 +139,26 @@ where
         }
     }
 
-    /// The node spec. In debug builds the coverage check must pass.
+    /// The node spec.
+    ///
+    /// The coverage check runs here, and it is the only place it runs — the
+    /// registry stores `NodeSpec`s, so by the time anything can walk it the
+    /// `StructNode` is gone. It used to be a bare `debug_assert!`, which meant
+    /// two things: a release build compiled it out entirely and registered a
+    /// node with a missing pin *silently*, leaving the field unreachable from
+    /// the graph with nothing said; and the test named for it,
+    /// `coverage_names_what_a_node_forgot_or_invented`, only ever exercised
+    /// the helper on synthetic nodes, so it passed happily while a real one
+    /// was broken. That is how `crest_round_mm` got in.
+    ///
+    /// Now every failure is recorded where a test can find it, whatever the
+    /// build profile, and the debug assertion stays as the fast local signal.
     pub fn build(mut self) -> NodeSpec {
-        debug_assert!(self.coverage().is_ok(), "{}", self.coverage().unwrap_err());
+        if let Err(e) = self.coverage() {
+            coverage_failures().lock().expect("coverage log").push(e.clone());
+            debug_assert!(false, "{e}");
+            log::error!("{e}");
+        }
         // A modifier must not overwrite its base with pin defaults.
         if self.base.is_some() {
             let fields: BTreeSet<&str> = self.fields.iter().map(|f| f.pin.as_str()).collect();

--- a/crates/ringdesign-gui/src/panels/layers.rs
+++ b/crates/ringdesign-gui/src/panels/layers.rs
@@ -61,7 +61,14 @@ pub fn ui(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
 
 fn add_menu(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
     ui.menu_button(format!("{} Add layer", icon::PLUS), |ui| {
-        if ui.button(format!("{} Tiling", icon::GRID_FOUR)).clicked() {
+        if ui
+            .button(format!("{} Tiling", icon::GRID_FOUR))
+            .on_hover_text(
+                "A repeating mask over the band. Lands on the wider side face, where \
+                 relief cannot undercut.",
+            )
+            .clicked()
+        {
             let ctx = app.design.field_context();
             let alpha = app
                 .lib
@@ -69,8 +76,29 @@ fn add_menu(app: &mut RingDesignerApp, ui: &mut egui::Ui) {
                 .first()
                 .cloned()
                 .unwrap_or_else(|| "Rope".to_string());
-            let layer = Layer::Tiling(TilingLayer::default_for(alpha.clone(), &ctx));
-            app.add_layer(alpha, layer);
+            // Every other ornament in this menu lands itself on a side face —
+            // Curve retargets, Openwork fits — and Tiling did not, so the
+            // first thing a new user adds went onto the crest of the default
+            // half-round, where CLAUDE.md measures 0.30 mm of relief at 1.77%
+            // undercut. Same three lines the Openwork arm already uses.
+            let mut t = TilingLayer::default_for(alpha.clone(), &ctx);
+            let on_side =
+                t.fit_to_side_faces(&ctx, ringdesign_core::field::SIDE_FACE_MIN_DRAFT_DEG);
+            app.add_layer(alpha, Layer::Tiling(t));
+            if on_side {
+                if let Some(e) = app.design.layers.layers.last_mut() {
+                    e.window.v_gate = ringdesign_core::field::VGate::SideFaces(
+                        ringdesign_core::field::SideFacePick::Wider,
+                    );
+                }
+                app.mark_dirty();
+            } else {
+                app.set_status(
+                    "This profile has no side face to put a pattern on — its crown eats the \
+                     whole thickness. Square the sides on the Design tab, or keep the relief \
+                     under 0.15 mm.",
+                );
+            }
             ui.close();
         }
         if ui.button(format!("{} Border", icon::LINE_SEGMENTS)).clicked() {
@@ -288,6 +316,7 @@ fn openwork(
     o: &mut ringdesign_core::field::OpenworkLayer,
     fctx: &FieldContext,
     names: &[String],
+    square_sides: &mut bool,
 ) -> bool {
     let mut c = false;
     ui.label(
@@ -338,7 +367,7 @@ fn openwork(
         c
     });
     let mut no_bake = None;
-    c |= tiling(ui, &mut o.tiling, fctx, names, None, &mut no_bake);
+    c |= tiling(ui, &mut o.tiling, fctx, names, None, &mut no_bake, square_sides);
     c
 }
 
@@ -508,6 +537,7 @@ fn editor(app: &mut RingDesignerApp, ui: &mut egui::Ui, i: usize) {
     let mut shape_head = false;
     let mut group_edit: Option<GroupEdit> = None;
     let mut bake_draft: Option<f64> = None;
+    let mut square_sides = false;
     let entry = &mut app.design.layers.layers[i];
     let mut dirty = ui
         .scope(|ui| {
@@ -681,17 +711,21 @@ fn editor(app: &mut RingDesignerApp, ui: &mut egui::Ui, i: usize) {
 
             ui.add_space(4.0);
             dirty |= match &mut entry.layer {
-                Layer::Tiling(t) => tiling(ui, t, &fctx, &names, thumb, &mut bake_draft),
+                Layer::Tiling(t) => {
+                    tiling(ui, t, &fctx, &names, thumb, &mut bake_draft, &mut square_sides)
+                }
                 Layer::Border(b) => border(ui, b, &fctx),
                 Layer::SeatPad(p) => seat_pad(ui, p, &fctx),
                 Layer::Milgrain(m) => milgrain(ui, m, &fctx),
                 Layer::Signet(s) => signet(ui, s, &fctx, &mut shape_head),
-                Layer::Group(g) => group(ui, g, &fctx, &names, &mut group_edit),
+                Layer::Group(g) => {
+                    group(ui, g, &fctx, &names, &mut group_edit, &mut square_sides)
+                }
                 Layer::Curve(l) => curve_editor(ui, l, &fctx),
                 Layer::Flutes(f) => flutes(ui, f),
                 Layer::Decals(d) => decals(ui, d, &fctx, &names),
                 Layer::SeatRun(r) => seat_run(ui, r, &fctx),
-                Layer::Openwork(o) => openwork(ui, o, &fctx, &names),
+                Layer::Openwork(o) => openwork(ui, o, &fctx, &names, &mut square_sides),
             };
             dirty
         })
@@ -704,6 +738,16 @@ fn editor(app: &mut RingDesignerApp, ui: &mut egui::Ui, i: usize) {
         // The crisp-edge mode reads the alpha's distance field; keep it
         // derived the moment the control moves.
         app.library_mut().insert(src.signed_distance_px());
+    }
+    // The tiling editor names the remedy for "no side face" and now offers it
+    // where it is named. Only the caller can reach the profile.
+    if square_sides {
+        app.design.profile.flatten_sides();
+        app.set_status(
+            "Squared the band's sides — side draft to zero, edge fillet shrunk. Width and \
+             thickness are unchanged.",
+        );
+        app.mark_dirty();
     }
     if let Some(deg) = bake_draft {
         let baked = match &app.design.layers.layers[i].layer {
@@ -775,6 +819,9 @@ fn tiling(
     names: &[String],
     thumb: Option<egui::TextureId>,
     bake_draft: &mut Option<f64>,
+    // Set when the user asks to square the band's sides: `tiling` cannot reach
+    // the profile and its caller can, the same shape as `bake_draft`.
+    square_sides: &mut bool,
 ) -> bool {
     let mut c = false;
     let v_max = fctx.band_v_len_mm.max(0.5);
@@ -801,7 +848,11 @@ fn tiling(
     });
 
     ui.add_space(3.0);
-    c |= side_face_fit(ui, t, fctx);
+    let (fit_changed, square_sides_clicked) = side_face_fit(ui, t, fctx);
+    c |= fit_changed;
+    if square_sides_clicked {
+        *square_sides = true;
+    }
 
     ui.add_space(3.0);
     c |= grid(ui, "tiling_lattice", |ui| {
@@ -1512,6 +1563,7 @@ fn group(
     fctx: &FieldContext,
     names: &[String],
     pending: &mut Option<GroupEdit>,
+    group_square_sides: &mut bool,
 ) -> bool {
     use ringdesign_core::pave::{GenRecipe, PinnedSeat};
     let mut c = false;
@@ -1645,7 +1697,7 @@ fn group(
                     .add_enabled_ui(editable, |ui| match &mut ce.layer {
                     Layer::Tiling(t) => {
                         let mut no_bake = None;
-                        tiling(ui, t, fctx, names, None, &mut no_bake)
+                        tiling(ui, t, fctx, names, None, &mut no_bake, group_square_sides)
                     }
                     Layer::Border(b) => border(ui, b, fctx),
                     Layer::SeatPad(p) => seat_pad(ui, p, fctx),
@@ -1655,7 +1707,7 @@ fn group(
                     Layer::Flutes(f) => flutes(ui, f),
                     Layer::Decals(d) => decals(ui, d, fctx, names),
                     Layer::SeatRun(r) => seat_run(ui, r, fctx),
-                    Layer::Openwork(o) => openwork(ui, o, fctx, names),
+                    Layer::Openwork(o) => openwork(ui, o, fctx, names, group_square_sides),
                     Layer::Group(_) => {
                         ui.label(
                             egui::RichText::new("Nested groups edit one level at a time.")
@@ -1894,8 +1946,16 @@ fn v_gate_controls(ui: &mut egui::Ui, w: &mut Window, fctx: &FieldContext) -> bo
 
 /// Snap the tiling onto the faces square to the mould pull, which are the only
 /// ones that hold relief deeper than a few tenths.
-fn side_face_fit(ui: &mut egui::Ui, t: &mut TilingLayer, fctx: &FieldContext) -> bool {
+/// Returns `(changed, square_the_sides)` — the second is the user asking for
+/// `BandProfile::flatten_sides`, which this function cannot reach and its
+/// caller can.
+fn side_face_fit(
+    ui: &mut egui::Ui,
+    t: &mut TilingLayer,
+    fctx: &FieldContext,
+) -> (bool, bool) {
     let mut c = false;
+    let mut square = false;
     let faces = fctx.side_faces(SIDE_FACE_MIN_DRAFT_DEG);
     ui.horizontal(|ui| {
         let enabled = faces.is_some();
@@ -1909,12 +1969,26 @@ fn side_face_fit(ui: &mut egui::Ui, t: &mut TilingLayer, fctx: &FieldContext) ->
                  Relief there pulls straight out of the sand.",
             )
             .on_disabled_hover_text(
-                "This profile has no face square to the mould pull. Square the sides on the \
-                 Design tab, or add an edge flange.",
+                "This profile has no face square to the mould pull. Square the sides — the \
+                 button beside this one — or add an edge flange.",
             )
             .clicked()
         {
             c |= t.fit_to_side_faces(fctx, SIDE_FACE_MIN_DRAFT_DEG);
+        }
+        // The disabled hover used to send the user to the Design tab to do
+        // this by hand. The fix belongs where the problem is named.
+        if !enabled
+            && ui
+                .button(format!("{} Square the sides", icon::SQUARE_HALF))
+                .on_hover_text(
+                    "Drop the side draft to zero and shrink the edge fillet, which is what \
+                     turns a nearly-square face into a square one. The band keeps its width \
+                     and thickness.",
+                )
+                .clicked()
+        {
+            square = true;
         }
         if ui
             .button(format!("{} Square cells", icon::SQUARE))
@@ -1953,7 +2027,7 @@ fn side_face_fit(ui: &mut egui::Ui, t: &mut TilingLayer, fctx: &FieldContext) ->
         ),
     };
     ui.label(egui::RichText::new(msg).small().color(colour));
-    c
+    (c, square)
 }
 
 fn border(ui: &mut egui::Ui, b: &mut BorderLayer, fctx: &FieldContext) -> bool {


### PR DESCRIPTION
Most of the rest of #175 (M10.7), and closes #199. Findings F17≡F30, F172, F158.

## The build clamp and the fill floor were two numbers for one thing

`mesh::build` floors the radial wall at a hardcoded `MIN_WALL_MM = 0.5`, while the verdict judges the *same geometry* against `min_section_mm` — 0.7 by default, 0.8 under Delft clay. Nothing connects them, so the builder could manufacture a wall the chosen sand cannot fill, and switching sand moved the floor the verdict wants without moving the floor the geometry is built to.

**Deriving one from the other is the obvious fix and the wrong one.** It would silently move metal the moment a user clicked Petrobond → Delft — exactly the hidden coupling this codebase's provenance rules exist to prevent. (The audit's own verifier overruled its auditor on this point; I followed the verifier.)

So the verdict says it instead:

> The wall at 210° is sitting on the build's 0.50 mm floor, under the 0.80 mm this sand fills — that metal was clamped, not designed.

If the constant is to move, it should move once, deliberately, with a measurement.

## Tiling now lands where its neighbours already do

`Add layer ▸ Tiling` was the only ornament in the menu that didn't place itself: Curve calls `retarget_v` and sets `VGate::SideFaces(Wider)`, Openwork calls `fit_to_side_faces`, Tiling did neither. So the first thing a new user adds went onto the crest of the default half-round — where CLAUDE.md measures **0.30 mm of relief at 1.77% undercut**.

It uses the Openwork arm's own three lines now, and when the profile has no side face it says so rather than silently doing the wrong thing.

And the tiling editor's disabled *Fit to sides* button named the remedy and sent the user to another tab to do it by hand. There's a **Square the sides** button beside it now — `flatten_sides` is exactly what it's for, and the fix belongs where the problem is named.

`BandProfile::default` is **deliberately untouched**: changing it moves every file that omits the field and every baseline in the golden corpus, and the first-run gallery (M13) is the better answer to the same problem.

## The coverage guard now guards — #199

CLAUDE.md credits `struct_node!` with making it so *"a field added to the core cannot go unnoticed"*. The check was a `debug_assert!` inside `StructNode::build`:

- **Compiled out in release** — a shipped binary registered a node with a missing pin *silently*, leaving the field unreachable from the graph with nothing said.
- **No test walked it.** `coverage_names_what_a_node_forgot_or_invented` checks the helper against two *synthetic* nodes, and passed the entire time `head` was missing `crest_round_mm`. What actually caught that was the registry panicking inside an unrelated CLI test.

Failures are now recorded whatever the build profile, and `every_node_covers_its_struct` builds the real registry and reads them back by name. Verified to fail with the pin removed:

```
head: fields with no pin and not hidden: ["crest_round_mm"];
```

## The innermost loop stops allocating

`TilingLayer::height` reached its distance field through `get(&sdf_name(base))` — a `format!`, so a malloc and a free **per sample**, for every bevelled tiling, and the field is evaluated at least five times per settled build (mesh, attributed field report, modulus scan, section view, stones report). `AlphaLibrary` keeps a derived-field index; `sdf_of` is one lookup on the base name.

`h(u,v)` is bit-identical — every measured 0.000% stays 0.000%, and the golden corpus does not move.

## Left on #175

The two module splits (F159) — `outline.rs` out of `field.rs`, `signet.rs` out of `profile.rs`. They are ~2,000 lines of **pure file movement** for zero behaviour change, and master is being pushed to from another session right now; a refactor that size would conflict with anything in flight. It wants a quiet tree, not a busy one.

## Verification

`cargo test --workspace --offline` under `systemd-run --user --scope -p MemoryMax=6G`: **20 suites, 0 failures, golden corpus unmoved.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)